### PR TITLE
Fix dev warnings from Next.js output tracing

### DIFF
--- a/apps/airnub/next.config.mjs
+++ b/apps/airnub/next.config.mjs
@@ -1,4 +1,11 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const config = {
+  outputFileTracingRoot: path.join(__dirname, "../../"),
   experimental: {
     optimizePackageImports: ["@airnub/ui", "@airnub/brand", "@airnub/seo"],
   },

--- a/apps/speckit/next.config.mjs
+++ b/apps/speckit/next.config.mjs
@@ -1,4 +1,11 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const config = {
+  outputFileTracingRoot: path.join(__dirname, "../../"),
   experimental: {
     optimizePackageImports: ["@airnub/ui", "@airnub/brand", "@airnub/seo"],
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.17.1",
   "scripts": {
-    "dev": "turbo run dev --parallel --no-cache",
+    "dev": "turbo run dev --parallel --cache=local:r,remote:r",
     "build": "turbo run build",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",


### PR DESCRIPTION
## Summary
- configure both app Next.js configs with an explicit outputFileTracingRoot so the workspace root is inferred correctly
- update the dev script to use the modern Turborepo cache flag instead of the deprecated --no-cache

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68d814abcddc83249f90def059334da2