### PR TITLE
refactor: centralize JSON-LD and route helpers

### DIFF
--- a/apps/airnub/app/layout.tsx
+++ b/apps/airnub/app/layout.tsx
@@ -2,29 +2,13 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { FooterAirnub, HeaderAirnub } from "@airnub/ui";
 import type { ReactNode } from "react";
-import { organizationJsonLd } from "@airnub/seo";
+import { buildAirnubOrganizationJsonLd } from "../lib/jsonld";
+import { AIRNUB_BASE_URL } from "../lib/routes";
 
-const jsonLd = organizationJsonLd({
-  name: "Airnub",
-  url: "https://airnub.io",
-  logo: "https://airnub.io/api/og",
-  sameAs: [
-    "https://github.com/airnub",
-    "https://www.linkedin.com/company/airnub",
-  ],
-  contactPoint: [
-    {
-      telephone: "+1-415-555-0163",
-      contactType: "sales",
-      email: "hello@airnub.io",
-      areaServed: "Global",
-      availableLanguage: ["English"],
-    },
-  ],
-});
+const jsonLd = buildAirnubOrganizationJsonLd();
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://airnub.io"),
+  metadataBase: new URL(AIRNUB_BASE_URL),
   title: {
     default: "Airnub — Governed developer platforms",
     template: "%s | Airnub",
@@ -33,7 +17,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Airnub",
     description: "Airnub builds governed, enterprise-ready developer platforms.",
-    url: "https://airnub.io",
+    url: AIRNUB_BASE_URL,
     siteName: "Airnub",
     locale: "en_US",
     type: "website",
@@ -50,7 +34,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Airnub",
     description: "Airnub builds governed, enterprise-ready developer platforms.",
-    images: ["https://airnub.io/api/og"],
+    images: [`${AIRNUB_BASE_URL}/api/og`],
   },
   icons: {
     icon: "/favicon.ico",

--- a/apps/airnub/app/products/page.tsx
+++ b/apps/airnub/app/products/page.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Button, Container } from "@airnub/ui";
-import { itemListJsonLd } from "@airnub/seo";
 import { PageHero } from "../../components/PageHero";
 import { JsonLd } from "../../components/JsonLd";
+import { buildAirnubProductPortfolioJsonLd } from "../../lib/jsonld";
 
 export const revalidate = 86_400;
 
@@ -32,26 +32,7 @@ const offerings = [
   },
 ];
 
