### PR TITLE
feat: sync Supabase env vars from CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # Each Next.js app in this monorepo should share the same keys for a given environment.
 
 # --- Supabase local defaults --------------------------------------------------
-# These settings match the local stack defined in `supabase/config.toml`. Once you
-# run `supabase start` you can copy the generated keys from `supabase/.env`.
+# These settings match the local stack defined in `supabase/config.toml`. After
+# you run `supabase start` you can populate `.env.local` files by running
+# `pnpm db:env:local`.
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=replace-with-local-anon-key
 SUPABASE_SERVICE_ROLE_KEY=replace-with-local-service-role-key

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ NEXT_PUBLIC_SUPABASE_URL=...
 NEXT_PUBLIC_SUPABASE_ANON_KEY=...
 ```
 
-(Use different keys per environment.)
+(Use different keys per environment.) After `supabase start` you can run `pnpm db:env:local` to sync the latest keys into `.env.local`, `apps/airnub/.env.local`, and `apps/speckit/.env.local` directly from the Supabase CLI output.
 
 ## GitHub Codespaces
 
@@ -199,10 +199,10 @@ The repo ships with a `.devcontainer/` that provisions Node 24, pnpm, and the Su
 
    ```bash
    supabase start
-   supabase status --local
+   pnpm db:env:local
    ```
 
-   Use the printed `anon` and `service_role` keys to update the `.env.local` files. Set `NEXT_PUBLIC_SUPABASE_URL` to the forwarded Codespace URL for port **54321** (for example, `https://<codespace-id>-54321.app.github.dev`) so that browser requests reach the local Supabase API. Keep the Postgres connection string values pointing at `127.0.0.1` for server-side access.
+   The script reads the local Supabase status and writes the keys into each `.env.local` file automatically. Set `NEXT_PUBLIC_SUPABASE_URL` to the forwarded Codespace URL for port **54321** (for example, `https://<codespace-id>-54321.app.github.dev`) so that browser requests reach the local Supabase API. Keep the Postgres connection string values pointing at `127.0.0.1` for server-side access.
 
 4. Forward the dev servers and Supabase ports:
    * 3000 → Airnub app (`apps/airnub`)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:link:prod": "supabase link --project-ref $SUPABASE_PROD_REF",
     "db:push": "supabase db push",
     "db:diff": "supabase db diff --use-mig-dir supabase/migrations",
+    "db:env:local": "node scripts/sync-supabase-env.mjs",
     "db:reset:local": "supabase stop || true && supabase start && supabase db reset",
     "prepare": "husky"
   },

