### PR TITLE
Parse contact form submissions before validation

### DIFF
--- a/apps/airnub/app/contact/actions.ts
+++ b/apps/airnub/app/contact/actions.ts
@@ -21,7 +21,9 @@ export async function leadInputFromFormData(formData: FormData): Promise<LeadInp
   };
 }
 
-export async function submitLead(input: LeadInput) {
+export async function submitLead(formData: FormData) {
+  const input = await leadInputFromFormData(formData);
+
   if (!input.email) {
     throw new Error("Email is required.");
   }

--- a/apps/speckit/app/contact/actions.ts
+++ b/apps/speckit/app/contact/actions.ts
@@ -21,7 +21,9 @@ export async function leadInputFromFormData(formData: FormData): Promise<LeadInp
   };
 }
 
-export async function submitLead(input: LeadInput) {
+export async function submitLead(formData: FormData) {
+  const input = await leadInputFromFormData(formData);
+
   if (!input.email) {
     throw new Error("Email is required.");
   }


### PR DESCRIPTION
## Summary
- update the Airnub contact submitLead action to accept FormData and derive its payload via leadInputFromFormData
- apply the same FormData parsing to the Speckit contact submitLead action to reuse the validated lead input when inserting

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7e1ec80808324a99840248de0ad88