### PR TITLE
fix: suppress hydration warnings from html attribute mismatches

### DIFF
--- a/apps/airnub/app/layout.tsx
+++ b/apps/airnub/app/layout.tsx
@@ -46,7 +46,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="font-sans">
+    <html lang="en" className="font-sans" suppressHydrationWarning>
       <head>
         <script
           type="application/ld+json"

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="font-sans">
+    <html lang="en" className="font-sans" suppressHydrationWarning>
       <head>
         <JsonLd data={jsonLd} />
       </head>


### PR DESCRIPTION
## Summary
- add suppressHydrationWarning to the root html elements in both apps to tolerate browser extensions mutating attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d931caa9d08324a656cfe984eaf5b2