### PR TITLE
Serve OG PNG locally in API routes

### DIFF
--- a/apps/airnub/app/api/og/route.tsx
+++ b/apps/airnub/app/api/og/route.tsx
@@ -1,9 +1,9 @@
-import { ogTemplateUrl } from "@airnub/brand";
+import { promises as fs } from "node:fs";
 
-export const runtime = "edge";
+import { ogTemplate } from "@airnub/brand";
 
 export async function GET() {
-  const template = await fetch(ogTemplateUrl).then((response) => response.arrayBuffer());
+  const template = await fs.readFile(ogTemplate);
 
   return new Response(template, {
     headers: {

--- a/apps/speckit/app/api/og/route.tsx
+++ b/apps/speckit/app/api/og/route.tsx
@@ -1,9 +1,9 @@
-import { ogTemplateUrl } from "@airnub/brand";
+import { promises as fs } from "node:fs";
 
-export const runtime = "edge";
+import { ogTemplate } from "@airnub/brand";
 
 export async function GET() {
-  const template = await fetch(ogTemplateUrl).then((response) => response.arrayBuffer());
+  const template = await fs.readFile(ogTemplate);
 
   return new Response(template, {
     headers: {

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -1,7 +1,9 @@
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const ogTemplateUrl = new URL("../public/og-template.png", import.meta.url);
-export const ogTemplate = fileURLToPath(ogTemplateUrl);
+const packageDir = dirname(fileURLToPath(import.meta.url));
+export const ogTemplate = join(packageDir, "../public/og-template.png");
 
 export * from "./AirnubWordmark";
 export * from "./SpeckitWordmark";


### PR DESCRIPTION
## Summary
- update the Airnub and Speckit OG API routes to load the PNG template from the local filesystem instead of fetching over HTTP
- expose a stable filesystem path for the shared OG template from `@airnub/brand`

## Testing
- pnpm --filter @airnub/airnub-app dev (curl -I http://localhost:3000/api/og)
- pnpm --filter @airnub/speckit-app dev (curl -I http://localhost:3000/api/og)


------
https://chatgpt.com/codex/tasks/task_e_68d80ecd73b4832483da430c51f01f40