### PR TITLE
ci: harden workflows and deploy docs

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,12 +1,25 @@
 name: a11y
-on: [pull_request]
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   a11y:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
       - uses: pnpm/action-setup@v4
-      - run: pnpm i -w
+        with:
+          version: 10.17.1
+          run_install: false
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Run pa11y-ci (targets defined per app)
         run: pnpm a11y

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,27 @@
 name: ci
+
 on:
   push:
     branches: [main]
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - run: pnpm i -w
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+          run_install: false
+      - run: pnpm install --frozen-lockfile
       - name: Commitlint (PR commits)
         if: github.event_name == 'pull_request'
         uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,83 @@
+name: deploy-docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/deploy-docs.yml'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'package.json'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    if: ${{ hashFiles('docs/package.json') != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
+          run_install: false
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install docs dependencies (with lockfile)
+        if: ${{ hashFiles('docs/pnpm-lock.yaml') != '' }}
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
+      - name: Install docs dependencies
+        if: ${{ hashFiles('docs/pnpm-lock.yaml') == '' }}
+        working-directory: docs
+        run: pnpm install
+      - name: Build docs
+        working-directory: docs
+        run: pnpm run build
+      - uses: actions/configure-pages@v5
+      - name: Resolve docs output directory
+        id: docs-path
+        working-directory: docs
+        run: |
+          if [ -d build ]; then
+            echo "path=docs/build" >> "$GITHUB_OUTPUT"
+          elif [ -d dist ]; then
+            echo "path=docs/dist" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Expected docs build output in docs/build or docs/dist" >&2
+            exit 1
+          fi
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ steps.docs-path.outputs.path }}
+
+  deploy:
+    needs: build
+    if: ${{ needs.build.result == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- ensure the accessibility workflow installs the expected Node.js and pnpm versions before running pa11y
- align the main CI workflow with the same pinned pnpm setup and conservative permissions
- add a deploy-docs workflow that builds the docs site and publishes it to GitHub Pages when changes land on main

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d9987b289883249cb69b5aa5746133