### PR TITLE
feat: add admin console for remote operations

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import { AIRNUB_BASE_URL } from "../../lib/routes";
 import { localeHref } from "../../lib/locale";
 import { assertLocale, locales, type Locale } from "../../i18n/routing";
 import { MaintenanceGate } from "./maintenance/MaintenanceGate";
+import { isMaintenanceModeEnabled } from "../../lib/runtime-flags";
 import { LocaleSwitcher } from "../../components/LocaleSwitcher";
 
 const jsonLd = buildAirnubOrganizationJsonLd();
@@ -96,7 +97,7 @@ export default async function LocaleLayout({
     { label: nav("contact"), href: withLocale("/contact") },
   ];
 
-  const maintenanceEnabled = process.env.MAINTENANCE_MODE === "true";
+  const maintenanceEnabled = await isMaintenanceModeEnabled();
   const maintenanceCopy = {
     title: common("maintenance.title"),
     description: common("maintenance.description"),

--- a/apps/airnub/app/admin/layout.tsx
+++ b/apps/airnub/app/admin/layout.tsx
@@ -1,0 +1,31 @@
+import "../globals.css";
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Airnub admin",
+  description: "Remote operations for marketing leads and runtime controls.",
+};
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+        <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-10 px-6 py-12 sm:px-10 lg:px-16">
+          <header className="flex flex-col gap-2 border-b border-slate-800/60 pb-6">
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-400/70">Airnub</p>
+            <h1 className="text-3xl font-semibold tracking-tight text-white">Operations console</h1>
+            <p className="max-w-2xl text-sm text-slate-300">
+              Securely manage inbound leads and runtime toggles from any device. Credentials are required through HTTP basic
+              auth; please keep them private.
+            </p>
+          </header>
+          <main className="flex-1 pb-16">{children}</main>
+          <footer className="border-t border-slate-800/60 pt-6 text-xs text-slate-500">
+            © {new Date().getFullYear()} Airnub. Remote updates are tracked via Supabase service role.
+          </footer>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/airnub/app/admin/leads/LeadActionForm.tsx
+++ b/apps/airnub/app/admin/leads/LeadActionForm.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import type { LeadActionFormState } from "./actions";
+import { submitLeadAction } from "./actions";
+import { LEAD_STATUSES, LEAD_STATUS_LABELS } from "./statuses";
+
+type LeadActionFormProps = {
+  leadId: string;
+  latestStatus?: string;
+  latestAssignee?: string | null;
+  actorSuggestion?: string | null;
+};
+
+const initialState: LeadActionFormState = { status: "idle" };
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      className="inline-flex items-center justify-center rounded-full bg-sky-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 disabled:cursor-not-allowed disabled:bg-slate-500"
+      disabled={pending}
+    >
+      {pending ? "Saving…" : label}
+    </button>
+  );
+}
+
+export function LeadActionForm({ leadId, latestStatus, latestAssignee, actorSuggestion }: LeadActionFormProps) {
+  const [state, formAction] = useFormState(submitLeadAction, initialState);
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset();
+    }
+  }, [state.status]);
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4"
+    >
+      <input type="hidden" name="leadId" value={leadId} />
+      <div>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Status</label>
+        <select
+          name="status"
+          defaultValue={latestStatus && LEAD_STATUSES.includes(latestStatus as any) ? latestStatus : "new"}
+          className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner focus:outline-none focus:ring-2 focus:ring-sky-400"
+        >
+          {LEAD_STATUSES.map((status) => (
+            <option key={status} value={status} className="bg-slate-950 text-slate-900">
+              {LEAD_STATUS_LABELS[status]}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Assign to</label>
+          <input
+            type="text"
+            name="assignee"
+            placeholder="Owner or teammate"
+            defaultValue={latestAssignee ?? ""}
+            className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Recorded by</label>
+          <input
+            type="text"
+            name="actor"
+            placeholder="Your name"
+            defaultValue={actorSuggestion ?? ""}
+            className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          />
+        </div>
+      </div>
+      <div>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Notes</label>
+        <textarea
+          name="note"
+          rows={3}
+          placeholder="Context, reply summary, or next steps"
+          className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400"
+        />
+      </div>
+      {state.status === "error" ? (
+        <p className="text-sm text-rose-400">{state.message ?? "Unable to save."}</p>
+      ) : null}
+      {state.status === "success" ? (
+        <p className="text-sm text-emerald-400">{state.message ?? "Saved."}</p>
+      ) : null}
+      <SubmitButton label="Save triage" />
+    </form>
+  );
+}

--- a/apps/airnub/app/admin/leads/MaintenanceToggleForm.tsx
+++ b/apps/airnub/app/admin/leads/MaintenanceToggleForm.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useFormState, useFormStatus } from "react-dom";
+import type { MaintenanceFormState } from "./actions";
+import { updateMaintenanceMode } from "./actions";
+
+type MaintenanceToggleFormProps = {
+  enabled: boolean;
+  updatedAt?: string;
+  updatedBy?: string | null;
+};
+
+const initialState: MaintenanceFormState = { status: "idle" };
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-500"
+      disabled={pending}
+    >
+      {pending ? "Saving…" : "Save maintenance setting"}
+    </button>
+  );
+}
+
+export function MaintenanceToggleForm({ enabled, updatedAt, updatedBy }: MaintenanceToggleFormProps) {
+  const [state, formAction] = useFormState(updateMaintenanceMode, initialState);
+  const formRef = useRef<HTMLFormElement | null>(null);
+
+  useEffect(() => {
+    if (state.status === "success") {
+      formRef.current?.reset();
+    }
+  }, [state.status]);
+
+  const formattedUpdatedAt = updatedAt ? new Date(updatedAt).toLocaleString(undefined, { hour12: false }) : null;
+
+  return (
+    <form
+      ref={formRef}
+      action={formAction}
+      className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4"
+    >
+      <div>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Maintenance mode</label>
+        <select
+          name="enabled"
+          defaultValue={String(enabled)}
+          className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-400"
+        >
+          <option value="false" className="bg-slate-950 text-slate-900">
+            Off — public site stays live
+          </option>
+          <option value="true" className="bg-slate-950 text-slate-900">
+            On — show downtime banner everywhere
+          </option>
+        </select>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-[1fr,1fr]">
+        <div>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Recorded by</label>
+          <input
+            type="text"
+            name="actor"
+            placeholder="Your name"
+            defaultValue={updatedBy ?? ""}
+            className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+          />
+        </div>
+        <div className="text-xs text-slate-400">
+          <p className="font-semibold uppercase tracking-wide">Last updated</p>
+          <p className="mt-2 text-slate-300">
+            {formattedUpdatedAt ? formattedUpdatedAt : "No changes yet"}
+            {updatedBy ? ` • ${updatedBy}` : ""}
+          </p>
+        </div>
+      </div>
+      {state.status === "error" ? (
+        <p className="text-sm text-rose-400">{state.message ?? "Unable to save."}</p>
+      ) : null}
+      {state.status === "success" ? (
+        <p className="text-sm text-emerald-400">{state.message ?? "Saved."}</p>
+      ) : null}
+      <SubmitButton />
+    </form>
+  );
+}

