### PR TITLE
Fix Speckit light theme and localize footers

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -1,5 +1,5 @@
 import "../globals.css";
-import { FooterAirnub, HeaderAirnub, ThemeProvider, ToastProvider } from "@airnub/ui";
+import { FooterAirnub, HeaderAirnub, ThemeProvider, ToastProvider, type FooterColumn } from "@airnub/ui";
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations } from "next-intl/server";
@@ -85,6 +85,7 @@ export default async function LocaleLayout({
   const messages = await getMessages();
   const common = await getTranslations({ locale, namespace: "common" });
   const nav = await getTranslations({ locale, namespace: "nav" });
+  const footer = await getTranslations({ locale, namespace: "footer" });
 
   const withLocale = (path: string) => localeHref(locale, path);
   const navItems = [
@@ -95,6 +96,54 @@ export default async function LocaleLayout({
     { label: nav("trust"), href: withLocale("/trust") },
     { label: nav("company"), href: withLocale("/company") },
     { label: nav("contact"), href: withLocale("/contact") },
+  ];
+
+  const footerColumns: FooterColumn[] = [
+    {
+      heading: footer("columns.products.heading"),
+      links: [
+        { label: footer("columns.products.links.speckit"), href: "https://speckit.airnub.io", external: true },
+      ],
+    },
+    {
+      heading: footer("columns.resources.heading"),
+      links: [
+        { label: footer("columns.resources.links.docs"), href: "https://docs.speckit.dev", external: true },
+        { label: footer("columns.resources.links.blog"), href: "/resources#blog" },
+        { label: footer("columns.resources.links.changelog"), href: "/resources#changelog" },
+      ],
+    },
+    {
+      heading: footer("columns.openSource.heading"),
+      links: [
+        { label: footer("columns.openSource.links.org"), href: "https://github.com/airnub", external: true },
+        { label: footer("columns.openSource.links.speckit"), href: "https://github.com/airnub/speckit", external: true },
+        { label: footer("columns.openSource.links.templates"), href: "https://github.com/airnub/landing-zones", external: true },
+      ],
+    },
+    {
+      heading: footer("columns.trust.heading"),
+      links: [
+        { label: footer("columns.trust.links.trustCenter"), href: "https://trust.airnub.io", external: true },
+        { label: footer("columns.trust.links.vdp"), href: "https://trust.airnub.io/vdp", external: true },
+        { label: footer("columns.trust.links.securityTxt"), href: "https://trust.airnub.io/.well-known/security.txt", external: true },
+      ],
+    },
+    {
+      heading: footer("columns.company.heading"),
+      links: [
+        { label: footer("columns.company.links.about"), href: "/company" },
+        { label: footer("columns.company.links.careers"), href: "/company#careers" },
+        { label: footer("columns.company.links.press"), href: "/company#press" },
+        { label: footer("columns.company.links.legal"), href: "/company#legal" },
+      ],
+    },
+  ];
+
+  const footerBottomLinks = [
+    { label: footer("bottom.privacy"), href: "/company#privacy" },
+    { label: footer("bottom.terms"), href: "/company#terms" },
+    { label: footer("bottom.email"), href: "mailto:hello@airnub.io" },
   ];
 
   const maintenanceEnabled = await isMaintenanceModeEnabled();
@@ -142,7 +191,7 @@ export default async function LocaleLayout({
                   {children}
                 </MaintenanceGate>
               </main>
-              <FooterAirnub pathPrefix={`/${locale}`} />
+              <FooterAirnub pathPrefix={`/${locale}`} columns={footerColumns} bottomLinks={footerBottomLinks} />
             </ToastProvider>
           </ThemeProvider>
         </NextIntlClientProvider>

--- a/apps/airnub/messages/de.json
+++ b/apps/airnub/messages/de.json
@@ -45,6 +45,54 @@
     "company": "Unternehmen",
     "contact": "Kontakt"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Produkte",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Ressourcen",
+        "links": {
+          "docs": "Dokumentation",
+          "blog": "Blog",
+          "changelog": "Änderungsprotokoll"
+        }
+      },
+      "openSource": {
+        "heading": "Open Source",
+        "links": {
+          "org": "GitHub-Organisation",
+          "speckit": "Speckit",
+          "templates": "Infrastrukturvorlagen"
+        }
+      },
+      "trust": {
+        "heading": "Vertrauen",
+        "links": {
+          "trustCenter": "Trust Center",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Unternehmen",
+        "links": {
+          "about": "Über uns",
+          "careers": "Karriere",
+          "press": "Presse",
+          "legal": "Rechtliches"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Datenschutz",
+      "terms": "Bedingungen",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Airnub entwickelt gesteuerte, unternehmensreife Entwicklerplattformen.",

--- a/apps/airnub/messages/en-GB.json
+++ b/apps/airnub/messages/en-GB.json
@@ -45,6 +45,54 @@
     "company": "Company",
     "contact": "Contact"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Products",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Resources",
+        "links": {
+          "docs": "Docs",
+          "blog": "Blog",
+          "changelog": "Changelog"
+        }
+      },
+      "openSource": {
+        "heading": "Open Source",
+        "links": {
+          "org": "GitHub org",
+          "speckit": "Speckit",
+          "templates": "Infrastructure templates"
+        }
+      },
+      "trust": {
+        "heading": "Trust",
+        "links": {
+          "trustCenter": "Trust Centre",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Company",
+        "links": {
+          "about": "About",
+          "careers": "Careers",
+          "press": "Press",
+          "legal": "Legal"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Privacy",
+      "terms": "Terms",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Airnub builds governed, enterprise-ready developer platforms.",

--- a/apps/airnub/messages/en-US.json
+++ b/apps/airnub/messages/en-US.json
@@ -45,6 +45,54 @@
     "company": "Company",
     "contact": "Contact"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Products",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Resources",
+        "links": {
+          "docs": "Docs",
+          "blog": "Blog",
+          "changelog": "Changelog"
+        }
+      },
+      "openSource": {
+        "heading": "Open Source",
+        "links": {
+          "org": "GitHub org",
+          "speckit": "Speckit",
+          "templates": "Infrastructure templates"
+        }
+      },
+      "trust": {
+        "heading": "Trust",
+        "links": {
+          "trustCenter": "Trust Center",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Company",
+        "links": {
+          "about": "About",
+          "careers": "Careers",
+          "press": "Press",
+          "legal": "Legal"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Privacy",
+      "terms": "Terms",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Airnub builds governed, enterprise-ready developer platforms.",

--- a/apps/airnub/messages/es.json
+++ b/apps/airnub/messages/es.json
@@ -45,6 +45,54 @@
     "company": "Empresa",
     "contact": "Contacto"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Productos",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Recursos",
+        "links": {
+          "docs": "Documentación",
+          "blog": "Blog",
+          "changelog": "Registro de cambios"
+        }
+      },
+      "openSource": {
+        "heading": "Código abierto",
+        "links": {
+          "org": "Organización de GitHub",
+          "speckit": "Speckit",
+          "templates": "Plantillas de infraestructura"
+        }
+      },
+      "trust": {
+        "heading": "Confianza",
+        "links": {
+          "trustCenter": "Centro de confianza",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Empresa",
+        "links": {
+          "about": "Acerca de",
+          "careers": "Carreras",
+          "press": "Prensa",
+          "legal": "Legal"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Privacidad",
+      "terms": "Términos",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Airnub crea plataformas de desarrolladores gobernadas y listas para la empresa.",

--- a/apps/airnub/messages/fr.json
+++ b/apps/airnub/messages/fr.json
@@ -45,6 +45,54 @@
     "company": "Entreprise",
     "contact": "Contact"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Produits",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Ressources",
+        "links": {
+          "docs": "Documentation",
+          "blog": "Blog",
+          "changelog": "Journal des modifications"
+        }
+      },
+      "openSource": {
+        "heading": "Open source",
+        "links": {
+          "org": "Organisation GitHub",
+          "speckit": "Speckit",
+          "templates": "Modèles d'infrastructure"
+        }
+      },
+      "trust": {
+        "heading": "Confiance",
+        "links": {
+          "trustCenter": "Centre de confiance",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Entreprise",
+        "links": {
+          "about": "À propos",
+          "careers": "Carrières",
+          "press": "Presse",
+          "legal": "Juridique"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Confidentialité",
+      "terms": "Conditions",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Airnub conçoit des plateformes développeurs gouvernées et prêtes pour l'entreprise.",

--- a/apps/airnub/messages/ga.json
+++ b/apps/airnub/messages/ga.json
@@ -45,6 +45,54 @@
     "company": "Cuideachta",
     "contact": "Teagmháil"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Táirgí",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Acmhainní",
+        "links": {
+          "docs": "Doiciméadú",
+          "blog": "Blag",
+          "changelog": "Log athruithe"
+        }
+      },
+      "openSource": {
+        "heading": "Foinse oscailte",
+        "links": {
+          "org": "Eagras GitHub",
+          "speckit": "Speckit",
+          "templates": "Teimpléid bonneagair"
+        }
+      },
+      "trust": {
+        "heading": "Iontaobhas",
+        "links": {
+          "trustCenter": "Lárionad iontaobhais",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Cuideachta",
+        "links": {
+          "about": "Fúinn",
+          "careers": "Gairmeacha",
+          "press": "Preas",
+          "legal": "Dlí"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Príobháideachas",
+      "terms": "Téarmaí",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Tógann Airnub ardáin forbróirí rialaithe atá réidh don fhiontar.",

--- a/apps/airnub/messages/it.json
+++ b/apps/airnub/messages/it.json
@@ -45,6 +45,54 @@
     "company": "Azienda",
     "contact": "Contatti"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Prodotti",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Risorse",
+        "links": {
+          "docs": "Documentazione",
+          "blog": "Blog",
+          "changelog": "Registro modifiche"
+        }
+      },
+      "openSource": {
+        "heading": "Open source",
+        "links": {
+          "org": "Organizzazione GitHub",
+          "speckit": "Speckit",
+          "templates": "Modelli di infrastruttura"
+        }
+      },
+      "trust": {
+        "heading": "Fiducia",
+        "links": {
+          "trustCenter": "Centro di fiducia",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Azienda",
+        "links": {
+          "about": "Chi siamo",
+          "careers": "Carriere",
+          "press": "Stampa",
+          "legal": "Legale"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Privacy",
+      "terms": "Termini",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "Airnub crea piattaforme per sviluppatori governate e pronte per l'azienda.",

--- a/apps/airnub/messages/pt.json
+++ b/apps/airnub/messages/pt.json
@@ -45,6 +45,54 @@
     "company": "Empresa",
     "contact": "Contacto"
   },
+  "footer": {
+    "columns": {
+      "products": {
+        "heading": "Produtos",
+        "links": {
+          "speckit": "Speckit"
+        }
+      },
+      "resources": {
+        "heading": "Recursos",
+        "links": {
+          "docs": "Documentação",
+          "blog": "Blog",
+          "changelog": "Registo de alterações"
+        }
+      },
+      "openSource": {
+        "heading": "Código aberto",
+        "links": {
+          "org": "Organização GitHub",
+          "speckit": "Speckit",
+          "templates": "Modelos de infraestrutura"
+        }
+      },
+      "trust": {
+        "heading": "Confiança",
+        "links": {
+          "trustCenter": "Centro de confiança",
+          "vdp": "VDP",
+          "securityTxt": "security.txt"
+        }
+      },
+      "company": {
+        "heading": "Empresa",
+        "links": {
+          "about": "Sobre",
+          "careers": "Carreiras",
+          "press": "Imprensa",
+          "legal": "Jurídico"
+        }
+      }
+    },
+    "bottom": {
+      "privacy": "Privacidade",
+      "terms": "Termos",
+      "email": "hello@airnub.io"
+    }
+  },
   "home": {
     "hero": {
       "eyebrow": "A Airnub cria plataformas governadas e prontas para empresas.",

--- a/apps/speckit/app/contact/page.tsx
+++ b/apps/speckit/app/contact/page.tsx
@@ -13,21 +13,21 @@ export const metadata: Metadata = {
 function ContactShortcuts() {
   return (
     <div className="space-y-6">
-      <div className="rounded-3xl border border-white/10 bg-white/10 p-6 shadow-lg">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Email</h3>
-        <p className="mt-2 text-sm text-slate-200">
-          Product questions: <a className="text-indigo-300" href="mailto:speckit@airnub.io">speckit@airnub.io</a>
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-white/10 dark:bg-white/10">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Email</h3>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">
+          Product questions: <a className="text-indigo-600 dark:text-indigo-300" href="mailto:speckit@airnub.io">speckit@airnub.io</a>
         </p>
-        <p className="mt-1 text-sm text-slate-200">
-          Security: <a className="text-indigo-300" href="mailto:security@airnub.io">security@airnub.io</a>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-200">
+          Security: <a className="text-indigo-600 dark:text-indigo-300" href="mailto:security@airnub.io">security@airnub.io</a>
         </p>
       </div>
-      <div className="rounded-3xl border border-white/10 bg-white/10 p-6 shadow-lg">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Docs</h3>
-        <p className="mt-2 text-sm text-slate-200">Explore API references and implementation guides.</p>
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-white/10 dark:bg-white/10">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Docs</h3>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">Explore API references and implementation guides.</p>
         <a
           href="https://docs.speckit.dev"
-          className="mt-3 inline-flex text-sm font-semibold text-indigo-300"
+          className="mt-3 inline-flex text-sm font-semibold text-indigo-600 transition hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
           target="_blank"
           rel="noreferrer"
         >
@@ -49,13 +49,13 @@ export default function ContactPage() {
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
-          <div className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
-            <h2 className="text-xl font-semibold text-white">Request a demo</h2>
-            <p className="mt-3 text-sm text-slate-300">Tell us about your environment and target launch timeline.</p>
+          <div className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Request a demo</h2>
+            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">Tell us about your environment and target launch timeline.</p>
             <form action={submitLead} className="mt-8 space-y-6">
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
-                  <label htmlFor="full_name" className="block text-sm font-semibold text-slate-100">
+                  <label htmlFor="full_name" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
                     Full name
                   </label>
                   <input
@@ -63,11 +63,11 @@ export default function ContactPage() {
                     name="full_name"
                     type="text"
                     autoComplete="name"
-                    className="mt-2 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
                   />
                 </div>
                 <div>
-                  <label htmlFor="email" className="block text-sm font-semibold text-slate-100">
+                  <label htmlFor="email" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
                     Work email <span className="text-rose-400">*</span>
                   </label>
                   <input
@@ -76,13 +76,13 @@ export default function ContactPage() {
                     type="email"
                     required
                     autoComplete="email"
-                    className="mt-2 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
                   />
                 </div>
               </div>
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
-                  <label htmlFor="company" className="block text-sm font-semibold text-slate-100">
+                  <label htmlFor="company" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
                     Company
                   </label>
                   <input
@@ -90,18 +90,18 @@ export default function ContactPage() {
                     name="company"
                     type="text"
                     autoComplete="organization"
-                    className="mt-2 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
                   />
                 </div>
                 <div>
-                  <label htmlFor="message" className="block text-sm font-semibold text-slate-100">
+                  <label htmlFor="message" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
                     What should we focus on?
                   </label>
                   <textarea
                     id="message"
                     name="message"
                     rows={4}
-                    className="mt-2 w-full rounded-xl border border-white/10 bg-white/10 px-3 py-2 text-sm text-white shadow-sm placeholder:text-slate-400 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
                   />
                 </div>
               </div>

--- a/apps/speckit/app/how-it-works/page.tsx
+++ b/apps/speckit/app/how-it-works/page.tsx
@@ -51,22 +51,30 @@ export default function HowItWorksPage() {
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {stages.map((stage, index) => (
-            <div key={stage.name} className="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-lg">
-              <span className="text-xs font-semibold uppercase tracking-wide text-indigo-300">Step {index + 1}</span>
-              <h2 className="mt-4 text-xl font-semibold text-white">{stage.name}</h2>
-              <p className="mt-3 text-sm text-slate-300">{stage.description}</p>
+            <div
+              key={stage.name}
+              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+            >
+              <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
+                Step {index + 1}
+              </span>
+              <h2 className="mt-4 text-xl font-semibold text-slate-900 dark:text-white">{stage.name}</h2>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{stage.description}</p>
             </div>
           ))}
         </Container>
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
+        <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
           <div className="grid gap-8 lg:grid-cols-3">
             {audiences.map((audience) => (
-              <div key={audience.role} className="rounded-2xl border border-white/10 bg-slate-950/40 p-6">
-                <h3 className="text-lg font-semibold text-white">{audience.role}</h3>
-                <p className="mt-3 text-sm text-slate-300">{audience.value}</p>
+              <div
+                key={audience.role}
+                className="rounded-2xl border border-slate-200 bg-slate-50 p-6 dark:border-white/10 dark:bg-slate-950/40"
+              >
+                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{audience.role}</h3>
+                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{audience.value}</p>
               </div>
             ))}
           </div>
@@ -74,12 +82,12 @@ export default function HowItWorksPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-10 shadow-xl">
-          <h2 className="text-3xl font-semibold text-white">Bring your own tooling</h2>
-          <p className="mt-4 text-sm text-slate-300">
+        <Container className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100 p-10 shadow-xl dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
+          <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">Bring your own tooling</h2>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
             Speckit integrates via webhooks, REST APIs, and SDKs. Use our Supabase adapters to sync data across environments with RLS intact.
           </p>
-          <ul className="mt-6 grid gap-4 text-sm text-slate-200 md:grid-cols-2">
+          <ul className="mt-6 grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-2">
             <li>→ GitHub Actions, CircleCI, GitLab pipelines</li>
             <li>→ Terraform, Pulumi, CloudFormation</li>
             <li>→ ServiceNow, Jira, Linear workflow updates</li>

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
-import { FooterSpeckit, HeaderSpeckit, ThemeProvider } from "@airnub/ui";
+import { FooterSpeckit, HeaderSpeckit, ThemeProvider, type FooterColumn } from "@airnub/ui";
 import { JsonLd } from "../components/JsonLd";
 import { buildSpeckitSoftwareJsonLd } from "../lib/jsonld";
 import { SPECKIT_BASE_URL } from "../lib/routes";
@@ -52,6 +52,43 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   const language = await getCurrentLanguage();
   const messages = getSpeckitMessages(language);
   const layoutMessages = messages.layout;
+  const footerMessages = layoutMessages.footer;
+
+  const footerColumns: FooterColumn[] = [
+    {
+      heading: footerMessages.columns.product.heading,
+      links: [
+        { label: footerMessages.columns.product.overview, href: "/" },
+        { label: footerMessages.columns.product.howItWorks, href: "/how-it-works" },
+        { label: footerMessages.columns.product.integrations, href: "/product#integrations" },
+      ],
+    },
+    {
+      heading: footerMessages.columns.resources.heading,
+      links: [
+        { label: footerMessages.columns.resources.docs, href: "https://docs.speckit.dev", external: true },
+        { label: footerMessages.columns.resources.apiReference, href: "https://docs.speckit.dev/api", external: true },
+        { label: footerMessages.columns.resources.community, href: "https://github.com/airnub/speckit/discussions", external: true },
+      ],
+    },
+    {
+      heading: footerMessages.columns.openSource.heading,
+      links: [
+        { label: footerMessages.columns.openSource.repo, href: "https://github.com/airnub/speckit", external: true },
+        { label: footerMessages.columns.openSource.templates, href: "https://github.com/airnub/speckit-templates", external: true },
+        { label: footerMessages.columns.openSource.issues, href: "https://github.com/airnub/speckit/issues", external: true },
+        { label: footerMessages.columns.openSource.license, href: "https://github.com/airnub/speckit/blob/main/LICENSE", external: true },
+      ],
+    },
+    {
+      heading: footerMessages.columns.trust.heading,
+      links: [
+        { label: footerMessages.columns.trust.trustCenter, href: "https://trust.airnub.io", external: true },
+        { label: footerMessages.columns.trust.status, href: "https://status.airnub.io", external: true },
+        { label: footerMessages.columns.trust.securityTxt, href: "https://trust.airnub.io/.well-known/security.txt", external: true },
+      ],
+    },
+  ];
 
   return (
     <html
@@ -81,7 +118,12 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
           <main id="content" className="flex-1">
             {children}
           </main>
-          <FooterSpeckit />
+          <FooterSpeckit
+            columns={footerColumns}
+            contactLabel={footerMessages.contact.label}
+            pricingLabel={footerMessages.contact.pricing}
+            pricingHref="/pricing"
+          />
         </ThemeProvider>
       </body>
     </html>

--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -39,9 +39,12 @@ export default async function SpeckitHome() {
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {home.features.map((feature) => (
-            <div key={feature.title} className="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-lg">
-              <h3 className="text-xl font-semibold text-white">{feature.title}</h3>
-              <p className="mt-3 text-sm text-slate-300">{feature.description}</p>
+            <div
+              key={feature.title}
+              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+            >
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{feature.title}</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
             </div>
           ))}
         </Container>
@@ -50,25 +53,30 @@ export default async function SpeckitHome() {
       <section>
         <Container className="grid gap-12 lg:grid-cols-[3fr,2fr] lg:items-center">
           <div>
-            <h2 className="text-3xl font-semibold text-white">{home.workflows.title}</h2>
-            <p className="mt-4 text-base text-slate-300">{home.workflows.description}</p>
+            <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{home.workflows.title}</h2>
+            <p className="mt-4 text-base text-slate-600 dark:text-slate-300">{home.workflows.description}</p>
             <div className="mt-6 grid gap-4">
               {home.workflows.items.map((workflow) => (
-                <div key={workflow.name} className="rounded-2xl border border-white/10 bg-white/5 p-4">
-                  <h3 className="text-lg font-semibold text-white">{workflow.name}</h3>
-                  <p className="mt-2 text-sm text-slate-300">{workflow.description}</p>
+                <div
+                  key={workflow.name}
+                  className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-white/10 dark:bg-white/5"
+                >
+                  <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{workflow.name}</h3>
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{workflow.description}</p>
                 </div>
               ))}
             </div>
           </div>
-          <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6">
-            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.25),_transparent_55%)]" aria-hidden="true" />
-            <div className="relative space-y-6 text-sm text-slate-200">
+          <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 dark:border-white/10 dark:bg-white/5">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.15),_transparent_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.25),_transparent_55%)]" aria-hidden="true" />
+            <div className="relative space-y-6 text-sm text-slate-700 dark:text-slate-200">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-indigo-300">{home.guardrails.cardTitle}</p>
-                <div className="mt-3 rounded-2xl border border-white/10 bg-slate-950/60 p-4">
-                  <p className="font-semibold text-white">{home.guardrails.specTitle}</p>
-                  <ul className="mt-3 space-y-2 text-xs text-slate-300">
+                <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
+                  {home.guardrails.cardTitle}
+                </p>
+                <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/60">
+                  <p className="font-semibold text-slate-900 dark:text-white">{home.guardrails.specTitle}</p>
+                  <ul className="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
                     {home.guardrails.checklist.map((item) => (
                       <li key={item}>{item}</li>
                     ))}
@@ -76,12 +84,17 @@ export default async function SpeckitHome() {
                 </div>
               </div>
               <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-indigo-300">{home.guardrails.evidenceTitle}</p>
-                <div className="mt-3 space-y-2 text-xs text-slate-200">
+                <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
+                  {home.guardrails.evidenceTitle}
+                </p>
+                <div className="mt-3 space-y-2 text-xs text-slate-700 dark:text-slate-200">
                   {home.guardrails.evidence.map((item) => (
-                    <div key={item.label} className="flex items-center justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+                    <div
+                      key={item.label}
+                      className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-white/10 dark:bg-white/5"
+                    >
                       <span>{item.label}</span>
-                      <span className="text-indigo-300">{item.status}</span>
+                      <span className="text-indigo-600 dark:text-indigo-300">{item.status}</span>
                     </div>
                   ))}
                 </div>
@@ -92,11 +105,11 @@ export default async function SpeckitHome() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
+        <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
           <div className="grid gap-10 lg:grid-cols-[2fr,3fr] lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold text-white">{home.alignment.title}</h2>
-              <p className="mt-4 text-base text-slate-200">{home.alignment.description}</p>
+              <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{home.alignment.title}</h2>
+              <p className="mt-4 text-base text-slate-600 dark:text-slate-200">{home.alignment.description}</p>
               <div className="mt-6 flex flex-wrap gap-4">
                 <Button variant="ghost" asChild>
                   <Link href="/how-it-works">{home.alignment.actions.howItWorks}</Link>
@@ -108,9 +121,12 @@ export default async function SpeckitHome() {
             </div>
             <div className="grid gap-4 md:grid-cols-2">
               {home.alignment.cards.map((card) => (
-                <div key={card.title} className="rounded-2xl border border-white/10 bg-slate-950/40 p-6">
-                  <h3 className="text-lg font-semibold text-white">{card.title}</h3>
-                  <p className="mt-2 text-sm text-slate-300">{card.description}</p>
+                <div
+                  key={card.title}
+                  className="rounded-2xl border border-slate-200 bg-slate-50 p-6 dark:border-white/10 dark:bg-slate-950/40"
+                >
+                  <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{card.title}</h3>
+                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{card.description}</p>
                 </div>
               ))}
             </div>
@@ -120,11 +136,16 @@ export default async function SpeckitHome() {
 
       <section>
         <Container className="text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-indigo-300">{home.integrations.eyebrow}</p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-slate-300">
+          <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
+            {home.integrations.eyebrow}
+          </p>
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-slate-600 dark:text-slate-300">
             {home.integrations.items.map((logo) => (
-              <div key={logo} className="flex h-16 w-36 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
-                <span className="text-sm font-semibold text-slate-200">{logo}</span>
+              <div
+                key={logo}
+                className="flex h-16 w-36 items-center justify-center rounded-2xl border border-slate-200 bg-white dark:border-white/10 dark:bg-white/5"
+              >
+                <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{logo}</span>
               </div>
             ))}
           </div>

--- a/apps/speckit/app/pricing/page.tsx
+++ b/apps/speckit/app/pricing/page.tsx
@@ -44,12 +44,15 @@ export default function PricingPage() {
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {tiers.map((tier) => (
-            <div key={tier.name} className="flex h-full flex-col rounded-3xl border border-white/10 bg-white/10 p-8 shadow-lg">
+            <div
+              key={tier.name}
+              className="flex h-full flex-col rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+            >
               <div className="flex-1">
-                <h2 className="text-2xl font-semibold text-white">{tier.name}</h2>
-                <p className="mt-3 text-lg font-semibold text-indigo-300">{tier.price}</p>
-                <p className="mt-3 text-sm text-slate-300">{tier.description}</p>
-                <ul className="mt-4 space-y-2 text-sm text-slate-200">
+                <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{tier.name}</h2>
+                <p className="mt-3 text-lg font-semibold text-indigo-600 dark:text-indigo-300">{tier.price}</p>
+                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{tier.description}</p>
+                <ul className="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate-200">
                   {tier.highlights.map((highlight) => (
                     <li key={highlight}>→ {highlight}</li>
                   ))}

--- a/apps/speckit/app/product/page.tsx
+++ b/apps/speckit/app/product/page.tsx
@@ -50,9 +50,12 @@ export default function ProductPage() {
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {pillars.map((pillar) => (
-            <div key={pillar.title} className="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-lg">
-              <h2 className="text-2xl font-semibold text-white">{pillar.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{pillar.description}</p>
+            <div
+              key={pillar.title}
+              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+            >
+              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{pillar.title}</h2>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{pillar.description}</p>
             </div>
           ))}
         </Container>
@@ -60,43 +63,46 @@ export default function ProductPage() {
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-start">
-          <div className="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-xl">
-            <h2 className="text-2xl font-semibold text-white">Speckit timeline</h2>
-            <ol className="mt-6 space-y-6 text-sm text-slate-300">
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl dark:border-white/10 dark:bg-white/10">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Speckit timeline</h2>
+            <ol className="mt-6 space-y-6 text-sm text-slate-600 dark:text-slate-300">
               <li>
-                <div className="font-semibold text-white">1. Spec kickoff</div>
+                <div className="font-semibold text-slate-900 dark:text-white">1. Spec kickoff</div>
                 <p className="mt-1">Start with a versioned spec linked to code. Assign approvers and risk posture.</p>
               </li>
               <li>
-                <div className="font-semibold text-white">2. Policy orchestration</div>
+                <div className="font-semibold text-slate-900 dark:text-white">2. Policy orchestration</div>
                 <p className="mt-1">Controls run across CI, IaC, and runtime. Exceptions are documented and routed for review.</p>
               </li>
               <li>
-                <div className="font-semibold text-white">3. Evidence stream</div>
+                <div className="font-semibold text-slate-900 dark:text-white">3. Evidence stream</div>
                 <p className="mt-1">SBOMs, attestations, and control proofs sync to Supabase, GRC tools, and customer portals.</p>
               </li>
             </ol>
           </div>
           <div className="space-y-8">
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-8">
-              <h3 className="text-xl font-semibold text-white">Integrations that meet you where you work</h3>
-              <p className="mt-3 text-sm text-slate-300">
+            <div className="rounded-3xl border border-slate-200 bg-white p-8 dark:border-white/10 dark:bg-white/5">
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Integrations that meet you where you work</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
                 Use Speckit UI, CLI, or APIs. Bring your own secrets manager, ticketing, and observability stack.
               </p>
-              <div className="mt-6 flex flex-wrap gap-3 text-xs text-slate-200">
+              <div className="mt-6 flex flex-wrap gap-3 text-xs text-slate-700 dark:text-slate-200">
                 {integrations.map((integration) => (
-                  <span key={integration} className="rounded-full border border-white/10 bg-white/5 px-4 py-2">
+                  <span
+                    key={integration}
+                    className="rounded-full border border-slate-200 bg-white px-4 py-2 dark:border-white/10 dark:bg-white/5"
+                  >
                     {integration}
                   </span>
                 ))}
               </div>
             </div>
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-8">
-              <h3 className="text-xl font-semibold text-white">Shared Supabase data core</h3>
-              <p className="mt-3 text-sm text-slate-300">
+            <div className="rounded-3xl border border-slate-200 bg-white p-8 dark:border-white/10 dark:bg-white/5">
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Shared Supabase data core</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
                 Marketing and product forms feed one Supabase project. Row-level security keeps leads private while your GTM and product teams analyze performance.
               </p>
-              <p className="mt-3 text-sm text-slate-300">
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
                 Use the service role to sync Speckit evidence to your data warehouse or customer trust portal with confidence.
               </p>
             </div>

--- a/apps/speckit/app/solutions/page.tsx
+++ b/apps/speckit/app/solutions/page.tsx
@@ -38,11 +38,13 @@ export default function SolutionsOverviewPage() {
             <Link
               key={persona.title}
               href={persona.href}
-              className="group rounded-3xl border border-white/10 bg-white/10 p-8 text-left shadow-lg transition hover:border-indigo-300"
+              className="group rounded-3xl border border-slate-200 bg-white p-8 text-left shadow-lg transition hover:border-indigo-500 dark:border-white/10 dark:bg-white/10"
             >
-              <h2 className="text-2xl font-semibold text-white">{persona.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{persona.description}</p>
-              <span className="mt-6 inline-flex text-sm font-semibold text-indigo-300">Explore →</span>
+              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{persona.title}</h2>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{persona.description}</p>
+              <span className="mt-6 inline-flex text-sm font-semibold text-indigo-600 transition group-hover:text-indigo-700 dark:text-indigo-300 dark:group-hover:text-indigo-200">
+                Explore →
+              </span>
             </Link>
           ))}
         </Container>

--- a/apps/speckit/app/template/page.tsx
+++ b/apps/speckit/app/template/page.tsx
@@ -51,9 +51,12 @@ export default function TemplatePage() {
       <section>
         <Container className="grid gap-6 md:grid-cols-2">
           {steps.map((step) => (
-            <div key={step.title} className="rounded-3xl border border-white/10 bg-white/10 p-8 shadow-lg">
-              <h2 className="text-xl font-semibold text-white">{step.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{step.description}</p>
+            <div
+              key={step.title}
+              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+            >
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{step.title}</h2>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
             </div>
           ))}
         </Container>

--- a/apps/speckit/components/PageHero.tsx
+++ b/apps/speckit/components/PageHero.tsx
@@ -16,16 +16,23 @@ export function PageHero({
   className?: string;
 }) {
   return (
-    <section className={clsx("relative overflow-hidden border-b border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-16", className)}>
-      <div className="absolute inset-0 opacity-40" aria-hidden="true">
-        <div className="h-full w-full bg-[radial-gradient(circle_at_top_right,_rgba(99,102,241,0.4),_transparent_45%)]" />
+    <section
+      className={clsx(
+        "relative overflow-hidden border-b border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100 py-16 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950",
+        className
+      )}
+    >
+      <div className="absolute inset-0 opacity-20 dark:opacity-40" aria-hidden="true">
+        <div className="h-full w-full bg-[radial-gradient(circle_at_top_right,_rgba(99,102,241,0.2),_transparent_45%)] dark:bg-[radial-gradient(circle_at_top_right,_rgba(99,102,241,0.4),_transparent_45%)]" />
       </div>
-      <Container className="relative max-w-4xl text-slate-100">
+      <Container className="relative max-w-4xl text-slate-900 dark:text-slate-100">
         {eyebrow ? (
-          <p className="text-sm font-semibold uppercase tracking-wide text-indigo-300">{eyebrow}</p>
+          <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">{eyebrow}</p>
         ) : null}
         <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">{title}</h1>
-        {description ? <p className="mt-6 text-lg text-slate-300">{description}</p> : null}
+        {description ? (
+          <p className="mt-6 text-lg text-slate-600 dark:text-slate-300">{description}</p>
+        ) : null}
         {actions ? <div className="mt-8 flex flex-wrap gap-4">{actions}</div> : null}
       </Container>
     </section>

--- a/apps/speckit/i18n/messages.ts
+++ b/apps/speckit/i18n/messages.ts
@@ -70,6 +70,39 @@ type LayoutMessages = {
   themeToggle: string;
   starLabel: string;
   languageLabel: string;
+  footer: {
+    columns: {
+      product: {
+        heading: string;
+        overview: string;
+        howItWorks: string;
+        integrations: string;
+      };
+      resources: {
+        heading: string;
+        docs: string;
+        apiReference: string;
+        community: string;
+      };
+      openSource: {
+        heading: string;
+        repo: string;
+        templates: string;
+        issues: string;
+        license: string;
+      };
+      trust: {
+        heading: string;
+        trustCenter: string;
+        status: string;
+        securityTxt: string;
+      };
+    };
+    contact: {
+      label: string;
+      pricing: string;
+    };
+  };
 };
 
 export type SpeckitMessages = {

--- a/apps/speckit/messages/de.json
+++ b/apps/speckit/messages/de.json
@@ -3,7 +3,40 @@
     "skipToContent": "Überspringen Sie zu Inhalten",
     "themeToggle": "Thema umschalten",
     "starLabel": "Sternprojekt",
-    "languageLabel": "Sprache"
+    "languageLabel": "Sprache",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Produkt",
+          "overview": "Überblick",
+          "howItWorks": "Funktionsweise",
+          "integrations": "Integrationen"
+        },
+        "resources": {
+          "heading": "Ressourcen",
+          "docs": "Dokumentation",
+          "apiReference": "API-Referenz",
+          "community": "Community"
+        },
+        "openSource": {
+          "heading": "Open Source",
+          "repo": "Repository",
+          "templates": "Vorlagen",
+          "issues": "Probleme",
+          "license": "Lizenz"
+        },
+        "trust": {
+          "heading": "Vertrauen",
+          "trustCenter": "Trust Center",
+          "status": "Status",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Preise"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/en-GB.json
+++ b/apps/speckit/messages/en-GB.json
@@ -3,7 +3,40 @@
     "skipToContent": "Skip to content",
     "themeToggle": "Toggle theme",
     "starLabel": "Star project",
-    "languageLabel": "Language"
+    "languageLabel": "Language",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Product",
+          "overview": "Overview",
+          "howItWorks": "How it works",
+          "integrations": "Integrations"
+        },
+        "resources": {
+          "heading": "Resources",
+          "docs": "Docs",
+          "apiReference": "API reference",
+          "community": "Community"
+        },
+        "openSource": {
+          "heading": "Open Source",
+          "repo": "Repo",
+          "templates": "Templates",
+          "issues": "Issues",
+          "license": "License"
+        },
+        "trust": {
+          "heading": "Trust",
+          "trustCenter": "Trust Centre",
+          "status": "Status",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Pricing"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/en-US.json
+++ b/apps/speckit/messages/en-US.json
@@ -3,7 +3,40 @@
     "skipToContent": "Skip to content",
     "themeToggle": "Toggle theme",
     "starLabel": "Star project",
-    "languageLabel": "Language"
+    "languageLabel": "Language",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Product",
+          "overview": "Overview",
+          "howItWorks": "How it works",
+          "integrations": "Integrations"
+        },
+        "resources": {
+          "heading": "Resources",
+          "docs": "Docs",
+          "apiReference": "API reference",
+          "community": "Community"
+        },
+        "openSource": {
+          "heading": "Open Source",
+          "repo": "Repo",
+          "templates": "Templates",
+          "issues": "Issues",
+          "license": "License"
+        },
+        "trust": {
+          "heading": "Trust",
+          "trustCenter": "Trust Center",
+          "status": "Status",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Pricing"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/es.json
+++ b/apps/speckit/messages/es.json
@@ -3,7 +3,40 @@
     "skipToContent": "Saltar al contenido",
     "themeToggle": "Tema de alternar",
     "starLabel": "Proyecto estrella",
-    "languageLabel": "Idioma"
+    "languageLabel": "Idioma",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Producto",
+          "overview": "Descripción general",
+          "howItWorks": "Cómo funciona",
+          "integrations": "Integraciones"
+        },
+        "resources": {
+          "heading": "Recursos",
+          "docs": "Documentación",
+          "apiReference": "Referencia de API",
+          "community": "Comunidad"
+        },
+        "openSource": {
+          "heading": "Código abierto",
+          "repo": "Repositorio",
+          "templates": "Plantillas",
+          "issues": "Incidencias",
+          "license": "Licencia"
+        },
+        "trust": {
+          "heading": "Confianza",
+          "trustCenter": "Centro de confianza",
+          "status": "Estado",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Precios"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/fr.json
+++ b/apps/speckit/messages/fr.json
@@ -3,7 +3,40 @@
     "skipToContent": "Passer au contenu",
     "themeToggle": "Thème de basculement",
     "starLabel": "Projet de star",
-    "languageLabel": "Langue"
+    "languageLabel": "Langue",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Produit",
+          "overview": "Aperçu",
+          "howItWorks": "Fonctionnement",
+          "integrations": "Intégrations"
+        },
+        "resources": {
+          "heading": "Ressources",
+          "docs": "Documentation",
+          "apiReference": "Référence API",
+          "community": "Communauté"
+        },
+        "openSource": {
+          "heading": "Open source",
+          "repo": "Dépôt",
+          "templates": "Modèles",
+          "issues": "Tickets",
+          "license": "Licence"
+        },
+        "trust": {
+          "heading": "Confiance",
+          "trustCenter": "Centre de confiance",
+          "status": "Statut",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Tarifs"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/ga.json
+++ b/apps/speckit/messages/ga.json
@@ -3,7 +3,40 @@
     "skipToContent": "Scipeáil chuig ábhar",
     "themeToggle": "Téama toggle",
     "starLabel": "Tionscadal réalta",
-    "languageLabel": "Teanga"
+    "languageLabel": "Teanga",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Táirge",
+          "overview": "Forbhreathnú",
+          "howItWorks": "Conas a oibríonn sé",
+          "integrations": "Comhtháthuithe"
+        },
+        "resources": {
+          "heading": "Acmhainní",
+          "docs": "Doiciméadú",
+          "apiReference": "Tagairt API",
+          "community": "Pobal"
+        },
+        "openSource": {
+          "heading": "Foinse oscailte",
+          "repo": "Stórlann",
+          "templates": "Teimpléid",
+          "issues": "Ceisteanna",
+          "license": "Ceadúnas"
+        },
+        "trust": {
+          "heading": "Muinín",
+          "trustCenter": "Lárionad muiníne",
+          "status": "Stádas",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Praghsanna"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/it.json
+++ b/apps/speckit/messages/it.json
@@ -3,7 +3,40 @@
     "skipToContent": "Salta al contenuto",
     "themeToggle": "Attiva tema",
     "starLabel": "Progetto stellare",
-    "languageLabel": "Lingua"
+    "languageLabel": "Lingua",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Prodotto",
+          "overview": "Panoramica",
+          "howItWorks": "Come funziona",
+          "integrations": "Integrazioni"
+        },
+        "resources": {
+          "heading": "Risorse",
+          "docs": "Documentazione",
+          "apiReference": "Riferimento API",
+          "community": "Comunità"
+        },
+        "openSource": {
+          "heading": "Open source",
+          "repo": "Repository",
+          "templates": "Modelli",
+          "issues": "Segnalazioni",
+          "license": "Licenza"
+        },
+        "trust": {
+          "heading": "Fiducia",
+          "trustCenter": "Centro di fiducia",
+          "status": "Stato",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Prezzi"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/apps/speckit/messages/pt.json
+++ b/apps/speckit/messages/pt.json
@@ -3,7 +3,40 @@
     "skipToContent": "Pule para o conteúdo",
     "themeToggle": "Tema de alternância",
     "starLabel": "Projeto Star",
-    "languageLabel": "Linguagem"
+    "languageLabel": "Linguagem",
+    "footer": {
+      "columns": {
+        "product": {
+          "heading": "Produto",
+          "overview": "Visão geral",
+          "howItWorks": "Como funciona",
+          "integrations": "Integrações"
+        },
+        "resources": {
+          "heading": "Recursos",
+          "docs": "Documentação",
+          "apiReference": "Referência da API",
+          "community": "Comunidade"
+        },
+        "openSource": {
+          "heading": "Código aberto",
+          "repo": "Repositório",
+          "templates": "Modelos",
+          "issues": "Problemas",
+          "license": "Licença"
+        },
+        "trust": {
+          "heading": "Confiança",
+          "trustCenter": "Centro de confiança",
+          "status": "Status",
+          "securityTxt": "security.txt"
+        }
+      },
+      "contact": {
+        "label": "speckit@airnub.io",
+        "pricing": "Preços"
+      }
+    }
   },
   "home": {
     "hero": {

--- a/packages/ui/src/FooterAirnub.tsx
+++ b/packages/ui/src/FooterAirnub.tsx
@@ -3,7 +3,7 @@ import { AirnubWordmark } from "@airnub/brand";
 import { Footer, type FooterProps, type FooterColumn } from "./Footer";
 import type { ReactNode } from "react";
 
-const footerColumns: FooterColumn[] = [
+const defaultFooterColumns: FooterColumn[] = [
   {
     heading: "Products",
     links: [{ label: "Speckit", href: "https://speckit.airnub.io", external: true }],
@@ -45,31 +45,59 @@ const footerColumns: FooterColumn[] = [
 
 type FooterAirnubProps = Omit<FooterProps, "logo" | "columns" | "bottomSlot" | "copyright"> & {
   bottomSlot?: ReactNode;
+  columns?: FooterColumn[];
+  bottomLinks?: { label: string; href: string; external?: boolean }[];
   copyrightPrefix?: string;
   pathPrefix?: string;
 };
 
-export function FooterAirnub({ bottomSlot, copyrightPrefix = "Airnub", pathPrefix = "", ...props }: FooterAirnubProps) {
+const defaultBottomLinks = [
+  { label: "Privacy", href: "/company#privacy" },
+  { label: "Terms", href: "/company#terms" },
+  { label: "hello@airnub.io", href: "mailto:hello@airnub.io" },
+];
+
+export function FooterAirnub({
+  bottomSlot,
+  columns = defaultFooterColumns,
+  bottomLinks = defaultBottomLinks,
+  copyrightPrefix = "Airnub",
+  pathPrefix = "",
+  ...props
+}: FooterAirnubProps) {
   const year = new Date().getFullYear();
   const withPrefix = (href: string) =>
     href.startsWith("/") ? `${pathPrefix}${href}`.replace(/\/+/g, "/") : href;
-  const columns = footerColumns.map((column) => ({
+  const resolvedColumns = columns.map((column) => ({
     ...column,
     links: column.links.map((link) => ({
       ...link,
       href: withPrefix(link.href),
     })),
   }));
+  const resolvedBottomLinks = bottomLinks.map((link) => ({
+    ...link,
+    href: withPrefix(link.href),
+  }));
   return (
     <Footer
       logo={<AirnubWordmark className="h-6" />}
-      columns={columns}
+      columns={resolvedColumns}
       bottomSlot={
         bottomSlot ?? (
-          <div className="flex items-center gap-3">
-            <Link href={withPrefix("/company#privacy")}>Privacy</Link>
-            <Link href={withPrefix("/company#terms")}>Terms</Link>
-            <Link href="mailto:hello@airnub.io">hello@airnub.io</Link>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-slate-500 dark:text-slate-400">
+            {resolvedBottomLinks.map((link, index) => (
+              <div key={`${link.href}-${link.label}`} className="flex items-center gap-3">
+                {index > 0 ? <span aria-hidden="true">•</span> : null}
+                <Link
+                  href={link.href}
+                  target={link.external ? "_blank" : undefined}
+                  rel={link.external ? "noreferrer" : undefined}
+                >
+                  {link.label}
+                </Link>
+              </div>
+            ))}
           </div>
         )
       }

--- a/packages/ui/src/FooterSpeckit.tsx
+++ b/packages/ui/src/FooterSpeckit.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { SpeckitWordmark } from "@airnub/brand";
 import { Footer, type FooterProps, type FooterColumn } from "./Footer";
 
-const footerColumns: FooterColumn[] = [
+const defaultFooterColumns: FooterColumn[] = [
   {
     heading: "Product",
     links: [
@@ -39,25 +39,31 @@ const footerColumns: FooterColumn[] = [
 ];
 
 type FooterSpeckitProps = Omit<FooterProps, "logo" | "columns" | "bottomSlot" | "copyright"> & {
+  columns?: FooterColumn[];
   contactHref?: string;
   contactLabel?: string;
+  pricingHref?: string;
+  pricingLabel?: string;
 };
 
 export function FooterSpeckit({
+  columns = defaultFooterColumns,
   contactHref = "mailto:speckit@airnub.io",
   contactLabel = "speckit@airnub.io",
+  pricingHref = "/pricing",
+  pricingLabel = "Pricing",
   ...props
 }: FooterSpeckitProps) {
   const year = new Date().getFullYear();
   return (
     <Footer
       logo={<SpeckitWordmark className="h-6" />}
-      columns={footerColumns}
+      columns={columns}
       bottomSlot={
-        <div className="flex items-center gap-3 text-slate-400">
+        <div className="flex items-center gap-3 text-slate-500 dark:text-slate-400">
           <Link href={contactHref}>{contactLabel}</Link>
           <span aria-hidden="true">•</span>
-          <Link href="/pricing">Pricing</Link>
+          <Link href={pricingHref}>{pricingLabel}</Link>
         </div>
       }
       copyright={`© ${year} Airnub. All rights reserved.`}


### PR DESCRIPTION
## Summary
- refresh Speckit hero, sections, and form styling to render legibly in both light and dark themes
- source Speckit footer content from the locale messages and extend the footer component to accept localized data
- add localized footer copy for the Airnub app and enhance the shared footer to consume translated columns and links

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9bb2ccf9883249ace2cd5d827d619