### PR TITLE
chore: ensure pnpm is available in ci

### DIFF
--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -15,10 +15,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack use pnpm@10.17.1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run pa11y-ci (targets defined per app)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack use pnpm@10.17.1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - run: pnpm install --frozen-lockfile
       - name: Commitlint (PR commits)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -14,10 +14,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack use pnpm@10.17.1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - uses: supabase/setup-cli@v1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,10 +35,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack use pnpm@10.17.1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - uses: supabase/setup-cli@v1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -32,10 +32,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack use pnpm@10.17.1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
       - name: Install docs dependencies (with lockfile)

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -10,10 +10,9 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack use pnpm@10.17.1
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Run link checks


### PR DESCRIPTION
## Summary
- replace the manual corepack setup with pnpm/action-setup@v4 across all workflows so pnpm is installed reliably on GitHub Actions runners

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68d9b1e064b483248275d5267a374937