### PR TITLE
Align apps with shared dark experience

### DIFF
--- a/apps/airnub/app/company/page.tsx
+++ b/apps/airnub/app/company/page.tsx
@@ -27,7 +27,7 @@ const values = [
 
 export default function CompanyPage() {
   return (
-    <div className="space-y-16 pb-20">
+    <div className="space-y-16 pb-24 text-slate-300">
       <PageHero
         eyebrow="Company"
         title="We help platform leaders turn trust into a competitive advantage"
@@ -37,19 +37,19 @@ export default function CompanyPage() {
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {values.map((value) => (
-            <div key={value.name} className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-              <h2 className="text-xl font-semibold text-slate-900">{value.name}</h2>
-              <p className="mt-3 text-sm text-slate-600">{value.description}</p>
+            <div key={value.name} className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40">
+              <h2 className="text-xl font-semibold text-white">{value.name}</h2>
+              <p className="mt-3 text-sm text-slate-300">{value.description}</p>
             </div>
           ))}
         </Container>
       </section>
 
       <section id="careers">
-        <Container className="rounded-3xl border border-slate-200 bg-slate-900 p-10 text-slate-100">
+        <Container className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 text-slate-200 shadow-lg shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight">Careers</h2>
+              <h2 className="text-3xl font-semibold tracking-tight text-white">Careers</h2>
               <p className="mt-4 text-sm text-slate-300">
                 We are a remote-first team across North America and Europe. If you are excited about developer platforms, compliance automation, and building delightful experiences, we would love to chat.
               </p>
@@ -57,7 +57,7 @@ export default function CompanyPage() {
             <div>
               <Link
                 href="mailto:careers@airnub.io"
-                className="inline-flex items-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-100"
+                className="inline-flex items-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
               >
                 careers@airnub.io
               </Link>
@@ -68,19 +68,19 @@ export default function CompanyPage() {
 
       <section id="press">
         <Container className="grid gap-6 md:grid-cols-2">
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <h2 className="text-xl font-semibold text-slate-900">Press kit</h2>
-            <p className="mt-3 text-sm text-slate-600">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40">
+            <h2 className="text-xl font-semibold text-white">Press kit</h2>
+            <p className="mt-3 text-sm text-slate-300">
               Logos, product screenshots, and leadership bios ready for publication.
             </p>
-            <Link href="mailto:press@airnub.io" className="mt-4 inline-flex text-sm font-semibold text-sky-600">
+            <Link href="mailto:press@airnub.io" className="mt-4 inline-flex text-sm font-semibold text-sky-400">
               press@airnub.io →
             </Link>
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <h2 className="text-xl font-semibold text-slate-900">Media inquiries</h2>
-            <p className="mt-3 text-sm text-slate-600">Reach out for commentary on platform governance, DevSecOps, and compliance automation trends.</p>
-            <Link href="https://cal.com/airnub/briefing" className="mt-4 inline-flex text-sm font-semibold text-sky-600" target="_blank" rel="noreferrer">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40">
+            <h2 className="text-xl font-semibold text-white">Media inquiries</h2>
+            <p className="mt-3 text-sm text-slate-300">Reach out for commentary on platform governance, DevSecOps, and compliance automation trends.</p>
+            <Link href="https://cal.com/airnub/briefing" className="mt-4 inline-flex text-sm font-semibold text-sky-400" target="_blank" rel="noreferrer">
               Book a briefing →
             </Link>
           </div>
@@ -88,20 +88,20 @@ export default function CompanyPage() {
       </section>
 
       <section id="legal">
-        <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-sm">
-          <h2 className="text-2xl font-semibold text-slate-900">Legal</h2>
+        <Container className="rounded-3xl border border-slate-800 bg-slate-900/60 p-10 shadow-lg shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-white">Legal</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-2">
             <div>
-              <h3 className="text-lg font-semibold text-slate-900">Privacy Notice</h3>
-              <p className="mt-2 text-sm text-slate-600">We collect only the information required to respond to inquiries and improve our services.</p>
-              <Link href="/resources#privacy" className="mt-3 inline-flex text-sm font-semibold text-sky-600">
+              <h3 className="text-lg font-semibold text-white">Privacy Notice</h3>
+              <p className="mt-2 text-sm text-slate-300">We collect only the information required to respond to inquiries and improve our services.</p>
+              <Link href="/resources#privacy" className="mt-3 inline-flex text-sm font-semibold text-sky-400">
                 Read more →
               </Link>
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-slate-900">Terms of Service</h3>
-              <p className="mt-2 text-sm text-slate-600">Our terms set expectations for customers, partners, and community contributors.</p>
-              <Link href="/resources#terms" className="mt-3 inline-flex text-sm font-semibold text-sky-600">
+              <h3 className="text-lg font-semibold text-white">Terms of Service</h3>
+              <p className="mt-2 text-sm text-slate-300">Our terms set expectations for customers, partners, and community contributors.</p>
+              <Link href="/resources#terms" className="mt-3 inline-flex text-sm font-semibold text-sky-400">
                 View terms →
               </Link>
             </div>

--- a/apps/airnub/app/contact/page.tsx
+++ b/apps/airnub/app/contact/page.tsx
@@ -13,23 +13,23 @@ export const metadata: Metadata = {
 function ContactShortcuts() {
   return (
     <div className="space-y-6">
-      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
         <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Email</h3>
-        <p className="mt-2 text-sm text-slate-600">
-          Sales & partnerships: <a className="text-sky-600" href="mailto:hello@airnub.io">hello@airnub.io</a>
+        <p className="mt-2 text-sm text-slate-300">
+          Sales & partnerships: <a className="text-sky-400" href="mailto:hello@airnub.io">hello@airnub.io</a>
         </p>
-        <p className="mt-1 text-sm text-slate-600">
-          Security reports: <a className="text-sky-600" href="mailto:security@airnub.io">security@airnub.io</a>
+        <p className="mt-1 text-sm text-slate-300">
+          Security reports: <a className="text-sky-400" href="mailto:security@airnub.io">security@airnub.io</a>
         </p>
       </div>
-      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+      <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
         <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-400">Office hours</h3>
-        <p className="mt-2 text-sm text-slate-600">
+        <p className="mt-2 text-sm text-slate-300">
           Join a weekly live session to see how Airnub and Speckit can accelerate your platform roadmap.
         </p>
         <a
           href="https://cal.com/airnub/office-hours"
-          className="mt-3 inline-flex text-sm font-semibold text-sky-600"
+          className="mt-3 inline-flex text-sm font-semibold text-sky-400"
           target="_blank"
           rel="noreferrer"
         >
@@ -42,7 +42,7 @@ function ContactShortcuts() {
 
 export default function ContactPage() {
   return (
-    <div className="space-y-16 pb-20">
+    <div className="space-y-16 pb-24 text-slate-300">
       <PageHero
         eyebrow="Contact"
         title="Let’s build your trust-forward platform"
@@ -51,13 +51,13 @@ export default function ContactPage() {
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
-          <div className="rounded-3xl border border-slate-200 bg-white p-10 shadow-sm">
-            <h2 className="text-xl font-semibold text-slate-900">Send us a note</h2>
-            <p className="mt-3 text-sm text-slate-500">We typically reply within one business day.</p>
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 shadow-lg shadow-slate-950/40">
+            <h2 className="text-xl font-semibold text-white">Send us a note</h2>
+            <p className="mt-3 text-sm text-slate-400">We typically reply within one business day.</p>
             <form action={submitLead} className="mt-8 space-y-6">
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
-                  <label htmlFor="full_name" className="block text-sm font-semibold text-slate-900">
+                  <label htmlFor="full_name" className="block text-sm font-semibold text-white">
                     Full name
                   </label>
                   <input
@@ -65,12 +65,12 @@ export default function ContactPage() {
                     name="full_name"
                     type="text"
                     autoComplete="name"
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
                   />
                 </div>
                 <div>
-                  <label htmlFor="email" className="block text-sm font-semibold text-slate-900">
-                    Work email <span className="text-rose-500">*</span>
+                  <label htmlFor="email" className="block text-sm font-semibold text-white">
+                    Work email <span className="text-rose-400">*</span>
                   </label>
                   <input
                     id="email"
@@ -78,13 +78,13 @@ export default function ContactPage() {
                     type="email"
                     required
                     autoComplete="email"
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
                   />
                 </div>
               </div>
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
-                  <label htmlFor="company" className="block text-sm font-semibold text-slate-900">
+                  <label htmlFor="company" className="block text-sm font-semibold text-white">
                     Company
                   </label>
                   <input
@@ -92,18 +92,18 @@ export default function ContactPage() {
                     name="company"
                     type="text"
                     autoComplete="organization"
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
                   />
                 </div>
                 <div>
-                  <label htmlFor="message" className="block text-sm font-semibold text-slate-900">
+                  <label htmlFor="message" className="block text-sm font-semibold text-white">
                     What can we help with?
                   </label>
                   <textarea
                     id="message"
                     name="message"
                     rows={4}
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
                   />
                 </div>
               </div>

--- a/apps/airnub/app/globals.css
+++ b/apps/airnub/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
 }
 
 html {
@@ -11,15 +11,15 @@ html {
 }
 
 body {
-  background-color: #f8fafc; /* slate-50 */
-  color: #0f172a; /* slate-900 */
+  background-color: #020617; /* slate-950 */
+  color: #e2e8f0; /* slate-300 */
   font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 a:focus-visible {
-  outline: 2px solid #0ea5e9; /* sky-500 */
+  outline: 2px solid #38bdf8; /* sky-400 */
   outline-offset: 2px;
 }
 

--- a/apps/airnub/app/layout.tsx
+++ b/apps/airnub/app/layout.tsx
@@ -46,14 +46,14 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="font-sans" suppressHydrationWarning>
+    <html lang="en" className="font-sans antialiased dark" suppressHydrationWarning>
       <head>
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       </head>
-      <body className="min-h-screen bg-slate-50 text-slate-900">
+      <body className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
         <a href="#content" className="skip-link">
           Skip to content
         </a>

--- a/apps/airnub/app/page.tsx
+++ b/apps/airnub/app/page.tsx
@@ -43,7 +43,7 @@ export default async function HomePage() {
   });
 
   return (
-    <div className="space-y-24 pb-20">
+    <div className="space-y-24 pb-24 text-slate-300">
       <PageHero
         eyebrow="Airnub builds governed, enterprise-ready developer platforms."
         title="Operationalize trust across every release pipeline"
@@ -63,9 +63,12 @@ export default async function HomePage() {
       <section>
         <Container className="grid gap-10 lg:grid-cols-3">
           {highlights.map((item) => (
-            <div key={item.title} className="rounded-2xl bg-white p-8 shadow-sm ring-1 ring-slate-200">
-              <h3 className="text-xl font-semibold text-slate-900">{item.title}</h3>
-              <p className="mt-3 text-sm text-slate-600">{item.description}</p>
+            <div
+              key={item.title}
+              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40 backdrop-blur"
+            >
+              <h3 className="text-xl font-semibold text-white">{item.title}</h3>
+              <p className="mt-3 text-sm text-slate-300">{item.description}</p>
             </div>
           ))}
         </Container>
@@ -73,10 +76,13 @@ export default async function HomePage() {
 
       <section>
         <Container className="text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">Trusted by platform leaders</p>
+          <p className="text-sm font-semibold uppercase tracking-wide text-slate-400">Trusted by platform leaders</p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-8">
             {customers.map((customer) => (
-              <div key={customer.name} className="flex h-16 w-40 items-center justify-center rounded-xl border border-slate-200 bg-white">
+              <div
+                key={customer.name}
+                className="flex h-16 w-40 items-center justify-center rounded-xl border border-slate-800 bg-slate-900/70 shadow-inner shadow-slate-950/40"
+              >
                 <Image src={customer.logo} alt={customer.name} width={120} height={40} className="object-contain" />
               </div>
             ))}
@@ -84,13 +90,12 @@ export default async function HomePage() {
         </Container>
       </section>
 
-      <section className="bg-slate-900 py-20 text-slate-100">
-        <Container className="grid gap-12 lg:grid-cols-2 lg:items-center">
+      <section>
+        <Container className="grid gap-12 rounded-3xl border border-slate-800 bg-slate-900/80 p-12 shadow-xl shadow-slate-950/40 lg:grid-cols-2 lg:items-center">
           <div>
-            <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">Secure the spec loop with Speckit</h2>
+            <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Secure the spec loop with Speckit</h2>
             <p className="mt-4 text-base text-slate-300">
-              Speckit brings change management, supply-chain controls, and runtime attestations together. Govern policy gates
-              with programmable workflows and surface the right signals to auditors and stakeholders instantly.
+              Speckit brings change management, supply-chain controls, and runtime attestations together. Govern policy gates with programmable workflows and surface the right signals to auditors and stakeholders instantly.
             </p>
             <div className="mt-6 flex flex-wrap gap-4">
               <Button asChild>
@@ -125,33 +130,41 @@ export default async function HomePage() {
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-center">
-          <div>
-            <h2 className="text-3xl font-semibold text-slate-900">Services aligned to your platform journey</h2>
-            <p className="mt-4 text-base text-slate-600">
-              From first landing zones to regulated scale, our services team embeds with platform, security, and compliance leaders to deliver quick wins and long-term maturity.
-            </p>
-            <ul className="mt-6 space-y-3 text-sm text-slate-600">
-              <li><strong className="font-semibold text-slate-900">Assessment:</strong> map current controls to regulatory expectations.</li>
-              <li><strong className="font-semibold text-slate-900">Blueprint:</strong> reference architectures with guardrails for teams and services.</li>
-              <li><strong className="font-semibold text-slate-900">Adoption:</strong> playbooks to scale platform operations with confidence.</li>
+          <div className="space-y-6">
+            <div>
+              <h2 className="text-3xl font-semibold text-white">Services aligned to your platform journey</h2>
+              <p className="mt-4 text-base text-slate-300">
+                From first landing zones to regulated scale, our services team embeds with platform, security, and compliance leaders to deliver quick wins and long-term maturity.
+              </p>
+            </div>
+            <ul className="space-y-3 text-sm text-slate-300">
+              <li>
+                <strong className="font-semibold text-white">Assessment:</strong> map current controls to regulatory expectations.
+              </li>
+              <li>
+                <strong className="font-semibold text-white">Blueprint:</strong> reference architectures with guardrails for teams and services.
+              </li>
+              <li>
+                <strong className="font-semibold text-white">Adoption:</strong> playbooks to scale platform operations with confidence.
+              </li>
             </ul>
           </div>
           <div className="grid gap-6 md:grid-cols-2">
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-slate-900">Platform operating model</h3>
-              <p className="mt-2 text-sm text-slate-600">Team structures, KPIs, and governance rituals to align craft and compliance.</p>
+            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+              <h3 className="text-lg font-semibold text-white">Platform operating model</h3>
+              <p className="mt-2 text-sm text-slate-300">Team structures, KPIs, and governance rituals to align craft and compliance.</p>
             </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-slate-900">Regulated cloud acceleration</h3>
-              <p className="mt-2 text-sm text-slate-600">Deploy secure baselines for FedRAMP, SOC 2, and ISO 27001 without slowing delivery.</p>
+            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+              <h3 className="text-lg font-semibold text-white">Regulated cloud acceleration</h3>
+              <p className="mt-2 text-sm text-slate-300">Deploy secure baselines for FedRAMP, SOC 2, and ISO 27001 without slowing delivery.</p>
             </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-slate-900">InnerSource enablement</h3>
-              <p className="mt-2 text-sm text-slate-600">Empower product teams with paved roads, golden paths, and clear guardrails.</p>
+            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+              <h3 className="text-lg font-semibold text-white">InnerSource enablement</h3>
+              <p className="mt-2 text-sm text-slate-300">Empower product teams with paved roads, golden paths, and clear guardrails.</p>
             </div>
-            <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-              <h3 className="text-lg font-semibold text-slate-900">Trust & assurance readiness</h3>
-              <p className="mt-2 text-sm text-slate-600">Prepare evidence for auditors, partners, and leadership with zero scramble.</p>
+            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+              <h3 className="text-lg font-semibold text-white">Trust & assurance readiness</h3>
+              <p className="mt-2 text-sm text-slate-300">Prepare evidence for auditors, partners, and leadership with zero scramble.</p>
             </div>
           </div>
         </Container>

--- a/apps/airnub/app/products/page.tsx
+++ b/apps/airnub/app/products/page.tsx
@@ -36,7 +36,7 @@ const jsonLd = buildAirnubProductPortfolioJsonLd();
 
 export default function ProductsPage() {
   return (
-    <div className="space-y-16 pb-20">
+    <div className="space-y-16 pb-24 text-slate-300">
       <PageHero
         eyebrow="Products"
         title="Everything you need to govern modern software delivery"
@@ -47,22 +47,25 @@ export default function ProductsPage() {
       <section>
         <Container className="grid gap-8 md:grid-cols-2">
           {offerings.map((offering) => (
-            <article key={offering.name} className="flex h-full flex-col justify-between rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+            <article
+              key={offering.name}
+              className="flex h-full flex-col justify-between rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40"
+            >
               <div>
                 <div className="flex items-center gap-3">
-                  <h2 className="text-2xl font-semibold text-slate-900">{offering.name}</h2>
+                  <h2 className="text-2xl font-semibold text-white">{offering.name}</h2>
                   {offering.badge ? (
-                    <span className="rounded-full bg-sky-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-700">
+                    <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-300">
                       {offering.badge}
                     </span>
                   ) : null}
                 </div>
-                <p className="mt-3 text-sm text-slate-600">{offering.description}</p>
+                <p className="mt-3 text-sm text-slate-300">{offering.description}</p>
               </div>
               <div className="mt-8">
                 <Link
                   href={offering.href}
-                  className="text-sm font-semibold text-sky-600 hover:text-sky-500"
+                  className="text-sm font-semibold text-sky-400 transition hover:text-sky-300"
                   target={offering.href.startsWith("http") ? "_blank" : undefined}
                   rel={offering.href.startsWith("http") ? "noreferrer" : undefined}
                 >
@@ -76,28 +79,29 @@ export default function ProductsPage() {
 
       <section>
         <Container className="grid gap-8 lg:grid-cols-2">
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <h3 className="text-xl font-semibold text-slate-900">Built with trust as a feature</h3>
-            <p className="mt-3 text-sm text-slate-600">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-lg shadow-slate-950/40">
+            <h3 className="text-xl font-semibold text-white">Built with trust as a feature</h3>
+            <p className="mt-3 text-sm text-slate-300">
               Every product ships with compliance guardrails, audit-ready evidence, and API-first integrations that slot into your delivery stack.
             </p>
-            <ul className="mt-4 space-y-2 text-sm text-slate-600">
+            <ul className="mt-4 space-y-2 text-sm text-slate-300">
               <li>→ SLSA-aligned attestations and SBOM automation</li>
               <li>→ Role-aware workflows for platform, security, and compliance leads</li>
               <li>→ Open APIs and adapters for the tools you already use</li>
             </ul>
           </div>
-          <div className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-            <h3 className="text-xl font-semibold text-slate-900">Shared Supabase foundations</h3>
-            <p className="mt-3 text-sm text-slate-600">
+          <div className="rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-lg shadow-slate-950/40">
+            <h3 className="text-xl font-semibold text-white">Shared Supabase foundations</h3>
+            <p className="mt-3 text-sm text-slate-300">
               Both the Airnub corporate site and Speckit microsite capture leads into the same Supabase project, keeping GTM signals aligned and secure.
             </p>
-            <p className="mt-3 text-sm text-slate-600">
+            <p className="mt-3 text-sm text-slate-300">
               Row-level security ensures visitor submissions stay private while platform teams can analyze performance via service-role access.
             </p>
           </div>
         </Container>
       </section>
+
       <JsonLd data={jsonLd} />
     </div>
   );

--- a/apps/airnub/app/resources/page.tsx
+++ b/apps/airnub/app/resources/page.tsx
@@ -48,7 +48,7 @@ const updates = [
 
 export default function ResourcesPage() {
   return (
-    <div className="space-y-16 pb-20">
+    <div className="space-y-16 pb-24 text-slate-300">
       <PageHero
         eyebrow="Resources"
         title="Enablement, updates, and research for platform and security teams"
@@ -57,17 +57,17 @@ export default function ResourcesPage() {
 
       <section>
         <Container>
-          <h2 className="text-xl font-semibold text-slate-900">Featured guides</h2>
+          <h2 className="text-xl font-semibold text-white">Featured guides</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-3">
             {guides.map((guide) => (
               <Link
                 key={guide.title}
                 href={guide.href}
-                className="group rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:border-sky-200"
+                className="group rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:-translate-y-1 hover:border-sky-500/40"
               >
-                <p className="text-sm font-semibold text-sky-600 group-hover:text-sky-500">Guide</p>
-                <h3 className="mt-2 text-lg font-semibold text-slate-900">{guide.title}</h3>
-                <p className="mt-2 text-sm text-slate-600">{guide.description}</p>
+                <p className="text-sm font-semibold text-sky-400 group-hover:text-sky-300">Guide</p>
+                <h3 className="mt-2 text-lg font-semibold text-white">{guide.title}</h3>
+                <p className="mt-2 text-sm text-slate-300">{guide.description}</p>
               </Link>
             ))}
           </div>
@@ -76,17 +76,17 @@ export default function ResourcesPage() {
 
       <section>
         <Container>
-          <h2 className="text-xl font-semibold text-slate-900">Latest updates</h2>
+          <h2 className="text-xl font-semibold text-white">Latest updates</h2>
           <div className="mt-6 space-y-4">
             {updates.map((update) => (
               <Link
                 key={update.title}
                 href={update.href}
-                className="flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm transition hover:border-sky-200"
+                className="flex flex-col rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:border-sky-500/40"
               >
                 <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">{update.date}</span>
-                <h3 className="mt-2 text-lg font-semibold text-slate-900">{update.title}</h3>
-                <span className="mt-2 text-sm text-sky-600">Read →</span>
+                <h3 className="mt-2 text-lg font-semibold text-white">{update.title}</h3>
+                <span className="mt-2 text-sm font-semibold text-sky-400">Read →</span>
               </Link>
             ))}
           </div>
@@ -94,11 +94,11 @@ export default function ResourcesPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-sm">
+        <Container className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 shadow-lg shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-2xl font-semibold text-slate-900">Prefer a live walkthrough?</h2>
-              <p className="mt-3 text-sm text-slate-600">
+              <h2 className="text-2xl font-semibold text-white">Prefer a live walkthrough?</h2>
+              <p className="mt-3 text-sm text-slate-300">
                 Join a monthly office hour to see how teams automate policy gates, evidence capture, and release governance with Speckit.
               </p>
             </div>

--- a/apps/airnub/app/services/page.tsx
+++ b/apps/airnub/app/services/page.tsx
@@ -45,7 +45,7 @@ const engagements = [
 
 export default function ServicesPage() {
   return (
-    <div className="space-y-16 pb-20">
+    <div className="space-y-16 pb-24 text-slate-300">
       <PageHero
         eyebrow="Services"
         title="Embedded experts for every stage of your platform journey"
@@ -56,15 +56,19 @@ export default function ServicesPage() {
       <section>
         <Container className="space-y-10">
           {engagements.map((engagement) => (
-            <article key={engagement.id} id={engagement.id} className="rounded-3xl border border-slate-200 bg-white p-10 shadow-sm">
+            <article
+              key={engagement.id}
+              id={engagement.id}
+              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-10 shadow-lg shadow-slate-950/40"
+            >
               <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
                 <div className="lg:max-w-2xl">
-                  <h2 className="text-2xl font-semibold text-slate-900">{engagement.title}</h2>
-                  <p className="mt-3 text-sm text-slate-600">{engagement.description}</p>
+                  <h2 className="text-2xl font-semibold text-white">{engagement.title}</h2>
+                  <p className="mt-3 text-sm text-slate-300">{engagement.description}</p>
                 </div>
                 <div className="lg:min-w-[16rem]">
                   <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Key deliverables</p>
-                  <ul className="mt-3 space-y-2 text-sm text-slate-600">
+                  <ul className="mt-3 space-y-2 text-sm text-slate-300">
                     {engagement.deliverables.map((item) => (
                       <li key={item}>→ {item}</li>
                     ))}
@@ -77,16 +81,16 @@ export default function ServicesPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-200 bg-slate-900 p-10 text-slate-100">
+        <Container className="rounded-3xl border border-slate-800 bg-slate-900/80 p-10 text-slate-200 shadow-xl shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight">Outcomes-first engagements</h2>
+              <h2 className="text-3xl font-semibold tracking-tight text-white">Outcomes-first engagements</h2>
               <p className="mt-4 text-sm text-slate-300">
                 We align each engagement to measurable KPIs: deployment frequency, change failure rate, audit readiness time, and customer trust metrics.
               </p>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/10 p-6">
-              <p className="text-sm text-slate-200">We embed alongside your teams for 6–12 weeks, transfer knowledge continuously, and operationalize Speckit for long-term success.</p>
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200">
+              <p>We embed alongside your teams for 6–12 weeks, transfer knowledge continuously, and operationalize Speckit for long-term success.</p>
             </div>
           </div>
         </Container>

--- a/apps/airnub/app/solutions/page.tsx
+++ b/apps/airnub/app/solutions/page.tsx
@@ -41,7 +41,7 @@ const sectors = [
 
 export default function SolutionsPage() {
   return (
-    <div className="space-y-16 pb-20">
+    <div className="space-y-16 pb-24 text-slate-300">
       <PageHero
         eyebrow="Solutions"
         title="Governance blueprints tailored to your sector"
@@ -51,10 +51,10 @@ export default function SolutionsPage() {
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {sectors.map((sector) => (
-            <div key={sector.name} className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
-              <h2 className="text-xl font-semibold text-slate-900">{sector.name}</h2>
-              <p className="mt-3 text-sm text-slate-600">{sector.summary}</p>
-              <ul className="mt-4 space-y-2 text-sm text-slate-600">
+            <div key={sector.name} className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40">
+              <h2 className="text-xl font-semibold text-white">{sector.name}</h2>
+              <p className="mt-3 text-sm text-slate-300">{sector.summary}</p>
+              <ul className="mt-4 space-y-2 text-sm text-slate-300">
                 {sector.bullets.map((bullet) => (
                   <li key={bullet}>→ {bullet}</li>
                 ))}
@@ -65,15 +65,15 @@ export default function SolutionsPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 p-10 text-slate-100">
+        <Container className="rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 p-10 text-slate-100 shadow-xl shadow-slate-950/40">
           <div className="grid gap-10 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight">Partner with platform strategists and compliance engineers</h2>
+              <h2 className="text-3xl font-semibold tracking-tight text-white">Partner with platform strategists and compliance engineers</h2>
               <p className="mt-4 text-sm text-slate-300">
                 Our cross-functional pods pair product, platform, and trust roles to deliver value from the first sprint. We co-design operating models, deliver automation, and upskill your teams.
               </p>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/10 p-6 text-sm text-slate-200">
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200">
               <p className="font-semibold text-white">What to expect:</p>
               <ul className="mt-3 space-y-2">
                 <li>→ Capability assessments mapped to maturity curves</li>

--- a/apps/airnub/app/trust/page.tsx
+++ b/apps/airnub/app/trust/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Container } from "@airnub/ui";
+import { PageHero } from "../../components/PageHero";
+
+export const revalidate = 86_400;
+
+export const metadata: Metadata = {
+  title: "Trust",
+  description: "Explore Airnub's approach to security, privacy, and responsible disclosure.",
+};
+
+const trustHighlights = [
+  {
+    title: "Trust Center",
+    description: "Review certifications, policies, and live status updates for Airnub and Speckit services.",
+    href: "https://trust.airnub.io",
+  },
+  {
+    title: "Vulnerability Disclosure",
+    description: "Coordinated security response with a 24-hour acknowledgement commitment and PGP details.",
+    href: "https://trust.airnub.io/vdp",
+  },
+  {
+    title: "security.txt",
+    description: "Find our canonical security contact, encryption keys, and preferred disclosure channels.",
+    href: "https://trust.airnub.io/.well-known/security.txt",
+  },
+];
+
+export default function TrustPage() {
+  return (
+    <div className="space-y-16 pb-24 text-slate-300">
+      <PageHero
+        eyebrow="Trust"
+        title="Transparency and assurance for every release"
+        description="Our security, privacy, and reliability posture is documented in a single destination so your teams can evaluate Airnub quickly."
+      />
+
+      <section>
+        <Container className="grid gap-8 lg:grid-cols-3">
+          {trustHighlights.map((item) => (
+            <Link
+              key={item.title}
+              href={item.href}
+              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-left shadow-lg shadow-slate-950/40 transition hover:border-sky-500/40"
+              target="_blank"
+              rel="noreferrer"
+            >
+              <h2 className="text-xl font-semibold text-white">{item.title}</h2>
+              <p className="mt-3 text-sm text-slate-300">{item.description}</p>
+              <span className="mt-4 inline-flex text-sm font-semibold text-sky-400">Visit resource →</span>
+            </Link>
+          ))}
+        </Container>
+      </section>
+
+      <section>
+        <Container className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 shadow-lg shadow-slate-950/40">
+          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
+            <div>
+              <h2 className="text-2xl font-semibold text-white">Need something specific?</h2>
+              <p className="mt-3 text-sm text-slate-300">
+                Our team can provide tailored security questionnaires, architecture diagrams, and penetration testing summaries under NDA.
+              </p>
+            </div>
+            <div>
+              <Link
+                href="/contact"
+                className="inline-flex items-center rounded-full bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
+              >
+                Request documents
+              </Link>
+            </div>
+          </div>
+        </Container>
+      </section>
+    </div>
+  );
+}

--- a/apps/airnub/components/PageHero.tsx
+++ b/apps/airnub/components/PageHero.tsx
@@ -16,13 +16,22 @@ export function PageHero({
   className?: string;
 }) {
   return (
-    <section className={clsx("border-b border-slate-200 bg-white py-16 text-slate-900", className)}>
+    <section
+      className={clsx(
+        "relative overflow-hidden border-b border-slate-800 bg-slate-950 py-16 text-slate-100",
+        className,
+      )}
+    >
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15)_0,_rgba(15,23,42,0)_55%)]"
+        aria-hidden="true"
+      />
       <Container className="max-w-4xl">
         {eyebrow ? (
-          <p className="text-sm font-semibold uppercase tracking-wide text-sky-600">{eyebrow}</p>
+          <p className="text-sm font-semibold uppercase tracking-wide text-sky-400/80">{eyebrow}</p>
         ) : null}
-        <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">{title}</h1>
-        {description ? <p className="mt-6 text-lg text-slate-600">{description}</p> : null}
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">{title}</h1>
+        {description ? <p className="mt-6 text-lg text-slate-300">{description}</p> : null}
         {actions ? <div className="mt-8 flex flex-wrap gap-4">{actions}</div> : null}
       </Container>
     </section>

--- a/apps/speckit/app/globals.css
+++ b/apps/speckit/app/globals.css
@@ -3,7 +3,11 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
+}
+
+html {
+  scroll-behavior: smooth;
 }
 
 body {

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -47,11 +47,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="font-sans" suppressHydrationWarning>
+    <html lang="en" className="font-sans antialiased dark" suppressHydrationWarning>
       <head>
         <JsonLd data={jsonLd} />
       </head>
-      <body className="min-h-screen bg-slate-950 text-slate-100">
+      <body className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
         <a href="#content" className="skip-link">
           Skip to content
         </a>

--- a/packages/ui/src/HeaderAirnub.tsx
+++ b/packages/ui/src/HeaderAirnub.tsx
@@ -46,7 +46,7 @@ export function HeaderAirnub({ homeAriaLabel = "Airnub home", additionalRightSlo
         <div className="flex items-center gap-3">
           <Link
             href="https://github.com/airnub"
-            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:inline-flex"
+            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white lg:inline-flex"
             aria-label="Airnub on GitHub"
             target="_blank"
             rel="noreferrer"


### PR DESCRIPTION
## Summary
- switch the Airnub app layout, globals, and hero component to a dark theme consistent with the Speckit app
- restyle all marketing subpages and cards to use the shared dark surfaces and create a placeholder Trust page for navigation links
- tweak the Airnub header styling so GitHub actions remain legible on the dark background
- align the Speckit root layout and global color scheme with the shared dark shell so header/footer styles render correctly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d944f52d648324a4d002a387274cf6