### PR TITLE
feat: automate supabase env syncing

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
   },
   "updateContentCommand": "pnpm install",
   "postCreateCommand": ".devcontainer/scripts/post-create.sh",
+  "postStartCommand": ".devcontainer/scripts/post-start.sh",
   "forwardPorts": [54321, 54322, 54323],
   "portsAttributes": {
     "54321": {

--- a/.devcontainer/scripts/post-start.sh
+++ b/.devcontainer/scripts/post-start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${DEBUG:-false}" == "true" ]]; then
+  set -x
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+supabase_ready=false
+
+if command -v supabase >/dev/null 2>&1; then
+  echo "[post-start] Checking Supabase local stack status..."
+  status_file="$(mktemp)"
+  if supabase status >"${status_file}" 2>&1; then
+    if grep -qi 'api url' "${status_file}"; then
+      echo "[post-start] Supabase services already running."
+      supabase_ready=true
+    else
+      echo "[post-start] Supabase services not running; starting now..."
+      supabase start
+      supabase_ready=true
+    fi
+  else
+    echo "[post-start] Supabase status check failed; attempting to start services..." >&2
+    supabase start
+    supabase_ready=true
+  fi
+  rm -f "${status_file}"
+else
+  echo "[post-start] Supabase CLI not found on PATH; skipping Supabase startup." >&2
+fi
+
+if command -v pnpm >/dev/null 2>&1; then
+  if [[ "${supabase_ready}" == "true" ]]; then
+    echo "[post-start] Syncing local environment files from Supabase status..."
+    pnpm db:env:local
+  else
+    echo "[post-start] Skipping environment sync because Supabase CLI is unavailable." >&2
+  fi
+else
+  echo "[post-start] pnpm not found; cannot run db:env:local." >&2
+fi

--- a/.env.example
+++ b/.env.example
@@ -3,14 +3,22 @@
 
 # --- Supabase local defaults --------------------------------------------------
 # These settings match the local stack defined in `supabase/config.toml`. After
-# you run `supabase start` you can populate `.env.local` files by running
-# `pnpm db:env:local`.
+# you run `supabase start`, run `pnpm db:env:local` to pull the latest values from
+# `supabase status` into `.env.local`, `apps/airnub/.env.local`, and
+# `apps/speckit/.env.local` without overwriting any custom variables. The
+# Codespaces devcontainer runs this command automatically after boot.
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_GRAPHQL_URL=http://127.0.0.1:54321/graphql/v1
 NEXT_PUBLIC_SUPABASE_ANON_KEY=replace-with-local-anon-key
 SUPABASE_SERVICE_ROLE_KEY=replace-with-local-service-role-key
-# Optional: direct Postgres access when generating types without the CLI helper.
 SUPABASE_DB_URL_LOCAL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 SUPABASE_DB_PASSWORD_LOCAL=postgres
+SUPABASE_STUDIO_URL=http://127.0.0.1:54323
+SUPABASE_MAILPIT_URL=http://127.0.0.1:54324
+SUPABASE_STORAGE_URL=http://127.0.0.1:54321/storage/v1/s3
+SUPABASE_S3_ACCESS_KEY=replace-with-local-storage-access-key
+SUPABASE_S3_SECRET_KEY=replace-with-local-storage-secret-key
+SUPABASE_S3_REGION=local
 
 # --- Supabase CLI / Remote project configuration ------------------------------
 # Required when running commands like `supabase link`, `supabase db push`, etc.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,6 @@
 # For detailed configuration reference documentation, visit:
 # https://supabase.com/docs/guides/local-development/cli/config
+# Template refreshed with Supabase CLI v2.45.5 on Codespaces post-start automation setup.
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
 project_id = "airnub-site-local"


### PR DESCRIPTION
## Summary
- add a devcontainer post-start hook that boots Supabase and runs the env sync helper
- enhance scripts/sync-supabase-env.mjs to parse `supabase status` output and write all `.env.local` files without clobbering other vars
- document the new workflow in README/.env.example and note the refreshed Supabase CLI template in `supabase/config.toml`

## Testing
- node scripts/sync-supabase-env.mjs *(fails: Unable to parse Supabase status output without Docker/Supabase running)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a49393c48324ab9027f61dc9924b