--- a/apps/airnub/app/admin/leads/actions.ts
+++ b/apps/airnub/app/admin/leads/actions.ts
@@ -1,0 +1,124 @@
+"use server";
+
+import { revalidatePath, revalidateTag } from "next/cache";
+import { getServiceRoleClient, insertLeadAction, upsertRuntimeFlag } from "@airnub/db";
+import type { TablesInsert } from "@airnub/db";
+import { LEAD_STATUSES, type LeadStatus } from "./statuses";
+
+export type LeadActionFormState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+};
+
+export type MaintenanceFormState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+};
+
+const leadStatusSet = new Set<LeadStatus>(LEAD_STATUSES);
+
+export async function submitLeadAction(_: LeadActionFormState, formData: FormData): Promise<LeadActionFormState> {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return {
+      status: "error",
+      message: "Supabase service role key is not configured.",
+    };
+  }
+
+  const leadId = formData.get("leadId");
+  const status = formData.get("status");
+
+  if (typeof leadId !== "string" || leadId.length === 0) {
+    return {
+      status: "error",
+      message: "Lead identifier is required.",
+    };
+  }
+
+  if (typeof status !== "string" || !leadStatusSet.has(status as LeadStatus)) {
+    return {
+      status: "error",
+      message: "Choose a valid status before saving.",
+    };
+  }
+
+  const assignee = formData.get("assignee");
+  const note = formData.get("note");
+  const actor = formData.get("actor");
+
+  const payload: TablesInsert<"lead_actions"> = {
+    lead_id: leadId,
+    status: status as LeadStatus,
+    assignee: typeof assignee === "string" && assignee.trim().length > 0 ? assignee.trim() : null,
+    note: typeof note === "string" && note.trim().length > 0 ? note.trim() : null,
+    created_by: typeof actor === "string" && actor.trim().length > 0 ? actor.trim() : null,
+  };
+
+  const db = getServiceRoleClient();
+  const { error } = await insertLeadAction(db, payload);
+
+  if (error) {
+    return {
+      status: "error",
+      message: "Unable to record the update. Please try again.",
+    };
+  }
+
+  await revalidatePath("/admin/leads");
+
+  return {
+    status: "success",
+    message: "Lead triage saved.",
+  };
+}
+
+export async function updateMaintenanceMode(
+  _: MaintenanceFormState,
+  formData: FormData
+): Promise<MaintenanceFormState> {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return {
+      status: "error",
+      message: "Supabase service role key is not configured.",
+    };
+  }
+
+  const enabledInput = formData.get("enabled");
+
+  if (typeof enabledInput !== "string" || !["true", "false"].includes(enabledInput)) {
+    return {
+      status: "error",
+      message: "Choose whether maintenance mode should be on or off.",
+    };
+  }
+
+  const actor = formData.get("actor");
+  const enabled = enabledInput === "true";
+
+  const payload: TablesInsert<"runtime_flags"> = {
+    key: "maintenance_mode",
+    value: enabled,
+    updated_by: typeof actor === "string" && actor.trim().length > 0 ? actor.trim() : null,
+    updated_at: new Date().toISOString(),
+  };
+
+  const db = getServiceRoleClient();
+  const { error } = await upsertRuntimeFlag(db, payload);
+
+  if (error) {
+    return {
+      status: "error",
+      message: "Failed to update maintenance mode. Please try again.",
+    };
+  }
+
+  await Promise.all([
+    revalidatePath("/admin/leads"),
+    revalidateTag("runtime-maintenance"),
+  ]);
+
+  return {
+    status: "success",
+    message: enabled ? "Maintenance mode enabled." : "Maintenance mode disabled.",
+  };
+}

