### PR TITLE
feat: hybrid rendering, supabase lead forms, seo/og/jsonld, commit rules, and ci guards

### DIFF
--- a/apps/speckit/app/contact/actions.ts
+++ b/apps/speckit/app/contact/actions.ts
@@ -1,36 +1,42 @@
 "use server";
 
 import { cookies } from "next/headers";
-import { getServerClient } from "@airnub/db";
+import { getServerClient, insertContactLead } from "@airnub/db";
+import type { SupabaseDatabaseClient, TablesInsert } from "@airnub/db";
 
-type LeadInput = {
+export type LeadInput = {
   full_name?: string;
   email: string;
   company?: string;
   message?: string;
 };
 
-export async function submitLead(formData: FormData) {
-  const input: LeadInput = {
-    full_name: formData.get("full_name")?.toString().trim() || undefined,
-    email: formData.get("email")?.toString().trim() || "",
-    company: formData.get("company")?.toString().trim() || undefined,
-    message: formData.get("message")?.toString().trim() || undefined,
+export async function leadInputFromFormData(formData: FormData): Promise<LeadInput> {
+  const toValue = (field: string) => formData.get(field)?.toString().trim();
+  return {
+    full_name: toValue("full_name") || undefined,
+    email: toValue("email") || "",
+    company: toValue("company") || undefined,
+    message: toValue("message") || undefined,
   };
+}
 
+export async function submitLead(input: LeadInput) {
   if (!input.email) {
     throw new Error("Email is required.");
   }
 
-  const db = getServerClient(cookies);
-  const { error } = await db.from("contact_leads").insert({
+  const db: SupabaseDatabaseClient = getServerClient(cookies);
+  const payload: TablesInsert<"contact_leads"> = {
     full_name: input.full_name ?? null,
     email: input.email,
     company: input.company ?? null,
     message: input.message ?? null,
-    source: "speckit",
+    source: "speckit" as const,
     consent: false,
-  });
+  };
+
+  const { error } = await insertContactLead(db, payload);
 
   if (error) {
     throw new Error(error.message);

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,21 +1,50 @@
-import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createBrowserClient, createServerClient } from "@supabase/ssr";
 import type { Database } from "./types";
+import type { TablesInsert } from "./types-helpers";
+
+type Cookie = { name: string; value: string };
+
+type CookieStore = {
+  getAll(): Cookie[] | Promise<Cookie[] | null> | null;
+};
+
+type MaybePromise<T> = T | Promise<T>;
+
+type CookieAccessor = () => MaybePromise<CookieStore>;
+
+type TypedClient = SupabaseClient<Database, "public", "public", Database["public"]>;
+
+export type SupabaseDatabaseClient = TypedClient;
 
 export function getBrowserClient(
   url = process.env.NEXT_PUBLIC_SUPABASE_URL!,
   anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-) {
-  return createClient<Database>(url, anon);
+): TypedClient {
+  return createBrowserClient<Database, "public", Database["public"]>(url, anon) as unknown as TypedClient;
 }
 
 export function getServerClient(
-  _cookies?: () => unknown,
+  getCookies: CookieAccessor,
   url = process.env.NEXT_PUBLIC_SUPABASE_URL!,
   anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+): TypedClient {
+  return createServerClient<Database, "public", Database["public"]>(url, anon, {
+    cookies: {
+      async getAll() {
+        const store = await getCookies();
+        const all = await store.getAll();
+        return all ?? [];
+      },
+    },
+  }) as unknown as TypedClient;
+}
+
+export async function insertContactLead(
+  db: SupabaseDatabaseClient,
+  payload: TablesInsert<"contact_leads">
 ) {
-  return createClient<Database>(url, anon, {
-    auth: { persistSession: false },
-  });
+  return (db as SupabaseClient<any>).from("contact_leads").insert(payload);
 }
 
 export type { Database } from "./types";

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./client";
+export type { TablesInsert, TablesUpdate, TablesRow } from "./types-helpers";

--- a/packages/db/src/types-helpers.ts
+++ b/packages/db/src/types-helpers.ts
@@ -1,0 +1,13 @@
+import type { Database } from "./types";
+
+type PublicSchema = Database["public"];
+
+type Tables = PublicSchema["Tables"];
+
+type TableName = keyof Tables & string;
+
+type TableFor<Name extends TableName> = Tables[Name];
+
+export type TablesInsert<Name extends TableName> = TableFor<Name>["Insert"];
+export type TablesUpdate<Name extends TableName> = TableFor<Name>["Update"];
+export type TablesRow<Name extends TableName> = TableFor<Name>["Row"];


### PR DESCRIPTION
## Summary
- align the shared Supabase client with @supabase/ssr helpers and add a typed insert helper for contact leads
- expose reusable `TablesInsert` utilities so apps can build strongly typed payloads
- update both contact Server Actions to rely on the shared helper and enforce typed form parsing

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d719ed9930832489fe5f7b12330aeb