### PR TITLE
fix: allow server actions in proxied dev hosts

### DIFF
--- a/next.shared-config.js
+++ b/next.shared-config.js
@@ -3,6 +3,94 @@ const path = require("node:path");
 const DEFAULT_TRANSPILE_PACKAGES = ["@airnub/ui", "@airnub/brand", "@airnub/seo"];
 const DEFAULT_OPTIMIZED_PACKAGES = ["@airnub/ui", "clsx"];
 
+function extractHost(value) {
+  if (!value) return undefined;
+
+  try {
+    return new URL(value).host;
+  } catch (error) {
+    if (typeof value === "string" && !value.includes("/")) {
+      return value;
+    }
+
+    return undefined;
+  }
+}
+
+function collectAllowedOrigins(overrideAllowedOrigins = []) {
+  const allowedOrigins = new Set(
+    Array.isArray(overrideAllowedOrigins)
+      ? overrideAllowedOrigins.filter(Boolean)
+      : overrideAllowedOrigins
+        ? [overrideAllowedOrigins]
+        : [],
+  );
+
+  const addOrigin = (origin) => {
+    if (origin) {
+      allowedOrigins.add(origin);
+    }
+  };
+
+  const fromEnv = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS;
+  if (fromEnv) {
+    for (const value of fromEnv.split(/[\s,]+/)) {
+      addOrigin(value.trim());
+    }
+  }
+
+  for (const candidate of [
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.SITE_URL,
+  ]) {
+    addOrigin(extractHost(candidate));
+  }
+
+  const devPorts = new Set(
+    [
+      process.env.PORT,
+      process.env.NEXT_PUBLIC_PORT,
+      process.env.NEXT_DEV_SERVER_PORT,
+      "3000",
+    ].filter(Boolean),
+  );
+
+  if (process.env.NODE_ENV !== "production") {
+    for (const port of devPorts) {
+      addOrigin(`localhost:${port}`);
+      addOrigin(`127.0.0.1:${port}`);
+    }
+  }
+
+  const isCodespaces =
+    process.env.CODESPACES === "true" || Boolean(process.env.CODESPACE_NAME);
+  if (isCodespaces) {
+    const port = process.env.PORT || "3000";
+    const domain =
+      process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN || "app.github.dev";
+
+    if (process.env.CODESPACE_NAME) {
+      addOrigin(`${process.env.CODESPACE_NAME}-${port}.${domain}`);
+    }
+
+    addOrigin(`*.${domain}`);
+  }
+
+  return Array.from(allowedOrigins).filter(Boolean);
+}
+
+function resolveServerActionsConfig(override = undefined) {
+  const allowedOrigins = collectAllowedOrigins(override?.allowedOrigins);
+
+  const baseConfig = override ? { ...override } : {};
+
+  if (allowedOrigins.length > 0) {
+    baseConfig.allowedOrigins = Array.from(new Set(allowedOrigins));
+  }
+
+  return Object.keys(baseConfig).length > 0 ? baseConfig : undefined;
+}
+
 function defineMonorepoNextConfig(appDirectory, overrides = {}) {
   if (!appDirectory) {
     throw new Error("defineMonorepoNextConfig requires the caller's directory path");
@@ -11,12 +99,18 @@ function defineMonorepoNextConfig(appDirectory, overrides = {}) {
   const monorepoRoot = path.resolve(appDirectory, "../../");
 
   const {
-    experimental: { optimizePackageImports = [], ...experimentalRest } = {},
+    experimental: {
+      optimizePackageImports = [],
+      serverActions: overrideServerActions,
+      ...experimentalRest
+    } = {},
     eslint: eslintConfig = {},
     typescript: typescriptConfig = {},
     transpilePackages = [],
     ...rest
   } = overrides;
+
+  const serverActions = resolveServerActionsConfig(overrideServerActions);
 
   return {
     outputFileTracingRoot: monorepoRoot,
@@ -28,6 +122,7 @@ function defineMonorepoNextConfig(appDirectory, overrides = {}) {
         new Set([...DEFAULT_OPTIMIZED_PACKAGES, ...optimizePackageImports])
       ),
       ...experimentalRest,
+      ...(serverActions ? { serverActions } : {}),
     },
     eslint: {
       ignoreDuringBuilds: Boolean(process.env.CI),


### PR DESCRIPTION
## Summary
- add helper utilities in the shared Next.js config to derive default server action allowed origins
- include GitHub Codespaces and local development hosts so CSRF protection accepts proxied origins
- merge the derived origins with any app-specific overrides without clobbering other server action options

## Testing
- pnpm -C apps/airnub lint

------
https://chatgpt.com/codex/tasks/task_e_68d9afee72188324879cbd03b257e9d4