### PR TITLE
Fix module resolution for workspace packages

### DIFF
--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -11,7 +11,9 @@
   },
   "exports": {
     ".": {
-      "import": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -10,7 +10,9 @@
   },
   "exports": {
     ".": {
-      "import": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   }
 }

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -6,7 +6,9 @@
   "types": "src/index.ts",
   "exports": {
     ".": {
-      "import": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,9 @@
   },
   "exports": {
     ".": {
-      "import": "./src/index.ts"
+      "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,18 @@
       "next",
       "next/image-types/global",
       "next/navigation"
-    ]
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@airnub/brand": ["packages/brand/src/index.ts"],
+      "@airnub/brand/*": ["packages/brand/src/*"],
+      "@airnub/ui": ["packages/ui/src/index.ts"],
+      "@airnub/ui/*": ["packages/ui/src/*"],
+      "@airnub/seo": ["packages/seo/src/index.ts"],
+      "@airnub/seo/*": ["packages/seo/src/*"],
+      "@airnub/db": ["packages/db/src/index.ts"],
+      "@airnub/db/*": ["packages/db/src/*"]
+    }
   },
   "include": [
     "apps",


### PR DESCRIPTION
## Summary
- expose type exports for shared packages so Next.js can resolve them correctly
- add workspace path aliases to the root tsconfig for cleaner cross-package imports

## Testing
- CI=1 FORCE_COLOR=0 pnpm --filter @airnub/airnub-app build
- CI=1 FORCE_COLOR=0 pnpm --filter @airnub/speckit-app build

------
https://chatgpt.com/codex/tasks/task_e_68d857d9dcfc832496ad3565df168148