### PR TITLE
feat: centralize shared headers and footers

### DIFF
--- a/apps/airnub/app/layout.tsx
+++ b/apps/airnub/app/layout.tsx
@@ -1,61 +1,8 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import "./globals.css";
-import { Footer, Header } from "@airnub/ui";
+import { FooterAirnub, HeaderAirnub } from "@airnub/ui";
 import type { ReactNode } from "react";
-import { AirnubWordmark } from "@airnub/brand";
-import { GithubIcon } from "../components/icons";
 import { organizationJsonLd } from "@airnub/seo";
-
-const navItems = [
-  { label: "Products", href: "/products" },
-  { label: "Solutions", href: "/solutions" },
-  { label: "Services", href: "/services" },
-  { label: "Resources", href: "/resources" },
-  { label: "Trust", href: "/trust" },
-  { label: "Company", href: "/company" },
-  { label: "Contact", href: "/contact" },
-];
-
-const footerColumns = [
-  {
-    heading: "Products",
-    links: [{ label: "Speckit", href: "https://speckit.airnub.io", external: true }],
-  },
-  {
-    heading: "Resources",
-    links: [
-      { label: "Docs", href: "https://docs.speckit.dev", external: true },
-      { label: "Blog", href: "/resources#blog" },
-      { label: "Changelog", href: "/resources#changelog" },
-    ],
-  },
-  {
-    heading: "Open Source",
-    links: [
-      { label: "GitHub org", href: "https://github.com/airnub", external: true },
-      { label: "Speckit", href: "https://github.com/airnub/speckit", external: true },
-      { label: "Infrastructure templates", href: "https://github.com/airnub/landing-zones", external: true },
-    ],
-  },
-  {
-    heading: "Trust",
-    links: [
-      { label: "Trust Center", href: "https://trust.airnub.io", external: true },
-      { label: "VDP", href: "https://trust.airnub.io/vdp", external: true },
-      { label: "security.txt", href: "https://trust.airnub.io/.well-known/security.txt", external: true },
-    ],
-  },
-  {
-    heading: "Company",
-    links: [
-      { label: "About", href: "/company" },
-      { label: "Careers", href: "/company#careers" },
-      { label: "Press", href: "/company#press" },
-      { label: "Legal", href: "/company#legal" },
-    ],
-  },
-];
 
 const jsonLd = organizationJsonLd({
   name: "Airnub",
@@ -126,37 +73,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <a href="#content" className="skip-link">
           Skip to content
         </a>
-        <Header
-          logo={<AirnubWordmark className="h-6" />}
-          navItems={navItems}
-          homeAriaLabel="Airnub home"
-          rightSlot={
-            <Link
-              href="https://github.com/airnub"
-              className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:inline-flex"
-              aria-label="Airnub on GitHub"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <GithubIcon className="h-4 w-4" />
-            </Link>
-          }
-        />
+        <HeaderAirnub />
         <main id="content" className="flex-1">
           {children}
         </main>
-        <Footer
-          logo={<AirnubWordmark className="h-6" />}
-          columns={footerColumns}
-          copyright={`© ${new Date().getFullYear()} Airnub. All rights reserved.`}
-          bottomSlot={
-            <div className="flex items-center gap-3">
-              <Link href="/company#privacy">Privacy</Link>
-              <Link href="/company#terms">Terms</Link>
-              <Link href="mailto:hello@airnub.io">hello@airnub.io</Link>
-            </div>
-          }
-        />
+        <FooterAirnub />
       </body>
     </html>
   );

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -1,57 +1,9 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import type { ReactNode } from "react";
 import "./globals.css";
-import { Footer, Header } from "@airnub/ui";
-import { SpeckitWordmark } from "@airnub/brand";
-import { GithubIcon, StarIcon } from "../components/icons";
+import { FooterSpeckit, HeaderSpeckit } from "@airnub/ui";
 import { softwareApplicationJsonLd } from "@airnub/seo";
 import { JsonLd } from "../components/JsonLd";
-
-const navItems = [
-  { label: "Product", href: "/product" },
-  { label: "How it works", href: "/how-it-works" },
-  { label: "Solutions", href: "/solutions" },
-  { label: "Docs", href: "https://docs.speckit.dev", external: true },
-  { label: "Pricing", href: "/pricing" },
-  { label: "Trust", href: "https://trust.airnub.io", external: true },
-];
-
-const footerColumns = [
-  {
-    heading: "Product",
-    links: [
-      { label: "Overview", href: "/" },
-      { label: "How it works", href: "/how-it-works" },
-      { label: "Integrations", href: "/product#integrations" },
-    ],
-  },
-  {
-    heading: "Resources",
-    links: [
-      { label: "Docs", href: "https://docs.speckit.dev", external: true },
-      { label: "API reference", href: "https://docs.speckit.dev/api", external: true },
-      { label: "Community", href: "https://github.com/airnub/speckit/discussions", external: true },
-    ],
-  },
-  {
-    heading: "Open Source",
-    links: [
-      { label: "Repo", href: "https://github.com/airnub/speckit", external: true },
-      { label: "Templates", href: "https://github.com/airnub/speckit-templates", external: true },
-      { label: "Issues", href: "https://github.com/airnub/speckit/issues", external: true },
-      { label: "License", href: "https://github.com/airnub/speckit/blob/main/LICENSE", external: true },
-    ],
-  },
-  {
-    heading: "Trust",
-    links: [
-      { label: "Trust Center", href: "https://trust.airnub.io", external: true },
-      { label: "Status", href: "https://status.airnub.io", external: true },
-      { label: "security.txt", href: "https://trust.airnub.io/.well-known/security.txt", external: true },
-    ],
-  },
-];
 
 const jsonLd = softwareApplicationJsonLd({
   name: "Speckit",
@@ -109,47 +61,11 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <a href="#content" className="skip-link">
           Skip to content
         </a>
-        <Header
-          logo={<SpeckitWordmark className="h-6" />}
-          navItems={navItems}
-          homeAriaLabel="Speckit home"
-          rightSlot={
-            <div className="hidden items-center gap-3 lg:flex">
-              <Link
-                href="https://github.com/airnub/speckit"
-                className="rounded-full border border-white/10 p-2 text-slate-100 transition hover:text-indigo-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400"
-                aria-label="Speckit on GitHub"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <GithubIcon className="h-4 w-4" />
-              </Link>
-              <Link
-                href="https://github.com/airnub/speckit"
-                className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90"
-                target="_blank"
-                rel="noreferrer"
-              >
-                <StarIcon className="h-4 w-4" /> Star project
-              </Link>
-            </div>
-          }
-        />
+        <HeaderSpeckit />
         <main id="content" className="flex-1">
           {children}
         </main>
-        <Footer
-          logo={<SpeckitWordmark className="h-6" />}
-          columns={footerColumns}
-          copyright={`© ${new Date().getFullYear()} Airnub. All rights reserved.`}
-          bottomSlot={
-            <div className="flex items-center gap-3 text-slate-400">
-              <Link href="mailto:speckit@airnub.io">speckit@airnub.io</Link>
-              <span aria-hidden="true">•</span>
-              <Link href="/pricing">Pricing</Link>
-            </div>
-          }
-        />
+        <FooterSpeckit />
       </body>
     </html>
   );

--- a/packages/ui/src/FooterAirnub.tsx
+++ b/packages/ui/src/FooterAirnub.tsx
@@ -1,0 +1,70 @@
+import Link from "next/link";
+import { AirnubWordmark } from "@airnub/brand";
+import { Footer, type FooterProps, type FooterColumn } from "./Footer";
+import type { ReactNode } from "react";
+
+const footerColumns: FooterColumn[] = [
+  {
+    heading: "Products",
+    links: [{ label: "Speckit", href: "https://speckit.airnub.io", external: true }],
+  },
+  {
+    heading: "Resources",
+    links: [
+      { label: "Docs", href: "https://docs.speckit.dev", external: true },
+      { label: "Blog", href: "/resources#blog" },
+      { label: "Changelog", href: "/resources#changelog" },
+    ],
+  },
+  {
+    heading: "Open Source",
+    links: [
+      { label: "GitHub org", href: "https://github.com/airnub", external: true },
+      { label: "Speckit", href: "https://github.com/airnub/speckit", external: true },
+      { label: "Infrastructure templates", href: "https://github.com/airnub/landing-zones", external: true },
+    ],
+  },
+  {
+    heading: "Trust",
+    links: [
+      { label: "Trust Center", href: "https://trust.airnub.io", external: true },
+      { label: "VDP", href: "https://trust.airnub.io/vdp", external: true },
+      { label: "security.txt", href: "https://trust.airnub.io/.well-known/security.txt", external: true },
+    ],
+  },
+  {
+    heading: "Company",
+    links: [
+      { label: "About", href: "/company" },
+      { label: "Careers", href: "/company#careers" },
+      { label: "Press", href: "/company#press" },
+      { label: "Legal", href: "/company#legal" },
+    ],
+  },
+];
+
+type FooterAirnubProps = Omit<FooterProps, "logo" | "columns" | "bottomSlot" | "copyright"> & {
+  bottomSlot?: ReactNode;
+  copyrightPrefix?: string;
+};
+
+export function FooterAirnub({ bottomSlot, copyrightPrefix = "Airnub", ...props }: FooterAirnubProps) {
+  const year = new Date().getFullYear();
+  return (
+    <Footer
+      logo={<AirnubWordmark className="h-6" />}
+      columns={footerColumns}
+      bottomSlot={
+        bottomSlot ?? (
+          <div className="flex items-center gap-3">
+            <Link href="/company#privacy">Privacy</Link>
+            <Link href="/company#terms">Terms</Link>
+            <Link href="mailto:hello@airnub.io">hello@airnub.io</Link>
+          </div>
+        )
+      }
+      copyright={`© ${year} ${copyrightPrefix}. All rights reserved.`}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/FooterSpeckit.tsx
+++ b/packages/ui/src/FooterSpeckit.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+import { SpeckitWordmark } from "@airnub/brand";
+import { Footer, type FooterProps, type FooterColumn } from "./Footer";
+
+const footerColumns: FooterColumn[] = [
+  {
+    heading: "Product",
+    links: [
+      { label: "Overview", href: "/" },
+      { label: "How it works", href: "/how-it-works" },
+      { label: "Integrations", href: "/product#integrations" },
+    ],
+  },
+  {
+    heading: "Resources",
+    links: [
+      { label: "Docs", href: "https://docs.speckit.dev", external: true },
+      { label: "API reference", href: "https://docs.speckit.dev/api", external: true },
+      { label: "Community", href: "https://github.com/airnub/speckit/discussions", external: true },
+    ],
+  },
+  {
+    heading: "Open Source",
+    links: [
+      { label: "Repo", href: "https://github.com/airnub/speckit", external: true },
+      { label: "Templates", href: "https://github.com/airnub/speckit-templates", external: true },
+      { label: "Issues", href: "https://github.com/airnub/speckit/issues", external: true },
+      { label: "License", href: "https://github.com/airnub/speckit/blob/main/LICENSE", external: true },
+    ],
+  },
+  {
+    heading: "Trust",
+    links: [
+      { label: "Trust Center", href: "https://trust.airnub.io", external: true },
+      { label: "Status", href: "https://status.airnub.io", external: true },
+      { label: "security.txt", href: "https://trust.airnub.io/.well-known/security.txt", external: true },
+    ],
+  },
+];
+
+type FooterSpeckitProps = Omit<FooterProps, "logo" | "columns" | "bottomSlot" | "copyright"> & {
+  contactHref?: string;
+  contactLabel?: string;
+};
+
+export function FooterSpeckit({
+  contactHref = "mailto:speckit@airnub.io",
+  contactLabel = "speckit@airnub.io",
+  ...props
+}: FooterSpeckitProps) {
+  const year = new Date().getFullYear();
+  return (
+    <Footer
+      logo={<SpeckitWordmark className="h-6" />}
+      columns={footerColumns}
+      bottomSlot={
+        <div className="flex items-center gap-3 text-slate-400">
+          <Link href={contactHref}>{contactLabel}</Link>
+          <span aria-hidden="true">•</span>
+          <Link href="/pricing">Pricing</Link>
+        </div>
+      }
+      copyright={`© ${year} Airnub. All rights reserved.`}
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/HeaderAirnub.tsx
+++ b/packages/ui/src/HeaderAirnub.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { AirnubWordmark } from "@airnub/brand";
+import { Header, type HeaderProps, type NavItem } from "./components/client/Header";
+import type { ReactNode } from "react";
+
+const navItems: NavItem[] = [
+  { label: "Products", href: "/products" },
+  { label: "Solutions", href: "/solutions" },
+  { label: "Services", href: "/services" },
+  { label: "Resources", href: "/resources" },
+  { label: "Trust", href: "/trust" },
+  { label: "Company", href: "/company" },
+  { label: "Contact", href: "/contact" },
+];
+
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 2C6.48 2 2 6.58 2 12.26c0 4.51 2.87 8.33 6.85 9.68.5.1.68-.22.68-.49 0-.24-.01-.88-.01-1.72-2.78.62-3.37-1.37-3.37-1.37-.46-1.19-1.13-1.51-1.13-1.51-.92-.64.07-.63.07-.63 1.02.07 1.55 1.07 1.55 1.07.9 1.57 2.36 1.12 2.94.86.09-.67.35-1.12.63-1.38-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.04a9.26 9.26 0 0 1 5 0c1.9-1.31 2.74-1.04 2.74-1.04.55 1.42.21 2.47.1 2.73.64.71 1.03 1.62 1.03 2.74 0 3.94-2.34 4.8-4.57 5.05.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.8 0 .27.18.6.69.49A10.04 10.04 0 0 0 22 12.26C22 6.58 17.52 2 12 2Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+type HeaderAirnubProps = Omit<HeaderProps, "logo" | "navItems" | "rightSlot" | "homeAriaLabel"> & {
+  homeAriaLabel?: string;
+  additionalRightSlot?: ReactNode;
+};
+
+export function HeaderAirnub({ homeAriaLabel = "Airnub home", additionalRightSlot, ...props }: HeaderAirnubProps) {
+  return (
+    <Header
+      logo={<AirnubWordmark className="h-6" />}
+      navItems={navItems}
+      homeAriaLabel={homeAriaLabel}
+      rightSlot={
+        <div className="flex items-center gap-3">
+          <Link
+            href="https://github.com/airnub"
+            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:inline-flex"
+            aria-label="Airnub on GitHub"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <GithubIcon className="h-4 w-4" />
+          </Link>
+          {additionalRightSlot}
+        </div>
+      }
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/HeaderSpeckit.tsx
+++ b/packages/ui/src/HeaderSpeckit.tsx
@@ -1,0 +1,93 @@
+import Link from "next/link";
+import { SpeckitWordmark } from "@airnub/brand";
+import { Header, type HeaderProps, type NavItem } from "./components/client/Header";
+import type { ReactNode } from "react";
+
+const navItems: NavItem[] = [
+  { label: "Product", href: "/product" },
+  { label: "How it works", href: "/how-it-works" },
+  { label: "Solutions", href: "/solutions" },
+  { label: "Docs", href: "https://docs.speckit.dev", external: true },
+  { label: "Pricing", href: "/pricing" },
+  { label: "Trust", href: "https://trust.airnub.io", external: true },
+];
+
+function GithubIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 2C6.48 2 2 6.58 2 12.26c0 4.51 2.87 8.33 6.85 9.68.5.1.68-.22.68-.49 0-.24-.01-.88-.01-1.72-2.78.62-3.37-1.37-3.37-1.37-.46-1.19-1.13-1.51-1.13-1.51-.92-.64.07-.63.07-.63 1.02.07 1.55 1.07 1.55 1.07.9 1.57 2.36 1.12 2.94.86.09-.67.35-1.12.63-1.38-2.22-.26-4.55-1.14-4.55-5.07 0-1.12.39-2.03 1.03-2.74-.1-.26-.45-1.31.1-2.73 0 0 .84-.27 2.75 1.04a9.26 9.26 0 0 1 5 0c1.9-1.31 2.74-1.04 2.74-1.04.55 1.42.21 2.47.1 2.73.64.71 1.03 1.62 1.03 2.74 0 3.94-2.34 4.8-4.57 5.05.36.32.68.94.68 1.9 0 1.37-.01 2.47-.01 2.8 0 .27.18.6.69.49A10.04 10.04 0 0 0 22 12.26C22 6.58 17.52 2 12 2Z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function StarIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M12 3.5 14.09 9h5.66l-4.58 3.32L16.66 18 12 14.89 7.34 18l1.49-5.68L4.25 9h5.66L12 3.5Z" />
+    </svg>
+  );
+}
+
+type HeaderSpeckitProps = Omit<HeaderProps, "logo" | "navItems" | "rightSlot" | "homeAriaLabel"> & {
+  homeAriaLabel?: string;
+  additionalRightSlot?: ReactNode;
+  githubHref?: string;
+  starHref?: string;
+  starLabel?: string;
+};
+
+export function HeaderSpeckit({
+  homeAriaLabel = "Speckit home",
+  additionalRightSlot,
+  githubHref = "https://github.com/airnub/speckit",
+  starHref = "https://github.com/airnub/speckit",
+  starLabel = "Star project",
+  ...props
+}: HeaderSpeckitProps) {
+  return (
+    <Header
+      logo={<SpeckitWordmark className="h-6" />}
+      navItems={navItems}
+      homeAriaLabel={homeAriaLabel}
+      rightSlot={
+        <div className="hidden items-center gap-3 lg:flex">
+          <Link
+            href={githubHref}
+            className="rounded-full border border-white/10 p-2 text-slate-100 transition hover:text-indigo-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400"
+            aria-label="Speckit on GitHub"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <GithubIcon className="h-4 w-4" />
+          </Link>
+          <Link
+            href={starHref}
+            className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90"
+            target="_blank"
+            rel="noreferrer"
+          >
+            <StarIcon className="h-4 w-4" /> {starLabel}
+          </Link>
+          {additionalRightSlot}
+        </div>
+      }
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -2,3 +2,7 @@ export * from "./components/client/Button";
 export * from "./Container";
 export * from "./components/client/Header";
 export * from "./Footer";
+export * from "./HeaderAirnub";
+export * from "./FooterAirnub";
+export * from "./HeaderSpeckit";
+export * from "./FooterSpeckit";


### PR DESCRIPTION
## Summary
- add branded Airnub and Speckit header/footer wrappers to the shared UI package
- re-export the new components for consumption by the apps
- replace inline navigation data in each app layout with the shared components

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d802f01b708324a75542b0ec1998e8