### PR TITLE
Fix semantic pull request validation defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          headerPattern: '^(.+)$'
-          headerPatternCorrespondence: type
           types: |
-            .+
-          headerPatternCorrespondence: subject
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
           subjectPattern: '^(?!\s*$).+'
           subjectPatternError: >-
             PR titles must include a short description (e.g. "Update pnpm setup configuration").


### PR DESCRIPTION
## Summary
- remove the custom header overrides from the semantic PR title workflow step
- enumerate the conventional commit types explicitly so wildcard matches are no longer allowed

## Testing
- `node - <<'NODE' ...` (validates that `fix: wire up tests` passes and `Fix missing colon` is rejected)


------
https://chatgpt.com/codex/tasks/task_e_68d80ed58ef883248e0e9a46394c890d