-const jsonLd = itemListJsonLd({
-  name: "Airnub product portfolio",
-  items: [
-    {
-      name: "Speckit",
-      url: "https://speckit.airnub.io",
-      description: "Developer workflow governance and evidence automation.",
-    },
-    {
-      name: "Platform blueprints",
-      url: "https://airnub.io/services#platform",
-      description: "Reference architectures and paved roads for platform teams.",
-    },
-    {
-      name: "Trust accelerators",
-      url: "https://airnub.io/services#trust",
-      description: "Compliance artifacts with automated evidence capture.",
-    },
-  ],
-});
+const jsonLd = buildAirnubProductPortfolioJsonLd();
 
 export default function ProductsPage() {
   return (

--- a/apps/airnub/app/sitemap.ts
+++ b/apps/airnub/app/sitemap.ts
@@ -1,19 +1,9 @@
 import type { MetadataRoute } from "next";
-
-const routes = [
-  "",
-  "/products",
-  "/solutions",
-  "/services",
-  "/resources",
-  "/company",
-  "/contact",
-  "/trust",
-];
+import { AIRNUB_BASE_URL, airnubRoutes } from "../lib/routes";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return routes.map((route) => ({
-    url: `https://airnub.io${route}`,
+  return airnubRoutes.map((route) => ({
+    url: `${AIRNUB_BASE_URL}${route}`,
     changefreq: "weekly",
     priority: route === "" ? 1 : 0.7,
   }));

--- a/apps/airnub/lib/jsonld.ts
+++ b/apps/airnub/lib/jsonld.ts
@@ -1,0 +1,49 @@
+import { itemListJsonLd, organizationJsonLd } from "@airnub/seo";
+import { AIRNUB_BASE_URL } from "./routes";
+
+export function buildAirnubOrganizationJsonLd() {
+  return organizationJsonLd({
+    name: "Airnub",
+    url: AIRNUB_BASE_URL,
+    logo: `${AIRNUB_BASE_URL}/api/og`,
+    sameAs: [
+      "https://github.com/airnub",
+      "https://www.linkedin.com/company/airnub",
+    ],
+    contactPoint: [
+      {
+        telephone: "+1-415-555-0163",
+        contactType: "sales",
+        email: "hello@airnub.io",
+        areaServed: "Global",
+        availableLanguage: ["English"],
+      },
+    ],
+  });
+}
+
+export function buildAirnubProductPortfolioJsonLd() {
+  return itemListJsonLd({
+    name: "Airnub product portfolio",
+    items: [
+      {
+        name: "Speckit",
+        url: "https://speckit.airnub.io",
+        description:
+          "Developer workflow governance and evidence automation.",
+      },
+      {
+        name: "Platform blueprints",
+        url: `${AIRNUB_BASE_URL}/services#platform`,
+        description:
+          "Reference architectures and paved roads for platform teams.",
+      },
+      {
+        name: "Trust accelerators",
+        url: `${AIRNUB_BASE_URL}/services#trust`,
+        description:
+          "Compliance artifacts with automated evidence capture.",
+      },
+    ],
+  });
+}

--- a/apps/airnub/lib/routes.ts
+++ b/apps/airnub/lib/routes.ts
@@ -1,0 +1,14 @@
+export const AIRNUB_BASE_URL = "https://airnub.io" as const;
+
+export const airnubRoutes = [
+  "",
+  "/products",
+  "/solutions",
+  "/services",
+  "/resources",
+  "/company",
+  "/contact",
+  "/trust",
+] as const;
+
+export type AirnubRoute = (typeof airnubRoutes)[number];

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -2,20 +2,14 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
 import { FooterSpeckit, HeaderSpeckit } from "@airnub/ui";
-import { softwareApplicationJsonLd } from "@airnub/seo";
 import { JsonLd } from "../components/JsonLd";
+import { buildSpeckitSoftwareJsonLd } from "../lib/jsonld";
+import { SPECKIT_BASE_URL } from "../lib/routes";
 
-const jsonLd = softwareApplicationJsonLd({
-  name: "Speckit",
-  url: "https://speckit.airnub.io",
-  applicationCategory: "DevSecOps Application",
-  description: "End vibe-coding. Ship secure, auditable releases with governed workflows and continuous evidence.",
-  softwareHelp: "https://docs.speckit.dev",
-  sameAs: ["https://github.com/airnub/speckit", "https://airnub.io"],
-});
+const jsonLd = buildSpeckitSoftwareJsonLd();
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://speckit.airnub.io"),
+  metadataBase: new URL(SPECKIT_BASE_URL),
   title: {
     default: "Speckit — Governed release workflows",
     template: "%s | Speckit",
@@ -24,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Speckit",
     description: "Governed release workflows with evidence automation.",
-    url: "https://speckit.airnub.io",
+    url: SPECKIT_BASE_URL,
     siteName: "Speckit",
     locale: "en_US",
     type: "website",
@@ -41,7 +35,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Speckit",
     description: "Governed release workflows with evidence automation.",
-    images: ["https://speckit.airnub.io/api/og"],
+    images: [`${SPECKIT_BASE_URL}/api/og`],
   },
   icons: {
     icon: "/favicon.ico",

--- a/apps/speckit/app/sitemap.ts
+++ b/apps/speckit/app/sitemap.ts
@@ -1,21 +1,9 @@
 import type { MetadataRoute } from "next";
-
-const routes = [
-  "",
-  "/product",
-  "/how-it-works",
-  "/solutions",
-  "/solutions/ciso",
-  "/solutions/devsecops",
-  "/template",
-  "/pricing",
-  "/contact",
-  "/trust",
-];
+import { SPECKIT_BASE_URL, speckitRoutes } from "../lib/routes";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return routes.map((route) => ({
-    url: `https://speckit.airnub.io${route}`,
+  return speckitRoutes.map((route) => ({
+    url: `${SPECKIT_BASE_URL}${route}`,
     changefreq: "weekly",
     priority: route === "" ? 1 : 0.7,
   }));

--- a/apps/speckit/lib/jsonld.ts
+++ b/apps/speckit/lib/jsonld.ts
@@ -1,0 +1,14 @@
+import { softwareApplicationJsonLd } from "@airnub/seo";
+import { SPECKIT_BASE_URL } from "./routes";
+
+export function buildSpeckitSoftwareJsonLd() {
+  return softwareApplicationJsonLd({
+    name: "Speckit",
+    url: SPECKIT_BASE_URL,
+    applicationCategory: "DevSecOps Application",
+    description:
+      "End vibe-coding. Ship secure, auditable releases with governed workflows and continuous evidence.",
+    softwareHelp: "https://docs.speckit.dev",
+    sameAs: ["https://github.com/airnub/speckit", "https://airnub.io"],
+  });
+}

--- a/apps/speckit/lib/routes.ts
+++ b/apps/speckit/lib/routes.ts
@@ -1,0 +1,16 @@
+export const SPECKIT_BASE_URL = "https://speckit.airnub.io" as const;
+
+export const speckitRoutes = [
+  "",
+  "/product",
+  "/how-it-works",
+  "/solutions",
+  "/solutions/ciso",
+  "/solutions/devsecops",
+  "/template",
+  "/pricing",
+  "/contact",
+  "/trust",
+] as const;
+
+export type SpeckitRoute = (typeof speckitRoutes)[number];


### PR DESCRIPTION
## Summary
- add shared JSON-LD builders and route maps for the Airnub and Speckit apps
- update layouts and pages to consume the new helpers for consistent metadata
## Testing
- pnpm --filter @airnub/airnub-app lint
- pnpm --filter @airnub/speckit-app lint

------
https://chatgpt.com/codex/tasks/task_e_68d805c522e88324942706102ad3ba36