### PR TITLE
Fix Codespace pnpm feature auth failure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,9 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "24"
-    },
-    "ghcr.io/devcontainers/features/pnpm:1": {
-      "version": "10.17.1"
+      "version": "24",
+      "installPnpm": true,
+      "pnpmVersion": "10.17.1"
     },
     "ghcr.io/devcontainers-contrib/features/supabase-cli:2": {}
   },

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 
 ## GitHub Codespaces
 
-The repo ships with a `.devcontainer/` that provisions Node 24, pnpm, and the Supabase CLI. To spin up a Codespace with a fully local Supabase stack:
+The repo ships with a `.devcontainer/` that provisions Node 24, pnpm, and the Supabase CLI. We install pnpm through the official Node feature so the build does not rely on the deprecated standalone pnpm feature, which now requires authenticated access and caused Codespace creation to fail. To spin up a Codespace with a fully local Supabase stack:
 
 1. Create a Codespace from the repository (the first boot runs `pnpm install` automatically).
 2. Copy environment files inside the Codespace:


### PR DESCRIPTION
## Summary
- install pnpm through the Node devcontainer feature instead of the deprecated standalone pnpm feature
- document the change in the Codespaces section of the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97f4c04748324917e23a3b275bbc3