### PR TITLE
ci: stabilize pnpm setup in workflows

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
-          run_install: false
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack use pnpm@10.17.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run pa11y-ci (targets defined per app)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
-          run_install: false
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack use pnpm@10.17.1
       - run: pnpm install --frozen-lockfile
       - name: Commitlint (PR commits)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -10,8 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - run: pnpm i -w
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack use pnpm@10.17.1
+      - uses: supabase/setup-cli@v1
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Link staging
         run: supabase link --project-ref ${{ secrets.SUPABASE_STAGING_REF }}
       - name: Push migrations (staging)
@@ -23,8 +32,17 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - run: pnpm i -w
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack use pnpm@10.17.1
+      - uses: supabase/setup-cli@v1
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Link prod
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROD_REF }}
       - name: Push migrations (prod)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
-          run_install: false
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack use pnpm@10.17.1
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
       - name: Install docs dependencies (with lockfile)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -6,13 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: .nvmrc
           cache: pnpm
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack use pnpm@10.17.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run link checks


### PR DESCRIPTION
## Summary
- enable Corepack in every workflow so pnpm 10.17.1 is available with the repo's Node version
- install dependencies with frozen lockfiles and configure the Supabase CLI for the migration pipeline
- align the link checker workflow with the workspace Node version file

## Testing
- not run (workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d9a8434ce4832498b765b9b3d29756