### PR TITLE
fix: make husky hooks portable

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,11 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+set -eu
 
-pnpm commitlint --edit "$1"
+COMMITLINT="./node_modules/.bin/commitlint"
+
+if [ ! -x "$COMMITLINT" ]; then
+  echo "commitlint not found at $COMMITLINT" >&2
+  exit 127
+fi
+
+exec "$COMMITLINT" --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
+# Reserved for future pre-commit checks.


### PR DESCRIPTION
## Summary
- remove deprecated husky bootstrap sourcing from local git hooks
- call commitlint via the workspace binary so commits no longer require pnpm on PATH

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d91460075483248798ce714943d58f