--- a/apps/airnub/app/admin/leads/page.tsx
+++ b/apps/airnub/app/admin/leads/page.tsx
@@ -1,0 +1,241 @@
+import type { Metadata } from "next";
+import { getServiceRoleClient, fetchRuntimeFlag, type LeadWithActions } from "@airnub/db";
+import { MaintenanceToggleForm } from "./MaintenanceToggleForm";
+import { LeadActionForm } from "./LeadActionForm";
+import { LEAD_STATUS_LABELS } from "./statuses";
+
+export const metadata: Metadata = {
+  title: "Airnub admin · Leads",
+  description: "Review inbound leads and keep the marketing site healthy while traveling.",
+};
+
+export const dynamic = "force-dynamic";
+
+const STATUS_LABELS = LEAD_STATUS_LABELS;
+
+function formatTimestamp(value: string | null | undefined) {
+  if (!value) {
+    return "";
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString(undefined, { hour12: false });
+}
+
+export default async function LeadsPage() {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return (
+      <div className="space-y-6 text-slate-100">
+        <h1 className="text-3xl font-semibold">Admin configuration missing</h1>
+        <p className="text-sm text-slate-300">
+          Add <code className="rounded bg-slate-800 px-1 py-0.5 text-xs">SUPABASE_SERVICE_ROLE_KEY</code>,
+          <code className="ml-1 rounded bg-slate-800 px-1 py-0.5 text-xs">ADMIN_DASHBOARD_USER</code>, and
+          <code className="ml-1 rounded bg-slate-800 px-1 py-0.5 text-xs">ADMIN_DASHBOARD_PASSWORD</code> to your environment
+          variables to unlock the remote operations console.
+        </p>
+      </div>
+    );
+  }
+
+  const serviceClient = getServiceRoleClient();
+
+  const [{ data: leadRows, error: leadError }, { data: maintenanceFlag, error: maintenanceError }] = await Promise.all([
+    serviceClient
+      .from("contact_leads")
+      .select(
+        "id,created_at,full_name,email,company,message,source,consent,lead_actions(id,status,assignee,note,created_at,created_by)"
+      )
+      .order("created_at", { ascending: false })
+      .limit(100),
+    fetchRuntimeFlag(serviceClient, "maintenance_mode"),
+  ]);
+
+  if (leadError) {
+    return (
+      <div className="space-y-4 text-slate-100">
+        <h1 className="text-3xl font-semibold">Unable to load leads</h1>
+        <p className="text-sm text-rose-300">
+          Supabase returned an error. Confirm the service role credentials and network reachability, then refresh.
+        </p>
+        {leadError.message ? <p className="text-xs text-rose-400">{leadError.message}</p> : null}
+      </div>
+    );
+  }
+
+  if (maintenanceError) {
+    return (
+      <div className="space-y-4 text-slate-100">
+        <h1 className="text-3xl font-semibold">Unable to load runtime flags</h1>
+        <p className="text-sm text-rose-300">
+          Supabase returned an error while loading runtime flags. Double-check the service role key and try again.
+        </p>
+        {maintenanceError.message ? <p className="text-xs text-rose-400">{maintenanceError.message}</p> : null}
+      </div>
+    );
+  }
+
+  const leads: LeadWithActions[] = (leadRows ?? []).map((lead) => ({
+    ...lead,
+    lead_actions: Array.isArray(lead.lead_actions)
+      ? [...lead.lead_actions].sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      : [],
+  }));
+
+  const leadsBySource = leads.reduce<{
+    airnub: LeadWithActions[];
+    speckit: LeadWithActions[];
+  }>(
+    (acc, lead) => {
+      if (lead.source === "speckit") {
+        acc.speckit.push(lead);
+      } else {
+        acc.airnub.push(lead);
+      }
+      return acc;
+    },
+    { airnub: [], speckit: [] }
+  );
+
+  const maintenanceEnabled =
+    typeof maintenanceFlag?.value === "boolean" ? maintenanceFlag.value : process.env.MAINTENANCE_MODE === "true";
+
+  return (
+    <div className="space-y-10 text-slate-100">
+      <header className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-400/70">Airnub</p>
+        <h1 className="text-4xl font-semibold tracking-tight">Remote operations</h1>
+        <p className="max-w-2xl text-sm text-slate-300">
+          Review inbound leads from both marketing sites, assign follow-ups, and toggle the maintenance banner without opening the
+          cloud console.
+        </p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Runtime controls</h2>
+        <MaintenanceToggleForm
+          enabled={maintenanceEnabled}
+          updatedAt={maintenanceFlag?.updated_at}
+          updatedBy={maintenanceFlag?.updated_by ?? null}
+        />
+      </section>
+
+      <section className="space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold">Inbound leads</h2>
+          <p className="text-sm text-slate-300">Showing the 100 most recent submissions across the Airnub and Speckit funnels.</p>
+        </div>
+
+        {leads.length === 0 ? (
+          <p className="rounded-3xl border border-dashed border-slate-800/60 bg-slate-950/40 p-6 text-sm text-slate-400">
+            No leads yet. Check back after the next launch.
+          </p>
+        ) : null}
+
+        {(["airnub", "speckit"] as const).map((source) => {
+          const sourceLeads = leadsBySource[source];
+
+          if (sourceLeads.length === 0) {
+            return null;
+          }
+
+          const sourceLabel = source === "airnub" ? "Airnub marketing" : "Speckit marketing";
+
+          return (
+            <div key={source} className="space-y-4">
+              <h3 className="text-lg font-semibold">{sourceLabel}</h3>
+              <div className="grid gap-6 lg:grid-cols-2">
+                {sourceLeads.map((lead) => {
+                  const latestAction = lead.lead_actions.at(0);
+
+                  return (
+                    <article
+                      key={lead.id}
+                      className="flex h-full flex-col justify-between gap-4 rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 shadow-lg shadow-slate-950/40"
+                    >
+                      <div className="space-y-4">
+                        <div>
+                          <p className="text-xs uppercase tracking-wide text-slate-400">Submitted</p>
+                          <p className="text-sm text-slate-200">{formatTimestamp(lead.created_at)}</p>
+                        </div>
+                        <div>
+                          <h4 className="text-2xl font-semibold text-white">{lead.full_name ?? lead.email}</h4>
+                          <a
+                            href={`mailto:${lead.email}`}
+                            className="text-sm text-sky-300 underline-offset-4 hover:underline"
+                          >
+                            {lead.email}
+                          </a>
+                          {lead.company ? (
+                            <p className="text-sm text-slate-300">{lead.company}</p>
+                          ) : null}
+                        </div>
+                        {lead.message ? (
+                          <div>
+                            <p className="text-xs uppercase tracking-wide text-slate-400">Message</p>
+                            <p className="mt-1 whitespace-pre-line text-sm text-slate-200">{lead.message}</p>
+                          </div>
+                        ) : null}
+                        {latestAction ? (
+                          <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4">
+                            <p className="text-xs uppercase tracking-wide text-slate-400">Latest triage</p>
+                            <p className="mt-1 text-sm text-slate-200">
+                              {STATUS_LABELS[latestAction.status] ?? latestAction.status}
+                              {latestAction.assignee ? ` • Assigned to ${latestAction.assignee}` : ""}
+                            </p>
+                            {latestAction.note ? (
+                              <p className="mt-2 text-sm text-slate-300 whitespace-pre-line">{latestAction.note}</p>
+                            ) : null}
+                            <p className="mt-2 text-xs text-slate-500">
+                              {latestAction.created_by ? `${latestAction.created_by} — ` : ""}
+                              {formatTimestamp(latestAction.created_at)}
+                            </p>
+                          </div>
+                        ) : (
+                          <div className="rounded-2xl border border-dashed border-slate-800/60 bg-slate-900/20 p-4 text-sm text-slate-400">
+                            No triage recorded yet.
+                          </div>
+                        )}
+                      </div>
+                      <div className="space-y-4">
+                        {lead.lead_actions.length > 1 ? (
+                          <div className="space-y-2">
+                            <p className="text-xs uppercase tracking-wide text-slate-400">History</p>
+                            <ul className="space-y-2 text-xs text-slate-400">
+                              {lead.lead_actions.slice(1, 5).map((action) => (
+                                <li key={action.id} className="rounded-xl border border-slate-800/60 bg-slate-900/30 p-3">
+                                  <p className="text-slate-300">
+                                    {STATUS_LABELS[action.status] ?? action.status}
+                                    {action.assignee ? ` • ${action.assignee}` : ""}
+                                  </p>
+                                  {action.note ? <p className="mt-1 whitespace-pre-line text-slate-400">{action.note}</p> : null}
+                                  <p className="mt-1 text-[0.7rem] text-slate-500">
+                                    {action.created_by ? `${action.created_by} — ` : ""}
+                                    {formatTimestamp(action.created_at)}
+                                  </p>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        ) : null}
+                        <LeadActionForm
+                          leadId={lead.id}
+                          latestStatus={latestAction?.status}
+                          latestAssignee={latestAction?.assignee ?? null}
+                          actorSuggestion={latestAction?.created_by ?? null}
+                        />
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/apps/airnub/app/admin/leads/statuses.ts
+++ b/apps/airnub/app/admin/leads/statuses.ts
@@ -1,0 +1,10 @@
+export const LEAD_STATUSES = ["new", "replied", "ignored", "handoff"] as const;
+
+export type LeadStatus = (typeof LEAD_STATUSES)[number];
+
+export const LEAD_STATUS_LABELS: Record<LeadStatus, string> = {
+  new: "New",
+  replied: "Replied",
+  ignored: "Ignored",
+  handoff: "Handoff",
+};

--- a/apps/airnub/lib/runtime-flags.ts
+++ b/apps/airnub/lib/runtime-flags.ts
@@ -1,0 +1,41 @@
+import { unstable_cache } from "next/cache";
+import { getServiceRoleClient, type RuntimeFlagRow } from "@airnub/db";
+
+const fetchMaintenanceFlag = unstable_cache(async (): Promise<RuntimeFlagRow | null> => {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return null;
+  }
+
+  try {
+    const client = getServiceRoleClient();
+    const { data, error } = await client
+      .from("runtime_flags")
+      .select("key,value,updated_at,updated_by")
+      .eq("key", "maintenance_mode")
+      .maybeSingle();
+
+    if (error) {
+      return null;
+    }
+
+    return (data as RuntimeFlagRow | null) ?? null;
+  } catch {
+    return null;
+  }
+}, ["runtime-maintenance"], {
+  revalidate: 60,
+});
+
+export async function isMaintenanceModeEnabled() {
+  const flag = await fetchMaintenanceFlag();
+
+  if (flag && typeof flag.value === "boolean") {
+    return flag.value;
+  }
+
+  return process.env.MAINTENANCE_MODE === "true";
+}
+
+export async function getMaintenanceFlag() {
+  return fetchMaintenanceFlag();
+}

--- a/apps/airnub/middleware.ts
+++ b/apps/airnub/middleware.ts
@@ -1,10 +1,56 @@
 import createMiddleware from "next-intl/middleware";
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { defaultLocale, locales } from "./i18n/routing";
 
-export default createMiddleware({
+const intlMiddleware = createMiddleware({
   defaultLocale,
   locales,
 });
+
+function unauthorizedResponse() {
+  return new NextResponse("Unauthorized", {
+    status: 401,
+    headers: {
+      "WWW-Authenticate": 'Basic realm="Airnub Admin"',
+    },
+  });
+}
+
+export default function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  if (pathname.startsWith("/admin")) {
+    const username = process.env.ADMIN_DASHBOARD_USER;
+    const password = process.env.ADMIN_DASHBOARD_PASSWORD;
+
+    if (!username || !password) {
+      return new NextResponse("Admin credentials are not configured.", { status: 503 });
+    }
+
+    const authHeader = request.headers.get("authorization");
+
+    if (!authHeader || !authHeader.startsWith("Basic ")) {
+      return unauthorizedResponse();
+    }
+
+    try {
+      const encoded = authHeader.split(" ", 2)[1] ?? "";
+      const decoded = atob(encoded);
+      const [providedUser, providedPassword] = decoded.split(":", 2);
+
+      if (providedUser !== username || providedPassword !== password) {
+        return unauthorizedResponse();
+      }
+    } catch {
+      return unauthorizedResponse();
+    }
+
+    return NextResponse.next();
+  }
+
+  return intlMiddleware(request);
+}
 
 export const config = {
   matcher: ["/((?!api|_next|.*\\..*).*)"],

--- a/docs/remote-operations.md
+++ b/docs/remote-operations.md
@@ -1,0 +1,40 @@
+# Remote operations guide
+
+This note captures which parts of the Airnub marketing stack can already be operated without
+opening the cloud console and highlights a few high-value additions to prioritize.
+
+## What you can control today
+
+- **Remote operations console:** Visit `/admin/leads` (guarded by HTTP basic auth) to review the
+  latest 100 leads from both Airnub and Speckit, assign owners, add notes, and view each triage
+  history. All reads and writes go through the Supabase service role so no credentials ever land in
+  the browser.【F:apps/airnub/app/admin/leads/page.tsx†L1-L213】【F:apps/airnub/middleware.ts†L1-L62】
+- **Maintenance banner toggle:** The admin console persists a `maintenance_mode` runtime flag in
+  Supabase. The public site consults the cached flag on every request (falling back to the
+  `MAINTENANCE_MODE` env var) so you can flip the banner from your phone without redeploying.【F:apps/airnub/lib/runtime-flags.ts†L1-L31】【F:apps/airnub/app/[locale]/layout.tsx†L1-L128】【F:apps/airnub/app/admin/leads/MaintenanceToggleForm.tsx†L1-L85】
+- **Inbound leads ingestion:** Both marketing sites post their contact forms through the `submitLead`
+  server action into the shared `contact_leads` table. Thanks to Supabase row-level security,
+  anonymous users can only insert rows; reads require the service role key, which means the admin
+  console is the approved way to review submissions.【F:apps/airnub/app/[locale]/contact/actions.ts†L1-L56】【F:supabase/migrations/20240718000000_create_contact_leads.sql†L1-L22】
+
+## High-value upgrades for on-the-road operations
+
+1. **Quick replies & integrations.** Embed `mailto:` and deep links into your CRM or helpdesk, or
+   trigger a server action that sends templated responses via your transactional email provider.
+   Storing the outbound email ID alongside the action record makes handoffs auditable when you're
+   back at a laptop.
+2. **Self-healing connectivity checks.** Implement a lightweight background job (Edge Function or
+   cron) that pings Supabase using the service role and raises an alert (Slack, SMS) when inserts or
+   reads fail. Pair it with a simple status widget in the admin view so you can confirm the API is
+   reachable before re-running a form submission.
+3. **Cache & ISR refresh endpoint.** Expose a protected API route that calls `revalidatePath` or
+   `resend` to invalidate stale ISR caches after content edits. That gives you a remote "soft
+   restart" lever without redeploying the app when marketing content updates or a Supabase hiccup
+   clears.
+4. **Feature-flag toggles beyond maintenance.** Expand the `runtime_flags` table with additional
+   keys (e.g., "pause forms", "switch hero CTA") so marketing can flip experiments without a
+   redeploy. The admin console already knows how to persist and revalidate those values; it just
+   needs additional form controls.【F:supabase/migrations/20240725000000_create_lead_actions_and_runtime_flags.sql†L1-L33】【F:apps/airnub/app/admin/leads/actions.ts†L1-L87】
+
+These additions keep day-to-day operations inside the product surface you already control, so you
+can stay effective on the road while reserving the cloud console for deeper incident response.

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,7 +1,7 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { createBrowserClient, createServerClient } from "@supabase/ssr";
 import type { Database } from "./types";
-import type { TablesInsert } from "./types-helpers";
+import type { TablesInsert, TablesRow } from "./types-helpers";
 
 type Cookie = { name: string; value: string };
 
@@ -14,6 +14,8 @@ type MaybePromise<T> = T | Promise<T>;
 type CookieAccessor = () => MaybePromise<CookieStore>;
 
 type TypedClient = SupabaseClient<Database, "public", "public", Database["public"]>;
+
+type ServiceClient = SupabaseClient<Database>;
 
 export type SupabaseDatabaseClient = TypedClient;
 
@@ -40,11 +42,47 @@ export function getServerClient(
   }) as unknown as TypedClient;
 }
 
+export function getServiceRoleClient(
+  url = process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY!
+): ServiceClient {
+  return createClient<Database>(url, serviceRole, {
+    auth: { persistSession: false },
+  });
+}
+
 export async function insertContactLead(
   db: SupabaseDatabaseClient,
   payload: TablesInsert<"contact_leads">
 ) {
   return (db as SupabaseClient<any>).from("contact_leads").insert(payload);
 }
+
+export async function insertLeadAction(
+  db: ServiceClient,
+  payload: TablesInsert<"lead_actions">
+) {
+  return db.from("lead_actions").insert(payload);
+}
+
+export async function upsertRuntimeFlag(
+  db: ServiceClient,
+  payload: TablesInsert<"runtime_flags">
+) {
+  return db.from("runtime_flags").upsert(payload, { onConflict: "key" });
+}
+
+export async function fetchRuntimeFlag(
+  db: ServiceClient,
+  key: string
+) {
+  return db.from("runtime_flags").select("key,value,updated_at,updated_by").eq("key", key).maybeSingle();
+}
+
+export type LeadWithActions = TablesRow<"contact_leads"> & {
+  lead_actions: TablesRow<"lead_actions">[];
+};
+
+export type RuntimeFlagRow = TablesRow<"runtime_flags">;
 
 export type { Database } from "./types";

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -48,6 +48,65 @@ export type Database = {
         };
         Relationships: [];
       };
+      lead_actions: {
+        Row: {
+          id: string;
+          lead_id: string;
+          status: "new" | "replied" | "ignored" | "handoff";
+          assignee: string | null;
+          note: string | null;
+          created_at: string;
+          created_by: string | null;
+        };
+        Insert: {
+          id?: string;
+          lead_id: string;
+          status: "new" | "replied" | "ignored" | "handoff";
+          assignee?: string | null;
+          note?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+        };
+        Update: {
+          id?: string;
+          lead_id?: string;
+          status?: "new" | "replied" | "ignored" | "handoff";
+          assignee?: string | null;
+          note?: string | null;
+          created_at?: string;
+          created_by?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "lead_actions_lead_id_fkey";
+            columns: ["lead_id"];
+            isOneToOne: false;
+            referencedRelation: "contact_leads";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+      runtime_flags: {
+        Row: {
+          key: string;
+          value: Json;
+          updated_at: string;
+          updated_by: string | null;
+        };
+        Insert: {
+          key: string;
+          value: Json;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Update: {
+          key?: string;
+          value?: Json;
+          updated_at?: string;
+          updated_by?: string | null;
+        };
+        Relationships: [];
+      };
     };
     Views: {};
     Functions: {};

--- a/supabase/migrations/20240725000000_create_lead_actions_and_runtime_flags.sql
+++ b/supabase/migrations/20240725000000_create_lead_actions_and_runtime_flags.sql
@@ -1,0 +1,37 @@
+create table if not exists public.lead_actions (
+  id uuid primary key default gen_random_uuid(),
+  lead_id uuid not null references public.contact_leads (id) on delete cascade,
+  status text not null check (status in ('new','replied','ignored','handoff')),
+  assignee text,
+  note text,
+  created_at timestamptz not null default now(),
+  created_by text
+);
+
+create index if not exists idx_lead_actions_lead_id_created_at on public.lead_actions (lead_id, created_at desc);
+
+alter table public.lead_actions enable row level security;
+
+create policy "lead_actions_select_service" on public.lead_actions
+  for select to service_role using (true);
+
+create policy "lead_actions_insert_service" on public.lead_actions
+  for insert to service_role with check (true);
+
+create table if not exists public.runtime_flags (
+  key text primary key,
+  value jsonb not null,
+  updated_at timestamptz not null default now(),
+  updated_by text
+);
+
+alter table public.runtime_flags enable row level security;
+
+create policy "runtime_flags_select_service" on public.runtime_flags
+  for select to service_role using (true);
+
+create policy "runtime_flags_upsert_service" on public.runtime_flags
+  for insert to service_role with check (true);
+
+create policy "runtime_flags_update_service" on public.runtime_flags
+  for update to service_role using (true) with check (true);


### PR DESCRIPTION
## Summary
- add a basic-auth protected /admin/leads console that lists Supabase leads from both marketing apps with triage history and forms
- persist triage actions and maintenance toggles via new Supabase tables plus service-role helpers consumed by the admin console
- read the maintenance runtime flag from Supabase on public pages and document the new remote-operations workflow

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9a77ef4d48324b2a2c0306c7581fc