### PR TITLE
chore(commitlint): restore conventional defaults

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,16 +1,25 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  parserPreset: {
-    name: '@commitlint/parse',
-    parserOpts: {
-      headerPattern: /^(?:(?<type>[\w-]+)(?:\((?<scope>.*)\))?!?:\s)?(?<subject>.+)$/,
-      headerCorrespondence: ['type', 'scope', 'subject'],
-    },
-  },
   rules: {
-    'type-empty': [0],
-    'type-case': [0],
-    'type-enum': [0],
+    'type-empty': [2, 'never'],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test',
+      ],
+    ],
     'subject-empty': [2, 'never'],
     'subject-case': [0],
   },


### PR DESCRIPTION
## Summary
- restore the commitlint configuration to use the default conventional rules and remove the custom parser override

## Testing
- pnpm commitlint --from HEAD~1 --to HEAD

------
https://chatgpt.com/codex/tasks/task_e_68d80ed2c8248324a6379f67b76931a4