### PR TITLE
feat: localize Airnub home and add Speckit selectors

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -104,7 +104,12 @@ export default async function LocaleLayout({
   };
 
   return (
-    <html lang={locale} className="font-sans antialiased" suppressHydrationWarning>
+    <html
+      lang={locale}
+      className="font-sans antialiased"
+      suppressHydrationWarning
+      data-scroll-behavior="smooth"
+    >
       <head>
         <script
           type="application/ld+json"

--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 import Image from "next/image";
+import Link from "next/link";
 import { Button, Container } from "@airnub/ui";
 import { serverFetch } from "@airnub/seo";
+import { getTranslations } from "next-intl/server";
 import { PageHero } from "../../components/PageHero";
 import { LocaleLink } from "../../components/LocaleLink";
-import Link from "next/link";
+import { assertLocale } from "../../i18n/routing";
 
 export const revalidate = 86_400;
 
@@ -12,50 +14,112 @@ export const metadata: Metadata = {
   title: "Airnub builds governed, enterprise-ready developer platforms",
 };
 
+const highlightIds = [
+  "unifiedGovernance",
+  "evidenceOnDemand",
+  "platformAccelerators",
+] as const;
+
+const customerLogos = [
+  { id: "forgeLabs", logo: "/logos/forge.svg" },
+  { id: "cloudyard", logo: "/logos/cloudyard.svg" },
+  { id: "northbeam", logo: "/logos/northbeam.svg" },
+] as const;
+
+const speckitOutcomeIds = [
+  "governedSpecLoop",
+  "policyGates",
+  "automatedEvidence",
+] as const;
+
+const serviceStepIds = ["assessment", "blueprint", "adoption"] as const;
+
+const serviceCardIds = [
+  "operatingModel",
+  "regulatedCloud",
+  "innerSource",
+  "trustReadiness",
+] as const;
+
 const airnubHomeContent = {
-  highlights: [
-    {
-      title: "Unified governance",
-      description: "Automate policy checks across SDLC gates with contextual guardrails for every team.",
-    },
-    {
-      title: "Evidence on demand",
-      description: "Capture SBOMs, attestations, and traceability artifacts as part of your delivery workflow.",
-    },
-    {
-      title: "Platform accelerators",
-      description: "Blueprints for platform teams to onboard products faster without sacrificing trust or velocity.",
-    },
-  ],
-  customers: [
-    { name: "Forge Labs", logo: "/logos/forge.svg" },
-    { name: "Cloudyard", logo: "/logos/cloudyard.svg" },
-    { name: "Northbeam", logo: "/logos/northbeam.svg" },
-  ],
+  highlights: highlightIds,
+  customers: customerLogos,
 } as const;
 
 const airnubHomeContentUrl = `data:application/json,${encodeURIComponent(JSON.stringify(airnubHomeContent))}`;
 
 type AirnubHomeContent = typeof airnubHomeContent;
 
-export default async function HomePage() {
-  const { highlights, customers } = await serverFetch<AirnubHomeContent>(airnubHomeContentUrl, {
-    revalidate,
-  });
+export default async function HomePage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale: localeParam } = await params;
+  const locale = assertLocale(localeParam);
+  const t = await getTranslations({ locale, namespace: "home" });
+
+  const { highlights: highlightKeys, customers } = await serverFetch<AirnubHomeContent>(
+    airnubHomeContentUrl,
+    {
+      revalidate,
+    }
+  );
+
+  const hero = {
+    eyebrow: t("hero.eyebrow"),
+    title: t("hero.title"),
+    description: t("hero.description"),
+    primaryCta: t("hero.primaryCta"),
+    secondaryCta: t("hero.secondaryCta"),
+  } as const;
+
+  const highlightItems = highlightKeys.map((key) => ({
+    id: key,
+    title: t(`highlights.${key}.title`),
+    description: t(`highlights.${key}.description`),
+  }));
+
+  const customerItems = customers.map((customer) => ({
+    ...customer,
+    name: t(`customers.items.${customer.id}`),
+  }));
+
+  const speckit = {
+    title: t("speckit.title"),
+    description: t("speckit.description"),
+    primaryCta: t("speckit.primaryCta"),
+    secondaryCta: t("speckit.secondaryCta"),
+    outcomesTitle: t("speckit.outcomes.title"),
+    outcomes: speckitOutcomeIds.map((id) => ({ id, copy: t(`speckit.outcomes.items.${id}`) })),
+  } as const;
+
+  const services = {
+    title: t("services.title"),
+    description: t("services.description"),
+    steps: serviceStepIds.map((id) => ({
+      id,
+      label: t(`services.steps.${id}.label`),
+      description: t(`services.steps.${id}.description`),
+    })),
+    cards: serviceCardIds.map((id) => ({
+      id,
+      title: t(`services.cards.${id}.title`),
+      description: t(`services.cards.${id}.description`),
+    })),
+  } as const;
+
+  const outcomeAccentClasses = ["bg-sky-400", "bg-violet-400", "bg-emerald-400"] as const;
 
   return (
-    <div className="space-y-24 pb-24 text-slate-300">
+    <div className="space-y-24 pb-24 text-slate-700 dark:text-slate-300">
       <PageHero
-        eyebrow="Airnub builds governed, enterprise-ready developer platforms."
-        title="Operationalize trust across every release pipeline"
-        description="We help platform and security teams replace spreadsheets with codified guardrails, evidence automation, and developer-native workflows."
+        eyebrow={hero.eyebrow}
+        title={hero.title}
+        description={hero.description}
         actions={
           <>
             <Button asChild>
-              <LocaleLink href="/contact">Talk to our team</LocaleLink>
+              <LocaleLink href="/contact">{hero.primaryCta}</LocaleLink>
             </Button>
             <Button variant="ghost" asChild>
-              <LocaleLink href="/products">Explore products</LocaleLink>
+              <LocaleLink href="/products">{hero.secondaryCta}</LocaleLink>
             </Button>
           </>
         }
@@ -63,13 +127,13 @@ export default async function HomePage() {
 
       <section>
         <Container className="grid gap-10 lg:grid-cols-3">
-          {highlights.map((item) => (
+          {highlightItems.map((item) => (
             <div
-              key={item.title}
-              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40 backdrop-blur"
+              key={item.id}
+              className="rounded-3xl border border-slate-200 bg-white/80 p-8 shadow-lg shadow-slate-900/5 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/40"
             >
-              <h3 className="text-xl font-semibold text-white">{item.title}</h3>
-              <p className="mt-3 text-sm text-slate-300">{item.description}</p>
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{item.title}</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{item.description}</p>
             </div>
           ))}
         </Container>
@@ -77,12 +141,14 @@ export default async function HomePage() {
 
       <section>
         <Container className="text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-slate-400">Trusted by platform leaders</p>
+          <p className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {t("customers.eyebrow")}
+          </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-8">
-            {customers.map((customer) => (
+            {customerItems.map((customer) => (
               <div
-                key={customer.name}
-                className="flex h-16 w-40 items-center justify-center rounded-xl border border-slate-800 bg-slate-900/70 shadow-inner shadow-slate-950/40"
+                key={customer.id}
+                className="flex h-16 w-40 items-center justify-center rounded-xl border border-slate-200 bg-white/70 shadow-inner shadow-slate-900/5 dark:border-slate-800 dark:bg-slate-900/70 dark:shadow-slate-950/40"
               >
                 <Image src={customer.logo} alt={customer.name} width={120} height={40} className="object-contain" />
               </div>
@@ -92,38 +158,38 @@ export default async function HomePage() {
       </section>
 
       <section>
-        <Container className="grid gap-12 rounded-3xl border border-slate-800 bg-slate-900/80 p-12 shadow-xl shadow-slate-950/40 lg:grid-cols-2 lg:items-center">
+        <Container className="grid gap-12 rounded-3xl border border-slate-200 bg-white/80 p-12 shadow-xl shadow-slate-900/10 backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 dark:shadow-slate-950/40 lg:grid-cols-2 lg:items-center">
           <div>
-            <h2 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">Secure the spec loop with Speckit</h2>
-            <p className="mt-4 text-base text-slate-300">
-              Speckit brings change management, supply-chain controls, and runtime attestations together. Govern policy gates with programmable workflows and surface the right signals to auditors and stakeholders instantly.
-            </p>
+            <h2 className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-4xl">{speckit.title}</h2>
+            <p className="mt-4 text-base text-slate-600 dark:text-slate-300">{speckit.description}</p>
             <div className="mt-6 flex flex-wrap gap-4">
               <Button asChild>
                 <Link href="https://speckit.airnub.io" target="_blank" rel="noreferrer">
-                  Visit Speckit
+                  {speckit.primaryCta}
                 </Link>
               </Button>
               <Button variant="ghost" asChild>
-                <LocaleLink href="/products">See product lineup</LocaleLink>
+                <LocaleLink href="/products">{speckit.secondaryCta}</LocaleLink>
               </Button>
             </div>
           </div>
-          <div className="rounded-3xl border border-white/10 bg-white/5 p-8">
-            <h3 className="text-lg font-semibold text-white">Outcomes</h3>
-            <ul className="mt-4 space-y-3 text-sm text-slate-200">
-              <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-sky-400" aria-hidden="true" />
-                Governed spec loop keeps architecture, security, and compliance in sync.
-              </li>
-              <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-violet-400" aria-hidden="true" />
-                Policy gates codify approvals across CI/CD, cloud, and service catalogs.
-              </li>
-              <li className="flex gap-3">
-                <span className="mt-1 inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400" aria-hidden="true" />
-                Evidence captured automatically: SBOMs, attestations, and traceability.
-              </li>
+          <div className="rounded-3xl border border-slate-200 bg-white/70 p-8 dark:border-white/10 dark:bg-white/5">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{speckit.outcomesTitle}</h3>
+            <ul className="mt-4 space-y-3 text-sm text-slate-700 dark:text-slate-200">
+              {speckit.outcomes.map((outcome, index) => {
+                const accentClass = outcomeAccentClasses[
+                  Math.min(index, outcomeAccentClasses.length - 1)
+                ];
+                return (
+                  <li key={outcome.id} className="flex gap-3">
+                    <span
+                      className={`mt-1 inline-flex h-2.5 w-2.5 rounded-full ${accentClass}`}
+                      aria-hidden="true"
+                    />
+                    {outcome.copy}
+                  </li>
+                );
+              })}
             </ul>
           </div>
         </Container>
@@ -133,40 +199,28 @@ export default async function HomePage() {
         <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-center">
           <div className="space-y-6">
             <div>
-              <h2 className="text-3xl font-semibold text-white">Services aligned to your platform journey</h2>
-              <p className="mt-4 text-base text-slate-300">
-                From first landing zones to regulated scale, our services team embeds with platform, security, and compliance leaders to deliver quick wins and long-term maturity.
-              </p>
+              <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{services.title}</h2>
+              <p className="mt-4 text-base text-slate-600 dark:text-slate-300">{services.description}</p>
             </div>
-            <ul className="space-y-3 text-sm text-slate-300">
-              <li>
-                <strong className="font-semibold text-white">Assessment:</strong> map current controls to regulatory expectations.
-              </li>
-              <li>
-                <strong className="font-semibold text-white">Blueprint:</strong> reference architectures with guardrails for teams and services.
-              </li>
-              <li>
-                <strong className="font-semibold text-white">Adoption:</strong> playbooks to scale platform operations with confidence.
-              </li>
+            <ul className="space-y-3 text-sm text-slate-700 dark:text-slate-300">
+              {services.steps.map((step) => (
+                <li key={step.id}>
+                  <strong className="font-semibold text-slate-900 dark:text-white">{step.label}</strong>{" "}
+                  {step.description}
+                </li>
+              ))}
             </ul>
           </div>
           <div className="grid gap-6 md:grid-cols-2">
-            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
-              <h3 className="text-lg font-semibold text-white">Platform operating model</h3>
-              <p className="mt-2 text-sm text-slate-300">Team structures, KPIs, and governance rituals to align craft and compliance.</p>
-            </div>
-            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
-              <h3 className="text-lg font-semibold text-white">Regulated cloud acceleration</h3>
-              <p className="mt-2 text-sm text-slate-300">Deploy secure baselines for FedRAMP, SOC 2, and ISO 27001 without slowing delivery.</p>
-            </div>
-            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
-              <h3 className="text-lg font-semibold text-white">InnerSource enablement</h3>
-              <p className="mt-2 text-sm text-slate-300">Empower product teams with paved roads, golden paths, and clear guardrails.</p>
-            </div>
-            <div className="rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
-              <h3 className="text-lg font-semibold text-white">Trust & assurance readiness</h3>
-              <p className="mt-2 text-sm text-slate-300">Prepare evidence for auditors, partners, and leadership with zero scramble.</p>
-            </div>
+            {services.cards.map((card) => (
+              <div
+                key={card.id}
+                className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-900/10 dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/40"
+              >
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{card.title}</h3>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{card.description}</p>
+              </div>
+            ))}
           </div>
         </Container>
       </section>

--- a/apps/airnub/components/PageHero.tsx
+++ b/apps/airnub/components/PageHero.tsx
@@ -18,20 +18,20 @@ export function PageHero({
   return (
     <section
       className={clsx(
-        "relative overflow-hidden border-b border-slate-800 bg-slate-950 py-16 text-slate-100",
+        "relative overflow-hidden border-b border-slate-200 bg-slate-50 py-16 text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100",
         className,
       )}
     >
       <div
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15)_0,_rgba(15,23,42,0)_55%)]"
+        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.15)_0,_rgba(248,250,252,0)_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15)_0,_rgba(15,23,42,0)_55%)]"
         aria-hidden="true"
       />
       <Container className="max-w-4xl">
         {eyebrow ? (
-          <p className="text-sm font-semibold uppercase tracking-wide text-sky-400/80">{eyebrow}</p>
+          <p className="text-sm font-semibold uppercase tracking-wide text-sky-600 dark:text-sky-400/80">{eyebrow}</p>
         ) : null}
-        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-white sm:text-5xl">{title}</h1>
-        {description ? <p className="mt-6 text-lg text-slate-300">{description}</p> : null}
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-5xl">{title}</h1>
+        {description ? <p className="mt-6 text-lg text-slate-600 dark:text-slate-300">{description}</p> : null}
         {actions ? <div className="mt-8 flex flex-wrap gap-4">{actions}</div> : null}
       </Container>
     </section>

--- a/apps/airnub/messages/de.json
+++ b/apps/airnub/messages/de.json
@@ -45,6 +45,87 @@
     "company": "Unternehmen",
     "contact": "Kontakt"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Airnub entwickelt gesteuerte, unternehmensreife Entwicklerplattformen.",
+      "title": "Operationalisieren Sie Vertrauen in jeder Release-Pipeline",
+      "description": "Wir helfen Plattform- und Sicherheitsteams, Tabellen durch codifizierte Leitplanken, Evidence-Automatisierung und entwicklernahe Workflows zu ersetzen.",
+      "primaryCta": "Mit unserem Team sprechen",
+      "secondaryCta": "Produkte entdecken"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Vereinheitlichte Governance",
+        "description": "Automatisieren Sie Richtlinienprüfungen über SDLC-Gates hinweg mit kontextbezogenen Leitplanken für jedes Team."
+      },
+      "evidenceOnDemand": {
+        "title": "Nachweise auf Abruf",
+        "description": "Erfassen Sie SBOMs, Bescheinigungen und Nachvollziehbarkeitsartefakte direkt im Auslieferungsworkflow."
+      },
+      "platformAccelerators": {
+        "title": "Plattform-Beschleuniger",
+        "description": "Blueprints, mit denen Plattformteams Produkte schneller und dennoch vertrauenswürdig onboarden."
+      }
+    },
+    "customers": {
+      "eyebrow": "Vertraut von führenden Plattformteams",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Sichern Sie den Spec-Loop mit Speckit",
+      "description": "Speckit vereint Change-Management, Lieferketten-Kontrollen und Laufzeit-Attestierungen. Steuern Sie Policy-Gates mit programmierbaren Workflows und liefern Sie Auditor:innen sowie Stakeholdern sofort die richtigen Nachweise.",
+      "primaryCta": "Speckit besuchen",
+      "secondaryCta": "Produktangebot ansehen",
+      "outcomes": {
+        "title": "Ergebnisse",
+        "items": {
+          "governedSpecLoop": "Ein gesteuerter Spec-Loop hält Architektur, Sicherheit und Compliance im Einklang.",
+          "policyGates": "Policy-Gates kodifizieren Freigaben über CI/CD, Cloud und Servicekataloge hinweg.",
+          "automatedEvidence": "Nachweise werden automatisch erfasst: SBOMs, Attestierungen und Rückverfolgbarkeit."
+        }
+      }
+    },
+    "services": {
+      "title": "Services für jede Phase Ihrer Plattformreise",
+      "description": "Vom ersten Landing-Zone-Konzept bis zur regulierten Skalierung begleitet unser Serviceteam Plattform-, Sicherheits- und Compliance-Führungskräfte mit schnellen Erfolgen und nachhaltiger Reife.",
+      "steps": {
+        "assessment": {
+          "label": "Bewertung:",
+          "description": "aktuelle Kontrollen regulatorischen Erwartungen zuordnen."
+        },
+        "blueprint": {
+          "label": "Blueprint:",
+          "description": "Referenzarchitekturen mit Leitplanken für Teams und Services bereitstellen."
+        },
+        "adoption": {
+          "label": "Adoption:",
+          "description": "Playbooks, um Plattformoperationen mit Zuversicht zu skalieren."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Plattform-Betriebsmodell",
+          "description": "Teamstrukturen, KPIs und Governance-Routinen, die Handwerk und Compliance verbinden."
+        },
+        "regulatedCloud": {
+          "title": "Beschleunigung regulierter Clouds",
+          "description": "Sichere Baselines für FedRAMP, SOC 2 und ISO 27001 bereitstellen, ohne die Lieferung zu verlangsamen."
+        },
+        "innerSource": {
+          "title": "InnerSource-Einführung",
+          "description": "Produktteams mit Paved Roads, Golden Paths und klaren Leitplanken befähigen."
+        },
+        "trustReadiness": {
+          "title": "Trust- & Assurance-Bereitschaft",
+          "description": "Nachweise für Auditor:innen, Partner und Führungskräfte ohne Hektik vorbereiten."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Kontakt",

--- a/apps/airnub/messages/en-GB.json
+++ b/apps/airnub/messages/en-GB.json
@@ -45,6 +45,87 @@
     "company": "Company",
     "contact": "Contact"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Airnub builds governed, enterprise-ready developer platforms.",
+      "title": "Operationalise trust across every release pipeline",
+      "description": "We help platform and security teams replace spreadsheets with codified guardrails, evidence automation, and developer-native workflows.",
+      "primaryCta": "Talk to our team",
+      "secondaryCta": "Explore products"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Unified governance",
+        "description": "Automate policy checks across SDLC gates with contextual guardrails for every team."
+      },
+      "evidenceOnDemand": {
+        "title": "Evidence on demand",
+        "description": "Capture SBOMs, attestations, and traceability artefacts as part of your delivery workflow."
+      },
+      "platformAccelerators": {
+        "title": "Platform accelerators",
+        "description": "Blueprints for platform teams to onboard products faster without sacrificing trust or velocity."
+      }
+    },
+    "customers": {
+      "eyebrow": "Trusted by platform leaders",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Secure the spec loop with Speckit",
+      "description": "Speckit brings change management, supply-chain controls, and runtime attestations together. Govern policy gates with programmable workflows and surface the right signals to auditors and stakeholders instantly.",
+      "primaryCta": "Visit Speckit",
+      "secondaryCta": "See product lineup",
+      "outcomes": {
+        "title": "Outcomes",
+        "items": {
+          "governedSpecLoop": "Governed spec loop keeps architecture, security, and compliance in sync.",
+          "policyGates": "Policy gates codify approvals across CI/CD, cloud, and service catalogues.",
+          "automatedEvidence": "Evidence captured automatically: SBOMs, attestations, and traceability."
+        }
+      }
+    },
+    "services": {
+      "title": "Services aligned to your platform journey",
+      "description": "From first landing zones to regulated scale, our services team embeds with platform, security, and compliance leaders to deliver quick wins and long-term maturity.",
+      "steps": {
+        "assessment": {
+          "label": "Assessment:",
+          "description": "map current controls to regulatory expectations."
+        },
+        "blueprint": {
+          "label": "Blueprint:",
+          "description": "reference architectures with guardrails for teams and services."
+        },
+        "adoption": {
+          "label": "Adoption:",
+          "description": "playbooks to scale platform operations with confidence."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Platform operating model",
+          "description": "Team structures, KPIs, and governance rituals to align craft and compliance."
+        },
+        "regulatedCloud": {
+          "title": "Regulated cloud acceleration",
+          "description": "Deploy secure baselines for FedRAMP, SOC 2, and ISO 27001 without slowing delivery."
+        },
+        "innerSource": {
+          "title": "InnerSource enablement",
+          "description": "Empower product teams with paved roads, golden paths, and clear guardrails."
+        },
+        "trustReadiness": {
+          "title": "Trust & assurance readiness",
+          "description": "Prepare evidence for auditors, partners, and leadership with zero scramble."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Contact",

--- a/apps/airnub/messages/en-US.json
+++ b/apps/airnub/messages/en-US.json
@@ -45,6 +45,87 @@
     "company": "Company",
     "contact": "Contact"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Airnub builds governed, enterprise-ready developer platforms.",
+      "title": "Operationalize trust across every release pipeline",
+      "description": "We help platform and security teams replace spreadsheets with codified guardrails, evidence automation, and developer-native workflows.",
+      "primaryCta": "Talk to our team",
+      "secondaryCta": "Explore products"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Unified governance",
+        "description": "Automate policy checks across SDLC gates with contextual guardrails for every team."
+      },
+      "evidenceOnDemand": {
+        "title": "Evidence on demand",
+        "description": "Capture SBOMs, attestations, and traceability artifacts as part of your delivery workflow."
+      },
+      "platformAccelerators": {
+        "title": "Platform accelerators",
+        "description": "Blueprints for platform teams to onboard products faster without sacrificing trust or velocity."
+      }
+    },
+    "customers": {
+      "eyebrow": "Trusted by platform leaders",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Secure the spec loop with Speckit",
+      "description": "Speckit brings change management, supply-chain controls, and runtime attestations together. Govern policy gates with programmable workflows and surface the right signals to auditors and stakeholders instantly.",
+      "primaryCta": "Visit Speckit",
+      "secondaryCta": "See product lineup",
+      "outcomes": {
+        "title": "Outcomes",
+        "items": {
+          "governedSpecLoop": "Governed spec loop keeps architecture, security, and compliance in sync.",
+          "policyGates": "Policy gates codify approvals across CI/CD, cloud, and service catalogs.",
+          "automatedEvidence": "Evidence captured automatically: SBOMs, attestations, and traceability."
+        }
+      }
+    },
+    "services": {
+      "title": "Services aligned to your platform journey",
+      "description": "From first landing zones to regulated scale, our services team embeds with platform, security, and compliance leaders to deliver quick wins and long-term maturity.",
+      "steps": {
+        "assessment": {
+          "label": "Assessment:",
+          "description": "map current controls to regulatory expectations."
+        },
+        "blueprint": {
+          "label": "Blueprint:",
+          "description": "reference architectures with guardrails for teams and services."
+        },
+        "adoption": {
+          "label": "Adoption:",
+          "description": "playbooks to scale platform operations with confidence."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Platform operating model",
+          "description": "Team structures, KPIs, and governance rituals to align craft and compliance."
+        },
+        "regulatedCloud": {
+          "title": "Regulated cloud acceleration",
+          "description": "Deploy secure baselines for FedRAMP, SOC 2, and ISO 27001 without slowing delivery."
+        },
+        "innerSource": {
+          "title": "InnerSource enablement",
+          "description": "Empower product teams with paved roads, golden paths, and clear guardrails."
+        },
+        "trustReadiness": {
+          "title": "Trust & assurance readiness",
+          "description": "Prepare evidence for auditors, partners, and leadership with zero scramble."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Contact",

--- a/apps/airnub/messages/es.json
+++ b/apps/airnub/messages/es.json
@@ -45,6 +45,87 @@
     "company": "Empresa",
     "contact": "Contacto"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Airnub crea plataformas de desarrolladores gobernadas y listas para la empresa.",
+      "title": "Operativiza la confianza en cada canal de lanzamiento",
+      "description": "Ayudamos a los equipos de plataforma y seguridad a reemplazar hojas de cálculo por barandillas codificadas, automatización de evidencias y flujos de trabajo nativos para desarrolladores.",
+      "primaryCta": "Habla con nuestro equipo",
+      "secondaryCta": "Explorar productos"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Gobernanza unificada",
+        "description": "Automatiza las comprobaciones de políticas en las etapas del SDLC con barandillas contextuales para cada equipo."
+      },
+      "evidenceOnDemand": {
+        "title": "Evidencia bajo demanda",
+        "description": "Captura SBOM, atestaciones y artefactos de trazabilidad dentro de tu flujo de entrega."
+      },
+      "platformAccelerators": {
+        "title": "Aceleradores de plataforma",
+        "description": "Planos para que los equipos de plataforma incorporen productos más rápido sin sacrificar confianza ni velocidad."
+      }
+    },
+    "customers": {
+      "eyebrow": "Confiado por líderes de plataforma",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Asegura el ciclo de especificaciones con Speckit",
+      "description": "Speckit reúne la gestión de cambios, los controles de la cadena de suministro y las atestaciones en ejecución. Gobierna los puntos de control con flujos de trabajo programables y entrega de inmediato las señales adecuadas a auditores y partes interesadas.",
+      "primaryCta": "Visitar Speckit",
+      "secondaryCta": "Ver catálogo de productos",
+      "outcomes": {
+        "title": "Resultados",
+        "items": {
+          "governedSpecLoop": "Un ciclo de especificaciones gobernado mantiene alineadas arquitectura, seguridad y cumplimiento.",
+          "policyGates": "Los puntos de control codifican aprobaciones en CI/CD, la nube y los catálogos de servicios.",
+          "automatedEvidence": "La evidencia se captura automáticamente: SBOM, atestaciones y trazabilidad."
+        }
+      }
+    },
+    "services": {
+      "title": "Servicios alineados con tu viaje de plataforma",
+      "description": "Desde las primeras landing zones hasta la escala regulada, nuestro equipo se integra con líderes de plataforma, seguridad y cumplimiento para lograr victorias rápidas y madurez sostenible.",
+      "steps": {
+        "assessment": {
+          "label": "Evaluación:",
+          "description": "mapear los controles actuales con las expectativas regulatorias."
+        },
+        "blueprint": {
+          "label": "Plano:",
+          "description": "ofrecer arquitecturas de referencia con barandillas para equipos y servicios."
+        },
+        "adoption": {
+          "label": "Adopción:",
+          "description": "guías para escalar las operaciones de plataforma con confianza."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Modelo operativo de plataforma",
+          "description": "Estructuras de equipo, KPI y rituales de gobernanza que alinean ejecución y cumplimiento."
+        },
+        "regulatedCloud": {
+          "title": "Aceleración de nubes reguladas",
+          "description": "Implementa bases seguras para FedRAMP, SOC 2 e ISO 27001 sin frenar la entrega."
+        },
+        "innerSource": {
+          "title": "Impulso a InnerSource",
+          "description": "Empodera a los equipos de producto con caminos pavimentados, rutas doradas y barandillas claras."
+        },
+        "trustReadiness": {
+          "title": "Preparación de confianza y aseguramiento",
+          "description": "Prepara evidencia para auditores, socios y liderazgo sin contratiempos."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Contacto",

--- a/apps/airnub/messages/fr.json
+++ b/apps/airnub/messages/fr.json
@@ -45,6 +45,87 @@
     "company": "Entreprise",
     "contact": "Contact"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Airnub conçoit des plateformes développeurs gouvernées et prêtes pour l'entreprise.",
+      "title": "Opérationnalisez la confiance sur chaque pipeline de livraison",
+      "description": "Nous aidons les équipes plateforme et sécurité à remplacer les tableurs par des garde-fous codifiés, une automatisation des preuves et des workflows natifs pour les développeurs.",
+      "primaryCta": "Parler avec notre équipe",
+      "secondaryCta": "Explorer les produits"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Gouvernance unifiée",
+        "description": "Automatisez les contrôles de politiques à chaque étape du SDLC avec des garde-fous contextuels pour chaque équipe."
+      },
+      "evidenceOnDemand": {
+        "title": "Preuves à la demande",
+        "description": "Capturez SBOM, attestations et artefacts de traçabilité dans votre flux de livraison."
+      },
+      "platformAccelerators": {
+        "title": "Accélérateurs de plateforme",
+        "description": "Plans de référence pour permettre aux équipes plateforme d'intégrer plus vite des produits sans sacrifier la confiance ni la vélocité."
+      }
+    },
+    "customers": {
+      "eyebrow": "Plébiscité par les leaders plateforme",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Sécurisez la boucle des specs avec Speckit",
+      "description": "Speckit réunit gestion du changement, contrôles supply-chain et attestations runtime. Gouvernez les points de contrôle avec des workflows programmables et fournissez instantanément les bons signaux aux auditeurs et parties prenantes.",
+      "primaryCta": "Visiter Speckit",
+      "secondaryCta": "Voir l'offre produits",
+      "outcomes": {
+        "title": "Résultats",
+        "items": {
+          "governedSpecLoop": "Une boucle de specs gouvernée maintient architecture, sécurité et conformité alignées.",
+          "policyGates": "Les points de contrôle codifient les validations à travers CI/CD, le cloud et les catalogues de services.",
+          "automatedEvidence": "Les preuves sont capturées automatiquement : SBOM, attestations et traçabilité."
+        }
+      }
+    },
+    "services": {
+      "title": "Des services alignés sur votre parcours plateforme",
+      "description": "Des premières landing zones jusqu'à la montée en charge réglementée, notre équipe accompagne les responsables plateforme, sécurité et conformité pour livrer des gains rapides et une maturité durable.",
+      "steps": {
+        "assessment": {
+          "label": "Évaluation :",
+          "description": "cartographier les contrôles actuels aux exigences réglementaires."
+        },
+        "blueprint": {
+          "label": "Blueprint :",
+          "description": "proposer des architectures de référence avec des garde-fous pour équipes et services."
+        },
+        "adoption": {
+          "label": "Adoption :",
+          "description": "playbooks pour faire évoluer les opérations plateforme en toute confiance."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Modèle opérationnel de plateforme",
+          "description": "Structures d'équipe, KPI et rituels de gouvernance pour aligner excellence technique et conformité."
+        },
+        "regulatedCloud": {
+          "title": "Accélération cloud réglementé",
+          "description": "Déployer des bases sécurisées pour FedRAMP, SOC 2 et ISO 27001 sans ralentir la livraison."
+        },
+        "innerSource": {
+          "title": "Activation InnerSource",
+          "description": "Donnez aux équipes produit des voies aménagées, des parcours dorés et des garde-fous clairs."
+        },
+        "trustReadiness": {
+          "title": "Préparation confiance & assurance",
+          "description": "Préparez des preuves pour auditeurs, partenaires et direction sans urgence inutile."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Contact",

--- a/apps/airnub/messages/ga.json
+++ b/apps/airnub/messages/ga.json
@@ -45,6 +45,87 @@
     "company": "Cuideachta",
     "contact": "Teagmháil"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Tógann Airnub ardáin forbróirí rialaithe atá réidh don fhiontar.",
+      "title": "Cuir muinín i bhfeidhm ar gach píblíne eisiúna",
+      "description": "Cuidímid le foirne ardáin agus slándála bileoga oibre a athrú go cosaintí códaithe, uathoibriú fianaise agus sreafaí oibre dúchasacha d'fhorbróirí.",
+      "primaryCta": "Labhair lenár bhfoireann",
+      "secondaryCta": "Fiosraigh na táirgí"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Rialachas aontaithe",
+        "description": "Uathoibrigh seiceálacha polasaí trasna chéimeanna an SDLC le cosaintí comhthéacsúla do gach foireann."
+      },
+      "evidenceOnDemand": {
+        "title": "Fianaise ar éileamh",
+        "description": "Bailigh SBOManna, dearbhuithe agus déantáin inrianaitheachta mar chuid de do shreabhadh seachadta."
+      },
+      "platformAccelerators": {
+        "title": "Luasairí ardáin",
+        "description": "Pleananna treoracha chun táirgí nua a thabhairt isteach níos tapúla gan muinín ná luas a chailleadh."
+      }
+    },
+    "customers": {
+      "eyebrow": "Muintear ag ceannairí ardáin",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Daingnigh lúb na sonraíochta le Speckit",
+      "description": "Tugann Speckit bainistíocht athraithe, rialuithe slabhra soláthair agus dearbhuithe ama reatha le chéile. Rialú geataí polasaí le sreafaí oibre in-ríomhchláraithe agus soláthair na comharthaí cearta d'iniúchóirí agus do pháirtithe leasmhara láithreach.",
+      "primaryCta": "Tabhair cuairt ar Speckit",
+      "secondaryCta": "Féach ar líne táirgí",
+      "outcomes": {
+        "title": "Torthaí",
+        "items": {
+          "governedSpecLoop": "Coinníonn lúb sonraíochta rialaithe ailtireacht, slándáil agus comhlíonadh ar aon dul.",
+          "policyGates": "Códálann geataí polasaí ceaduithe trasna CI/CD, na néalaí agus catalóga seirbhíse.",
+          "automatedEvidence": "Bailítear an fhianaise go huathoibríoch: SBOManna, dearbhuithe agus inrianaitheacht."
+        }
+      }
+    },
+    "services": {
+      "title": "Seirbhísí ailínithe le do thuras ardáin",
+      "description": "Ó chéad chriosanna tuirlingthe go scála rialáilte, oibríonn ár bhfoireann le ceannairí ardáin, slándála agus comhlíonta chun buaiteoirí tapa agus aibíocht fadtéarmach a sholáthar.",
+      "steps": {
+        "assessment": {
+          "label": "Measúnú:",
+          "description": "mapáil na rialuithe reatha le hionchais rialála."
+        },
+        "blueprint": {
+          "label": "Blaupriont:",
+          "description": "ailtireachtaí tagartha a thabhairt le cosaintí do fhoirne agus do sheirbhísí."
+        },
+        "adoption": {
+          "label": "Glacadh:",
+          "description": "leabhair súgartha chun oibríochtaí ardáin a scálú le muinín."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Múnla oibriúcháin ardáin",
+          "description": "Struchtúir foirne, KPIanna agus deasghnátha rialachais chun ceird agus comhlíonadh a ailíniú."
+        },
+        "regulatedCloud": {
+          "title": "Luasghéarú néal rialáilte",
+          "description": "Cuir bonnslacha slána i bhfeidhm do FedRAMP, SOC 2 agus ISO 27001 gan seachadadh a mhoilliú."
+        },
+        "innerSource": {
+          "title": "Cumhachtú InnerSource",
+          "description": "Cumasaigh foirne táirge le bóithre pábháilte, cosáin órga agus cosaintí soiléire."
+        },
+        "trustReadiness": {
+          "title": "Ullmhacht iontaobhais & dearbhaithe",
+          "description": "Ullmhaigh fianaise d'iniúchóirí, do chomhpháirtithe agus don cheannaireacht gan aon scuaine phráinneach."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Teagmháil",

--- a/apps/airnub/messages/it.json
+++ b/apps/airnub/messages/it.json
@@ -45,6 +45,87 @@
     "company": "Azienda",
     "contact": "Contatti"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "Airnub crea piattaforme per sviluppatori governate e pronte per l'azienda.",
+      "title": "Operationalizza la fiducia in ogni pipeline di rilascio",
+      "description": "Aiutiamo i team di piattaforma e sicurezza a sostituire i fogli di calcolo con guardrail codificati, automazione delle evidenze e workflow nativi per gli sviluppatori.",
+      "primaryCta": "Parla con il nostro team",
+      "secondaryCta": "Esplora i prodotti"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Governance unificata",
+        "description": "Automatizza i controlli di policy in ogni fase del SDLC con guardrail contestuali per ogni team."
+      },
+      "evidenceOnDemand": {
+        "title": "Evidenza on demand",
+        "description": "Acquisisci SBOM, attestazioni e artefatti di tracciabilità all'interno del flusso di delivery."
+      },
+      "platformAccelerators": {
+        "title": "Acceleratori di piattaforma",
+        "description": "Blueprint per permettere ai team di piattaforma di avviare prodotti più rapidamente senza rinunciare a fiducia e velocità."
+      }
+    },
+    "customers": {
+      "eyebrow": "Scelto dai leader di piattaforma",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Proteggi il ciclo delle specifiche con Speckit",
+      "description": "Speckit riunisce gestione del cambiamento, controlli della supply chain e attestazioni runtime. Governa i gate di policy con workflow programmabili e fornisci subito i segnali giusti ad auditor e stakeholder.",
+      "primaryCta": "Visita Speckit",
+      "secondaryCta": "Vedi l'offerta prodotti",
+      "outcomes": {
+        "title": "Risultati",
+        "items": {
+          "governedSpecLoop": "Un ciclo delle specifiche governato mantiene allineate architettura, sicurezza e conformità.",
+          "policyGates": "I gate di policy codificano le approvazioni attraverso CI/CD, cloud e cataloghi di servizi.",
+          "automatedEvidence": "Le evidenze vengono raccolte automaticamente: SBOM, attestazioni e tracciabilità."
+        }
+      }
+    },
+    "services": {
+      "title": "Servizi allineati al tuo percorso di piattaforma",
+      "description": "Dalle prime landing zone alla scala regolamentata, il nostro team affianca i leader di piattaforma, sicurezza e compliance per ottenere vittorie rapide e maturità nel lungo termine.",
+      "steps": {
+        "assessment": {
+          "label": "Assessment:",
+          "description": "mappare i controlli attuali alle aspettative normative."
+        },
+        "blueprint": {
+          "label": "Blueprint:",
+          "description": "fornire architetture di riferimento con guardrail per team e servizi."
+        },
+        "adoption": {
+          "label": "Adoption:",
+          "description": "playbook per scalare le operazioni di piattaforma con sicurezza."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Modello operativo di piattaforma",
+          "description": "Strutture di team, KPI e rituali di governance che allineano eccellenza tecnica e conformità."
+        },
+        "regulatedCloud": {
+          "title": "Accelerazione cloud regolamentato",
+          "description": "Distribuisci baseline sicure per FedRAMP, SOC 2 e ISO 27001 senza rallentare la delivery."
+        },
+        "innerSource": {
+          "title": "Abilitazione InnerSource",
+          "description": "Offri ai team di prodotto percorsi pavimentati, golden path e guardrail chiari."
+        },
+        "trustReadiness": {
+          "title": "Preparazione a fiducia e assurance",
+          "description": "Prepara le evidenze per auditor, partner e leadership senza corse all'ultimo minuto."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Contatti",

--- a/apps/airnub/messages/pt.json
+++ b/apps/airnub/messages/pt.json
@@ -45,6 +45,87 @@
     "company": "Empresa",
     "contact": "Contacto"
   },
+  "home": {
+    "hero": {
+      "eyebrow": "A Airnub cria plataformas governadas e prontas para empresas.",
+      "title": "Operacionalize a confiança em cada pipeline de lançamento",
+      "description": "Ajudamos as equipas de plataforma e segurança a substituir folhas de cálculo por guardrails codificados, automação de evidências e fluxos de trabalho nativos para developers.",
+      "primaryCta": "Fale com a nossa equipa",
+      "secondaryCta": "Explorar produtos"
+    },
+    "highlights": {
+      "unifiedGovernance": {
+        "title": "Governança unificada",
+        "description": "Automatize verificações de políticas em todas as fases do SDLC com guardrails contextuais para cada equipa."
+      },
+      "evidenceOnDemand": {
+        "title": "Evidência sob pedido",
+        "description": "Capture SBOM, atestações e artefactos de rastreabilidade dentro do fluxo de entrega."
+      },
+      "platformAccelerators": {
+        "title": "Aceleradores de plataforma",
+        "description": "Blueprints para que as equipas de plataforma lancem produtos mais rápido sem perder confiança nem velocidade."
+      }
+    },
+    "customers": {
+      "eyebrow": "Confiado por líderes de plataforma",
+      "items": {
+        "forgeLabs": "Forge Labs",
+        "cloudyard": "Cloudyard",
+        "northbeam": "Northbeam"
+      }
+    },
+    "speckit": {
+      "title": "Proteja o ciclo de especificações com a Speckit",
+      "description": "A Speckit reúne gestão de mudança, controlos da cadeia de fornecimento e atestações em runtime. Governe os checkpoints com workflows programáveis e entregue rapidamente os sinais certos a auditores e stakeholders.",
+      "primaryCta": "Visitar Speckit",
+      "secondaryCta": "Ver portefólio de produtos",
+      "outcomes": {
+        "title": "Resultados",
+        "items": {
+          "governedSpecLoop": "Um ciclo de especificações governado mantém arquitetura, segurança e compliance alinhadas.",
+          "policyGates": "Os checkpoints codificam aprovações em CI/CD, na cloud e em catálogos de serviços.",
+          "automatedEvidence": "A evidência é capturada automaticamente: SBOM, atestações e rastreabilidade."
+        }
+      }
+    },
+    "services": {
+      "title": "Serviços alinhados à sua jornada de plataforma",
+      "description": "Das primeiras landing zones à escala regulada, a nossa equipa acompanha líderes de plataforma, segurança e compliance para garantir vitórias rápidas e maturidade sustentável.",
+      "steps": {
+        "assessment": {
+          "label": "Avaliação:",
+          "description": "mapear os controlos atuais para as exigências regulamentares."
+        },
+        "blueprint": {
+          "label": "Blueprint:",
+          "description": "fornecer arquiteturas de referência com guardrails para equipas e serviços."
+        },
+        "adoption": {
+          "label": "Adoção:",
+          "description": "playbooks para escalar operações de plataforma com confiança."
+        }
+      },
+      "cards": {
+        "operatingModel": {
+          "title": "Modelo operacional de plataforma",
+          "description": "Estruturas de equipa, KPI e rituais de governança que alinham execução e conformidade."
+        },
+        "regulatedCloud": {
+          "title": "Aceleração de cloud regulada",
+          "description": "Implemente bases seguras para FedRAMP, SOC 2 e ISO 27001 sem atrasar a entrega."
+        },
+        "innerSource": {
+          "title": "Capacitação de InnerSource",
+          "description": "Dê às equipas de produto caminhos pavimentados, percursos dourados e guardrails claros."
+        },
+        "trustReadiness": {
+          "title": "Preparação para confiança e assurance",
+          "description": "Prepare evidências para auditores, parceiros e liderança sem correrias."
+        }
+      }
+    }
+  },
   "contact": {
     "metadata": {
       "title": "Contacto",

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
-import { FooterSpeckit, HeaderSpeckit } from "@airnub/ui";
+import { FooterSpeckit, HeaderSpeckit, ThemeProvider } from "@airnub/ui";
 import { JsonLd } from "../components/JsonLd";
 import { buildSpeckitSoftwareJsonLd } from "../lib/jsonld";
 import { SPECKIT_BASE_URL } from "../lib/routes";
+import { LanguageSwitcher } from "../components/LanguageSwitcher";
 
 const jsonLd = buildSpeckitSoftwareJsonLd();
 
@@ -47,19 +48,29 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="font-sans antialiased dark" suppressHydrationWarning>
+    <html
+      lang="en-US"
+      className="font-sans antialiased"
+      suppressHydrationWarning
+      data-scroll-behavior="smooth"
+    >
       <head>
         <JsonLd data={jsonLd} />
       </head>
-      <body className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
-        <a href="#content" className="skip-link">
-          Skip to content
-        </a>
-        <HeaderSpeckit />
-        <main id="content" className="flex-1">
-          {children}
-        </main>
-        <FooterSpeckit />
+      <body className="flex min-h-screen flex-col bg-white text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-100">
+        <ThemeProvider>
+          <a href="#content" className="skip-link">
+            Skip to content
+          </a>
+          <HeaderSpeckit
+            themeToggleLabel="Toggle theme"
+            additionalRightSlot={<LanguageSwitcher />}
+          />
+          <main id="content" className="flex-1">
+            {children}
+          </main>
+          <FooterSpeckit />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/speckit/components/LanguageSwitcher.tsx
+++ b/apps/speckit/components/LanguageSwitcher.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState, type ChangeEvent } from "react";
+import { clsx } from "clsx";
+
+const SUPPORTED_LANGUAGES = [
+  "en-US",
+  "en-GB",
+  "fr",
+  "es",
+  "de",
+  "pt",
+  "it",
+  "ga",
+] as const;
+
+type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+const LANGUAGE_LABELS: Record<SupportedLanguage, string> = {
+  "en-US": "English (US)",
+  "en-GB": "English (UK)",
+  fr: "Français",
+  es: "Español",
+  de: "Deutsch",
+  pt: "Português",
+  it: "Italiano",
+  ga: "Gaeilge",
+};
+
+const STORAGE_KEY = "speckit.language";
+
+export function LanguageSwitcher({ className }: { className?: string }) {
+  const [language, setLanguage] = useState<SupportedLanguage>("en-US");
+
+  useEffect(() => {
+    const saved = typeof window !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    if (saved && SUPPORTED_LANGUAGES.includes(saved as SupportedLanguage)) {
+      setLanguage(saved as SupportedLanguage);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = language;
+    }
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, language);
+    }
+  }, [language]);
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setLanguage(event.target.value as SupportedLanguage);
+  };
+
+  return (
+    <div className={clsx("relative inline-flex", className)}>
+      <label htmlFor="speckit-language-switcher" className="sr-only">
+        Language
+      </label>
+      <select
+        id="speckit-language-switcher"
+        name="language"
+        value={language}
+        onChange={handleChange}
+        className="appearance-none rounded-full border border-slate-200 bg-white px-3 py-2 pr-8 text-sm font-medium text-slate-700 transition hover:border-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-600"
+      >
+        {SUPPORTED_LANGUAGES.map((code) => (
+          <option key={code} value={code}>
+            {LANGUAGE_LABELS[code]}
+          </option>
+        ))}
+      </select>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-500 dark:text-slate-400"
+        viewBox="0 0 12 8"
+      >
+        <path d="M1.41.59 6 5.17l4.59-4.58L12 2l-6 6-6-6z" fill="currentColor" />
+      </svg>
+    </div>
+  );
+}

--- a/packages/ui/src/HeaderSpeckit.tsx
+++ b/packages/ui/src/HeaderSpeckit.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { SpeckitWordmark } from "@airnub/brand";
 import { Header, type HeaderProps, type NavItem } from "./components/client/Header";
+import { ThemeToggle } from "./components/client/ThemeToggle";
 import type { ReactNode } from "react";
 
 const navItems: NavItem[] = [
@@ -50,6 +51,7 @@ type HeaderSpeckitProps = Omit<HeaderProps, "logo" | "navItems" | "rightSlot" | 
   githubHref?: string;
   starHref?: string;
   starLabel?: string;
+  themeToggleLabel?: string;
 };
 
 export function HeaderSpeckit({
@@ -58,6 +60,7 @@ export function HeaderSpeckit({
   githubHref = "https://github.com/airnub/speckit",
   starHref = "https://github.com/airnub/speckit",
   starLabel = "Star project",
+  themeToggleLabel = "Toggle theme",
   ...props
 }: HeaderSpeckitProps) {
   return (
@@ -66,10 +69,10 @@ export function HeaderSpeckit({
       navItems={navItems}
       homeAriaLabel={homeAriaLabel}
       rightSlot={
-        <div className="hidden items-center gap-3 lg:flex">
+        <div className="flex items-center gap-3">
           <Link
             href={githubHref}
-            className="rounded-full border border-white/10 p-2 text-slate-100 transition hover:text-indigo-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400"
+            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-white/10 dark:text-slate-200 dark:hover:text-white lg:inline-flex"
             aria-label="Speckit on GitHub"
             target="_blank"
             rel="noreferrer"
@@ -78,12 +81,13 @@ export function HeaderSpeckit({
           </Link>
           <Link
             href={starHref}
-            className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90"
+            className="hidden items-center gap-2 rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90 lg:inline-flex"
             target="_blank"
             rel="noreferrer"
           >
             <StarIcon className="h-4 w-4" /> {starLabel}
           </Link>
+          <ThemeToggle className="inline-flex" label={themeToggleLabel} />
           {additionalRightSlot}
         </div>
       }


### PR DESCRIPTION
## Summary
- internationalize the Airnub home page so hero, highlights, customer, and services copy pull from locale-specific message files and respect light/dark themes
- refresh the shared PageHero styling to support both light and dark backgrounds and add localized home strings for every supported language
- add theme and language controls to the Speckit layout by introducing a client language switcher, wiring HeaderSpeckit to the ThemeToggle, and wrapping the app in the shared ThemeProvider

## Testing
- `pnpm lint` *(fails: Next.js lint step cannot resolve the optional next-intl plugin under the repository's locked Node version)*

------
https://chatgpt.com/codex/tasks/task_e_68d97e1d671c8324a669d854d8b23103