### PR TITLE
Ignore Supabase CLI temp directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 # misc
 .DS_Store
 *.pem
+supabase/.temp/
+supabase/.branches/
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
## Summary
- add Supabase CLI working directories to the gitignore to prevent committing local state

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9434f19b48324a598f48611cf579f