--- a/scripts/sync-supabase-env.mjs
+++ b/scripts/sync-supabase-env.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+import { promisify } from 'node:util';
+import { execFile } from 'node:child_process';
+import { readFile, writeFile, access, mkdir } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+const SOURCE_TO_ENV = new Map([
+  ['api.url', 'NEXT_PUBLIC_SUPABASE_URL'],
+  ['api.anon_key', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'],
+  ['api.service_role_key', 'SUPABASE_SERVICE_ROLE_KEY'],
+  ['db.password', 'SUPABASE_DB_PASSWORD_LOCAL'],
+]);
+
+const TARGET_FILES = [
+  '.env.local',
+  path.join('apps', 'airnub', '.env.local'),
+  path.join('apps', 'speckit', '.env.local'),
+];
+
+function parseEnvOutput(envText) {
+  const result = new Map();
+  for (const rawLine of envText.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex === -1) {
+      continue;
+    }
+    const key = line.slice(0, equalsIndex).trim();
+    let value = line.slice(equalsIndex + 1);
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    result.set(key, value);
+  }
+  return result;
+}
+
+function formatEnvValue(value) {
+  if (value === '' || /[^A-Za-z0-9_./:@-]/.test(value)) {
+    return JSON.stringify(value);
+  }
+  return value;
+}
+
+function parseExistingEnv(content) {
+  const lines = content.split(/\r?\n/);
+  return lines.map((line) => {
+    if (!line.trim()) {
+      return { type: 'blank', raw: line };
+    }
+    if (line.trim().startsWith('#')) {
+      return { type: 'comment', raw: line };
+    }
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex === -1) {
+      return { type: 'other', raw: line };
+    }
+    const key = line.slice(0, equalsIndex).trim();
+    const value = line.slice(equalsIndex + 1);
+    return { type: 'entry', key, value, raw: line };
+  });
+}
+
+function applyEnvUpdates(originalContent, updates) {
+  const lines = parseExistingEnv(originalContent);
+  const handledKeys = new Set();
+  const updatedLines = lines.map((line) => {
+    if (line.type === 'entry' && updates.has(line.key)) {
+      handledKeys.add(line.key);
+      const value = updates.get(line.key);
+      return `${line.key}=${formatEnvValue(value)}`;
+    }
+    return line.raw;
+  });
+
+  const missingKeys = [];
+  for (const [key, value] of updates) {
+    if (!handledKeys.has(key)) {
+      missingKeys.push([key, value]);
+    }
+  }
+
+  if (missingKeys.length > 0) {
+    if (updatedLines.length > 0 && updatedLines[updatedLines.length - 1].trim() !== '') {
+      updatedLines.push('');
+    }
+    updatedLines.push('# Synced from Supabase CLI status');
+    for (const [key, value] of missingKeys) {
+      updatedLines.push(`${key}=${formatEnvValue(value)}`);
+    }
+  }
+
+  return `${updatedLines.join('\n')}${updatedLines.length > 0 ? '\n' : ''}`;
+}
+
+async function ensureFileUpdated(filePath, updates) {
+  try {
+    await access(filePath, constants.F_OK);
+    const existing = await readFile(filePath, 'utf8');
+    const nextContent = applyEnvUpdates(existing, updates);
+    await writeFile(filePath, nextContent, 'utf8');
+    return { filePath, status: 'updated' };
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+    const header = [
+      '# Generated Supabase environment variables',
+      '# Run `pnpm db:env:local` after `supabase start` to refresh.',
+      '',
+    ];
+    const lines = [];
+    for (const [key, value] of updates) {
+      lines.push(`${key}=${formatEnvValue(value)}`);
+    }
+    const content = `${header.concat(lines).join('\n')}\n`;
+    const dir = path.dirname(filePath);
+    await mkdir(dir, { recursive: true });
+    await writeFile(filePath, content, 'utf8');
+    return { filePath, status: 'created' };
+  }
+}
+
+async function main() {
+  const args = ['status', '-o', 'env'];
+  for (const [source, target] of SOURCE_TO_ENV) {
+    args.push('--override-name', `${source}=${target}`);
+  }
+
+  let envOutput;
+  try {
+    const { stdout } = await execFileAsync('supabase', args, {
+      encoding: 'utf8',
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    envOutput = stdout;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error('[sync-supabase-env] Supabase CLI is not installed or not on PATH.');
+    } else {
+      console.error('[sync-supabase-env] Failed to run `supabase status`:', error.message || error);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  const parsed = parseEnvOutput(envOutput);
+  const updates = new Map();
+  for (const targetKey of SOURCE_TO_ENV.values()) {
+    if (parsed.has(targetKey)) {
+      updates.set(targetKey, parsed.get(targetKey));
+    }
+  }
+
+  const requiredKeys = ['NEXT_PUBLIC_SUPABASE_URL', 'NEXT_PUBLIC_SUPABASE_ANON_KEY'];
+  const missingRequired = requiredKeys.filter((key) => !updates.has(key));
+  if (missingRequired.length > 0) {
+    console.error(
+      `[sync-supabase-env] Missing required keys from Supabase status output: ${missingRequired.join(', ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  for (const targetFile of TARGET_FILES) {
+    try {
+      const result = await ensureFileUpdated(targetFile, updates);
+      console.log(`[sync-supabase-env] ${result.status === 'created' ? 'Created' : 'Updated'} ${result.filePath}`);
+    } catch (error) {
+      console.error(`[sync-supabase-env] Failed to update ${targetFile}:`, error.message || error);
+      process.exitCode = 1;
+    }
+  }
+}
+
+main();

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,9 +1,338 @@
-[project]
-api_url = "http://127.0.0.1:54321"
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
 project_id = "airnub-site-local"
 
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
 [db]
+# Port to use for the local database URL.
 port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
 
 [studio]
+enabled = true
+# Port to use for Supabase Studio.
 port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth redirectUrl.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"


### PR DESCRIPTION
## Summary
- add a Supabase CLI helper that copies status output into each `.env.local`
- document the new workflow in the README and sample env file
- refresh `supabase/config.toml` to the current CLI schema so status runs cleanly

## Testing
- pnpm db:env:local *(fails: Docker daemon unavailable in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d999064304832489cddf32f491b2d7