### PR TITLE
feat: unify speckit internationalization and header

### DIFF
--- a/apps/speckit/app/contact/page.tsx
+++ b/apps/speckit/app/contact/page.tsx
@@ -1,62 +1,75 @@
 import type { Metadata } from "next";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
+import { getCurrentLanguage } from "../../lib/language";
+import { getSpeckitMessages, type SpeckitMessages } from "../../i18n/messages";
 import { submitLead } from "./actions";
 
-export const revalidate = 86_400;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Contact",
-  description: "Request a Speckit demo or talk to our product specialists.",
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const contact = getSpeckitMessages(language).contact;
+  return {
+    title: contact.hero.title,
+    description: contact.hero.description,
+  };
+}
+
+type ContactShortcutsProps = {
+  shortcuts: SpeckitMessages["contact"]["shortcuts"];
 };
 
-function ContactShortcuts() {
+function ContactShortcuts({ shortcuts }: ContactShortcutsProps) {
   return (
     <div className="space-y-6">
       <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-white/10 dark:bg-white/10">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Email</h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">
-          Product questions: <a className="text-indigo-600 dark:text-indigo-300" href="mailto:speckit@airnub.io">speckit@airnub.io</a>
-        </p>
-        <p className="mt-1 text-sm text-slate-600 dark:text-slate-200">
-          Security: <a className="text-indigo-600 dark:text-indigo-300" href="mailto:security@airnub.io">security@airnub.io</a>
-        </p>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+          {shortcuts.emailHeading}
+        </h3>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">{shortcuts.productQuestions}</p>
+        <p className="mt-1 text-sm text-slate-600 dark:text-slate-200">{shortcuts.security}</p>
       </div>
       <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-white/10 dark:bg-white/10">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">Docs</h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">Explore API references and implementation guides.</p>
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+          {shortcuts.docsHeading}
+        </h3>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">{shortcuts.docsDescription}</p>
         <a
           href="https://docs.speckit.dev"
           className="mt-3 inline-flex text-sm font-semibold text-indigo-600 transition hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
           target="_blank"
           rel="noreferrer"
         >
-          docs.speckit.dev →
+          {shortcuts.docsCtaLabel}
         </a>
       </div>
     </div>
   );
 }
 
-export default function ContactPage() {
+export default async function ContactPage() {
+  const language = await getCurrentLanguage();
+  const contact = getSpeckitMessages(language).contact;
+
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="Contact"
-        title="See Speckit in action"
-        description="Share a bit about your platform program and we will tailor a walkthrough to your goals."
+        eyebrow={contact.hero.eyebrow}
+        title={contact.hero.title}
+        description={contact.hero.description}
       />
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
           <div className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Request a demo</h2>
-            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">Tell us about your environment and target launch timeline.</p>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{contact.form.title}</h2>
+            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{contact.form.description}</p>
             <form action={submitLead} className="mt-8 space-y-6">
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
                   <label htmlFor="full_name" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
-                    Full name
+                    {contact.form.fields.nameLabel}
                   </label>
                   <input
                     id="full_name"
@@ -68,7 +81,7 @@ export default function ContactPage() {
                 </div>
                 <div>
                   <label htmlFor="email" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
-                    Work email <span className="text-rose-400">*</span>
+                    {contact.form.fields.emailLabel} <span className="text-rose-400">{contact.form.fields.emailRequiredSuffix}</span>
                   </label>
                   <input
                     id="email"
@@ -83,7 +96,7 @@ export default function ContactPage() {
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
                   <label htmlFor="company" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
-                    Company
+                    {contact.form.fields.companyLabel}
                   </label>
                   <input
                     id="company"
@@ -95,7 +108,7 @@ export default function ContactPage() {
                 </div>
                 <div>
                   <label htmlFor="message" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
-                    What should we focus on?
+                    {contact.form.fields.focusLabel}
                   </label>
                   <textarea
                     id="message"
@@ -109,11 +122,11 @@ export default function ContactPage() {
                 type="submit"
                 className="inline-flex items-center rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400"
               >
-                Request demo
+                {contact.form.submitLabel}
               </button>
             </form>
           </div>
-          <ContactShortcuts />
+          <ContactShortcuts shortcuts={contact.shortcuts} />
         </Container>
       </section>
     </div>

--- a/apps/speckit/app/how-it-works/page.tsx
+++ b/apps/speckit/app/how-it-works/page.tsx
@@ -1,62 +1,41 @@
 import type { Metadata } from "next";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
+import { getCurrentLanguage } from "../../lib/language";
+import { getSpeckitMessages } from "../../i18n/messages";
 
-export const revalidate = 604_800;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "How it works",
-  description: "Understand the Speckit lifecycle from spec capture to evidence distribution.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const messages = getSpeckitMessages(language).howItWorks;
+  return {
+    title: messages.hero.title,
+    description: messages.hero.description,
+  };
+}
 
-const stages = [
-  {
-    name: "Capture",
-    description: "Specs start in Git-backed docs. Risk, controls, and approvers are defined at the beginning, not the end.",
-  },
-  {
-    name: "Orchestrate",
-    description: "Controls trigger across pipelines and environments. Exceptions kick off review workflows automatically.",
-  },
-  {
-    name: "Publish",
-    description: "Evidence lands where it is needed — Supabase, GRC tools, customer trust portals, and analytics stacks.",
-  },
-];
+export default async function HowItWorksPage() {
+  const language = await getCurrentLanguage();
+  const messages = getSpeckitMessages(language).howItWorks;
 
-const audiences = [
-  {
-    role: "Platform",
-    value: "Golden paths with governance built-in. No more waiting for approvals or chasing down sign-offs.",
-  },
-  {
-    role: "Security",
-    value: "Policy-as-code with transparency. Audit every control execution and exception trail.",
-  },
-  {
-    role: "Compliance",
-    value: "Evidence on demand. Dashboards map controls to frameworks and highlight gaps instantly.",
-  },
-];
-
-export default function HowItWorksPage() {
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="How it works"
-        title="A continuous loop that brings trust into daily delivery"
-        description="Speckit unites planning, shipping, and proving. Every step is automated, traceable, and designed for collaboration."
+        eyebrow={messages.hero.eyebrow}
+        title={messages.hero.title}
+        description={messages.hero.description}
       />
 
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
-          {stages.map((stage, index) => (
+          {messages.stages.map((stage, index) => (
             <div
               key={stage.name}
               className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
             >
               <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
-                Step {index + 1}
+                {messages.stageLabel.replace(/\{[^}]+\}/g, String(index + 1))}
               </span>
               <h2 className="mt-4 text-xl font-semibold text-slate-900 dark:text-white">{stage.name}</h2>
               <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{stage.description}</p>
@@ -68,7 +47,7 @@ export default function HowItWorksPage() {
       <section>
         <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
           <div className="grid gap-8 lg:grid-cols-3">
-            {audiences.map((audience) => (
+            {messages.audiences.map((audience) => (
               <div
                 key={audience.role}
                 className="rounded-2xl border border-slate-200 bg-slate-50 p-6 dark:border-white/10 dark:bg-slate-950/40"
@@ -83,15 +62,12 @@ export default function HowItWorksPage() {
 
       <section>
         <Container className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100 p-10 shadow-xl dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
-          <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">Bring your own tooling</h2>
-          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">
-            Speckit integrates via webhooks, REST APIs, and SDKs. Use our Supabase adapters to sync data across environments with RLS intact.
-          </p>
+          <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{messages.tooling.title}</h2>
+          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">{messages.tooling.description}</p>
           <ul className="mt-6 grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-2">
-            <li>→ GitHub Actions, CircleCI, GitLab pipelines</li>
-            <li>→ Terraform, Pulumi, CloudFormation</li>
-            <li>→ ServiceNow, Jira, Linear workflow updates</li>
-            <li>→ Supabase, Snowflake, and customer trust portals</li>
+            {messages.tooling.items.map((item) => (
+              <li key={item}>→ {item}</li>
+            ))}
           </ul>
         </Container>
       </section>

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import "./globals.css";
-import { FooterSpeckit, HeaderSpeckit, ThemeProvider, type FooterColumn } from "@airnub/ui";
+import { FooterSpeckit, HeaderSpeckit, ThemeProvider, type FooterColumn, type NavItem } from "@airnub/ui";
 import { JsonLd } from "../components/JsonLd";
 import { buildSpeckitSoftwareJsonLd } from "../lib/jsonld";
 import { SPECKIT_BASE_URL } from "../lib/routes";
@@ -53,6 +53,15 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   const messages = getSpeckitMessages(language);
   const layoutMessages = messages.layout;
   const footerMessages = layoutMessages.footer;
+  const navItems: NavItem[] = [
+    { label: layoutMessages.nav.product, href: "/product" },
+    { label: layoutMessages.nav.howItWorks, href: "/how-it-works" },
+    { label: layoutMessages.nav.solutions, href: "/solutions" },
+    { label: layoutMessages.nav.docs, href: "https://docs.speckit.dev", external: true },
+    { label: layoutMessages.nav.pricing, href: "/pricing" },
+    { label: layoutMessages.nav.trust, href: "https://trust.airnub.io", external: true },
+    { label: layoutMessages.nav.contact, href: "/contact" },
+  ];
 
   const footerColumns: FooterColumn[] = [
     {
@@ -106,8 +115,9 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             {layoutMessages.skipToContent}
           </a>
           <HeaderSpeckit
+            navItems={navItems}
             themeToggleLabel={layoutMessages.themeToggle}
-            starLabel={layoutMessages.starLabel}
+            githubLabel={layoutMessages.githubLabel}
             additionalRightSlot={
               <LanguageSwitcher
                 initialLanguage={language}

--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -5,11 +5,16 @@ import { PageHero } from "../components/PageHero";
 import { getCurrentLanguage } from "../lib/language";
 import { getSpeckitMessages } from "../i18n/messages";
 
-export const revalidate = 86_400;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "End vibe-coding. Ship secure, auditable releases.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const home = getSpeckitMessages(language).home;
+  return {
+    title: home.hero.title,
+    description: home.hero.description,
+  };
+}
 
 export default async function SpeckitHome() {
   const language = await getCurrentLanguage();
@@ -24,14 +29,22 @@ export default async function SpeckitHome() {
         description={home.hero.description}
         actions={
           <>
-            <Button asChild>
-              <Link href="/contact">{home.hero.actions.requestDemo}</Link>
-            </Button>
-            <Button variant="ghost" asChild>
-              <Link href="https://docs.speckit.dev" target="_blank" rel="noreferrer">
-                {home.hero.actions.exploreDocs}
-              </Link>
-            </Button>
+            {home.hero.actions.primaryLabel ? (
+              <Button asChild>
+                <Link href={home.hero.actions.primaryHref ?? "/contact"}>{home.hero.actions.primaryLabel}</Link>
+              </Button>
+            ) : null}
+            {home.hero.actions.secondaryLabel ? (
+              <Button variant="ghost" asChild>
+                <Link
+                  href={home.hero.actions.secondaryHref ?? "https://docs.speckit.dev"}
+                  target={home.hero.actions.secondaryHref?.startsWith("http") ? "_blank" : undefined}
+                  rel={home.hero.actions.secondaryHref?.startsWith("http") ? "noreferrer" : undefined}
+                >
+                  {home.hero.actions.secondaryLabel}
+                </Link>
+              </Button>
+            ) : null}
           </>
         }
       />
@@ -112,10 +125,10 @@ export default async function SpeckitHome() {
               <p className="mt-4 text-base text-slate-600 dark:text-slate-200">{home.alignment.description}</p>
               <div className="mt-6 flex flex-wrap gap-4">
                 <Button variant="ghost" asChild>
-                  <Link href="/how-it-works">{home.alignment.actions.howItWorks}</Link>
+                  <Link href={home.alignment.actions.primaryHref}>{home.alignment.actions.primaryLabel}</Link>
                 </Button>
                 <Button asChild>
-                  <Link href="/template">{home.alignment.actions.template}</Link>
+                  <Link href={home.alignment.actions.secondaryHref}>{home.alignment.actions.secondaryLabel}</Link>
                 </Button>
               </div>
             </div>

--- a/apps/speckit/app/pricing/page.tsx
+++ b/apps/speckit/app/pricing/page.tsx
@@ -2,48 +2,42 @@ import type { Metadata } from "next";
 import { Button, Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
 import Link from "next/link";
+import { getCurrentLanguage } from "../../lib/language";
+import { getSpeckitMessages } from "../../i18n/messages";
 
-export const revalidate = 3_600;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Pricing",
-  description: "Transparent pricing aligned to platform maturity stages.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const pricing = getSpeckitMessages(language).pricing;
+  return {
+    title: pricing.hero.title,
+    description: pricing.hero.description,
+  };
+}
 
-const tiers = [
-  {
-    name: "Launch",
-    price: "$1,250/mo",
-    description: "For teams piloting governance across 3 services.",
-    highlights: ["Up to 20 engineers", "Spec + policy orchestration", "Evidence dashboard"],
-  },
-  {
-    name: "Scale",
-    price: "$3,400/mo",
-    description: "For organizations rolling Speckit out across multiple product lines.",
-    highlights: ["Up to 75 engineers", "Multi-project Supabase tenancy", "Customer trust portal integration"],
-  },
-  {
-    name: "Enterprise",
-    price: "Custom",
-    description: "Dedicated pods for regulated workloads and complex environments.",
-    highlights: ["Unlimited engineers", "Private cloud deployment options", "Compliance automation services"],
-  },
-];
+export default async function PricingPage() {
+  const language = await getCurrentLanguage();
+  const pricing = getSpeckitMessages(language).pricing;
 
-export default function PricingPage() {
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="Pricing"
-        title="Pick the plan that matches your governance journey"
-        description="All plans include the shared Supabase data core, policy orchestration engine, and evidence APIs."
-        actions={<Button asChild><Link href="/contact">Talk to sales</Link></Button>}
+        eyebrow={pricing.hero.eyebrow}
+        title={pricing.hero.title}
+        description={pricing.hero.description}
+        actions={
+          pricing.hero.actions.primaryLabel ? (
+            <Button asChild>
+              <Link href={pricing.hero.actions.primaryHref ?? "/contact"}>{pricing.hero.actions.primaryLabel}</Link>
+            </Button>
+          ) : null
+        }
       />
 
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
-          {tiers.map((tier) => (
+          {pricing.tiers.map((tier) => (
             <div
               key={tier.name}
               className="flex h-full flex-col rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
@@ -59,7 +53,7 @@ export default function PricingPage() {
                 </ul>
               </div>
               <Button variant="ghost" asChild>
-                <Link href="/contact">Request quote</Link>
+                <Link href="/contact">{tier.ctaLabel}</Link>
               </Button>
             </div>
           ))}

--- a/apps/speckit/app/product/page.tsx
+++ b/apps/speckit/app/product/page.tsx
@@ -2,54 +2,42 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Button, Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
+import { getCurrentLanguage } from "../../lib/language";
+import { getSpeckitMessages } from "../../i18n/messages";
 
-export const revalidate = 86_400;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Product",
-  description: "See how Speckit orchestrates governance across specs, pipelines, and evidence streams.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const product = getSpeckitMessages(language).product;
+  return {
+    title: product.hero.title,
+    description: product.hero.description,
+  };
+}
 
-const pillars = [
-  {
-    title: "Model",
-    description: "Capture architecture decisions, risks, and policy owners in collaborative specs synced to Git.",
-  },
-  {
-    title: "Enforce",
-    description: "Apply reusable controls across pipelines, cloud, and service catalogs with explainable results.",
-  },
-  {
-    title: "Prove",
-    description: "Generate and distribute evidence to auditors, customers, and leadership automatically.",
-  },
-];
+export default async function ProductPage() {
+  const language = await getCurrentLanguage();
+  const product = getSpeckitMessages(language).product;
 
-const integrations = [
-  "GitHub",
-  "GitLab",
-  "Bitbucket",
-  "Jira",
-  "ServiceNow",
-  "PagerDuty",
-  "AWS",
-  "Azure",
-  "GCP",
-];
-
-export default function ProductPage() {
   return (
     <div className="space-y-20 pb-20">
       <PageHero
-        eyebrow="Product"
-        title="One platform to model, enforce, and prove governance"
-        description="Speckit connects planning, delivery, and assurance. Ship faster with guardrails that satisfy platform, security, and compliance leaders."
-        actions={<Button asChild><Link href="/pricing">See pricing</Link></Button>}
+        eyebrow={product.hero.eyebrow}
+        title={product.hero.title}
+        description={product.hero.description}
+        actions={
+          product.hero.actions.primaryLabel ? (
+            <Button asChild>
+              <Link href={product.hero.actions.primaryHref ?? "/pricing"}>{product.hero.actions.primaryLabel}</Link>
+            </Button>
+          ) : null
+        }
       />
 
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
-          {pillars.map((pillar) => (
+          {product.pillars.map((pillar) => (
             <div
               key={pillar.title}
               className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
@@ -64,30 +52,22 @@ export default function ProductPage() {
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-start">
           <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl dark:border-white/10 dark:bg-white/10">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">Speckit timeline</h2>
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{product.timeline.title}</h2>
             <ol className="mt-6 space-y-6 text-sm text-slate-600 dark:text-slate-300">
-              <li>
-                <div className="font-semibold text-slate-900 dark:text-white">1. Spec kickoff</div>
-                <p className="mt-1">Start with a versioned spec linked to code. Assign approvers and risk posture.</p>
-              </li>
-              <li>
-                <div className="font-semibold text-slate-900 dark:text-white">2. Policy orchestration</div>
-                <p className="mt-1">Controls run across CI, IaC, and runtime. Exceptions are documented and routed for review.</p>
-              </li>
-              <li>
-                <div className="font-semibold text-slate-900 dark:text-white">3. Evidence stream</div>
-                <p className="mt-1">SBOMs, attestations, and control proofs sync to Supabase, GRC tools, and customer portals.</p>
-              </li>
+              {product.timeline.steps.map((step, index) => (
+                <li key={step.name}>
+                  <div className="font-semibold text-slate-900 dark:text-white">{`${index + 1}. ${step.name}`}</div>
+                  <p className="mt-1">{step.description}</p>
+                </li>
+              ))}
             </ol>
           </div>
           <div className="space-y-8">
             <div className="rounded-3xl border border-slate-200 bg-white p-8 dark:border-white/10 dark:bg-white/5">
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Integrations that meet you where you work</h3>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
-                Use Speckit UI, CLI, or APIs. Bring your own secrets manager, ticketing, and observability stack.
-              </p>
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{product.integrationsCard.title}</h3>
+              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{product.integrationsCard.description}</p>
               <div className="mt-6 flex flex-wrap gap-3 text-xs text-slate-700 dark:text-slate-200">
-                {integrations.map((integration) => (
+                {product.integrationsCard.items.map((integration) => (
                   <span
                     key={integration}
                     className="rounded-full border border-slate-200 bg-white px-4 py-2 dark:border-white/10 dark:bg-white/5"
@@ -98,13 +78,12 @@ export default function ProductPage() {
               </div>
             </div>
             <div className="rounded-3xl border border-slate-200 bg-white p-8 dark:border-white/10 dark:bg-white/5">
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">Shared Supabase data core</h3>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
-                Marketing and product forms feed one Supabase project. Row-level security keeps leads private while your GTM and product teams analyze performance.
-              </p>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">
-                Use the service role to sync Speckit evidence to your data warehouse or customer trust portal with confidence.
-              </p>
+              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{product.supabaseCard.title}</h3>
+              {product.supabaseCard.paragraphs.map((paragraph) => (
+                <p key={paragraph} className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                  {paragraph}
+                </p>
+              ))}
             </div>
           </div>
         </Container>

--- a/apps/speckit/app/solutions/ciso/page.tsx
+++ b/apps/speckit/app/solutions/ciso/page.tsx
@@ -1,34 +1,37 @@
 import type { Metadata } from "next";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../../components/PageHero";
+import { getCurrentLanguage } from "../../../lib/language";
+import { getSpeckitMessages } from "../../../i18n/messages";
 
-export const revalidate = 604_800;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Solutions for CISOs",
-  description: "Give CISOs continuous assurance with automated controls, evidence, and reporting.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const messages = getSpeckitMessages(language).solutionsCiso;
+  return {
+    title: messages.hero.title,
+    description: messages.hero.description,
+  };
+}
 
-const outcomes = [
-  "Live control status mapped to SOC 2, ISO 27001, HIPAA, and FedRAMP",
-  "Automated SSP narratives and customer trust report feeds",
-  "Evidence retention policies backed by Supabase row-level security",
-];
+export default async function CisoSolutionsPage() {
+  const language = await getCurrentLanguage();
+  const messages = getSpeckitMessages(language).solutionsCiso;
 
-export default function CisoSolutionsPage() {
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="Solutions"
-        title="Continuous compliance without manual scramble"
-        description="Speckit gives CISOs real-time visibility into control posture, exceptions, and audit readiness."
+        eyebrow={messages.hero.eyebrow}
+        title={messages.hero.title}
+        description={messages.hero.description}
       />
 
       <section>
         <Container className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">Why CISOs choose Speckit</h2>
+          <h2 className="text-2xl font-semibold text-white">{messages.outcomesTitle}</h2>
           <ul className="mt-6 space-y-3 text-sm text-slate-300">
-            {outcomes.map((outcome) => (
+            {messages.outcomes.map((outcome) => (
               <li key={outcome}>→ {outcome}</li>
             ))}
           </ul>
@@ -37,16 +40,14 @@ export default function CisoSolutionsPage() {
 
       <section>
         <Container className="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">Deliverables</h2>
+          <h2 className="text-2xl font-semibold text-white">{messages.deliverables.title}</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-2 text-sm text-slate-300">
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-              <h3 className="text-lg font-semibold text-white">Control automation</h3>
-              <p className="mt-2">Codified guardrails for change management, access reviews, vulnerability management, and incident response.</p>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-              <h3 className="text-lg font-semibold text-white">Executive reporting</h3>
-              <p className="mt-2">Dashboards for board and customer updates with drill-down evidence trails.</p>
-            </div>
+            {messages.deliverables.cards.map((card) => (
+              <div key={card.title} className="rounded-2xl border border-white/10 bg-white/5 p-6">
+                <h3 className="text-lg font-semibold text-white">{card.title}</h3>
+                <p className="mt-2">{card.description}</p>
+              </div>
+            ))}
           </div>
         </Container>
       </section>

--- a/apps/speckit/app/solutions/devsecops/page.tsx
+++ b/apps/speckit/app/solutions/devsecops/page.tsx
@@ -1,34 +1,37 @@
 import type { Metadata } from "next";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../../components/PageHero";
+import { getCurrentLanguage } from "../../../lib/language";
+import { getSpeckitMessages } from "../../../i18n/messages";
 
-export const revalidate = 604_800;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Solutions for DevSecOps",
-  description: "Empower DevSecOps to embed guardrails and evidence in every pipeline.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const messages = getSpeckitMessages(language).solutionsDevSecOps;
+  return {
+    title: messages.hero.title,
+    description: messages.hero.description,
+  };
+}
 
-const benefits = [
-  "Policy-as-code modules for GitHub Actions, GitLab CI, and Jenkins",
-  "Runtime attestations linked to environments and deployments",
-  "Service catalogs with self-serve golden paths and guardrails",
-];
+export default async function DevSecOpsSolutionsPage() {
+  const language = await getCurrentLanguage();
+  const messages = getSpeckitMessages(language).solutionsDevSecOps;
 
-export default function DevSecOpsSolutionsPage() {
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="Solutions"
-        title="Guardrails and speed for every delivery team"
-        description="Speckit gives DevSecOps teams programmable controls, observability, and shared context with security and compliance."
+        eyebrow={messages.hero.eyebrow}
+        title={messages.hero.title}
+        description={messages.hero.description}
       />
 
       <section>
         <Container className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">What DevSecOps gains</h2>
+          <h2 className="text-2xl font-semibold text-white">{messages.benefitsTitle}</h2>
           <ul className="mt-6 space-y-3 text-sm text-slate-300">
-            {benefits.map((benefit) => (
+            {messages.benefits.map((benefit) => (
               <li key={benefit}>→ {benefit}</li>
             ))}
           </ul>
@@ -37,16 +40,14 @@ export default function DevSecOpsSolutionsPage() {
 
       <section>
         <Container className="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">Key capabilities</h2>
+          <h2 className="text-2xl font-semibold text-white">{messages.capabilities.title}</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-2 text-sm text-slate-300">
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-              <h3 className="text-lg font-semibold text-white">Workflow adapters</h3>
-              <p className="mt-2">Drop-in actions, templates, and CLI commands for pipelines and infrastructure.</p>
-            </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
-              <h3 className="text-lg font-semibold text-white">Observability hooks</h3>
-              <p className="mt-2">Send control results to Datadog, Grafana, or Slack with deep links into evidence.</p>
-            </div>
+            {messages.capabilities.cards.map((card) => (
+              <div key={card.title} className="rounded-2xl border border-white/10 bg-white/5 p-6">
+                <h3 className="text-lg font-semibold text-white">{card.title}</h3>
+                <p className="mt-2">{card.description}</p>
+              </div>
+            ))}
           </div>
         </Container>
       </section>

--- a/apps/speckit/app/solutions/page.tsx
+++ b/apps/speckit/app/solutions/page.tsx
@@ -2,39 +2,35 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
+import { getCurrentLanguage } from "../../lib/language";
+import { getSpeckitMessages } from "../../i18n/messages";
 
-export const revalidate = 604_800;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Solutions",
-  description: "Choose tailored Speckit playbooks for CISOs and DevSecOps leaders.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const solutions = getSpeckitMessages(language).solutions;
+  return {
+    title: solutions.hero.title,
+    description: solutions.hero.description,
+  };
+}
 
-const personas = [
-  {
-    title: "CISO",
-    description: "Make compliance continuous. Turn control evidence into a daily signal instead of an annual fire drill.",
-    href: "/solutions/ciso",
-  },
-  {
-    title: "DevSecOps",
-    description: "Embed guardrails in every pipeline while empowering teams to ship faster with transparency.",
-    href: "/solutions/devsecops",
-  },
-];
+export default async function SolutionsOverviewPage() {
+  const language = await getCurrentLanguage();
+  const solutions = getSpeckitMessages(language).solutions;
 
-export default function SolutionsOverviewPage() {
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="Solutions"
-        title="Speckit adapts to your security and platform operating model"
-        description="Pick a tailored path to orchestrate policy gates, evidence automation, and cross-team collaboration."
+        eyebrow={solutions.hero.eyebrow}
+        title={solutions.hero.title}
+        description={solutions.hero.description}
       />
 
       <section>
         <Container className="grid gap-8 lg:grid-cols-2">
-          {personas.map((persona) => (
+          {solutions.personas.map((persona) => (
             <Link
               key={persona.title}
               href={persona.href}
@@ -43,7 +39,7 @@ export default function SolutionsOverviewPage() {
               <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{persona.title}</h2>
               <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{persona.description}</p>
               <span className="mt-6 inline-flex text-sm font-semibold text-indigo-600 transition group-hover:text-indigo-700 dark:text-indigo-300 dark:group-hover:text-indigo-200">
-                Explore →
+                {persona.ctaLabel}
               </span>
             </Link>
           ))}

--- a/apps/speckit/app/template/page.tsx
+++ b/apps/speckit/app/template/page.tsx
@@ -2,55 +2,48 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
+import { getCurrentLanguage } from "../../lib/language";
+import { getSpeckitMessages } from "../../i18n/messages";
+import Link from "next/link";
 
-export const revalidate = 604_800;
+export const dynamic = "force-dynamic";
 
-export const metadata: Metadata = {
-  title: "Rollout template",
-  description: "Kickstart your Speckit implementation with a ready-to-run rollout plan.",
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const template = getSpeckitMessages(language).template;
+  return {
+    title: template.hero.title,
+    description: template.hero.description,
+  };
+}
 
-const steps = [
-  {
-    title: "Week 1 — Discovery",
-    description: "Map current controls, tooling, and evidence flows. Identify pilot teams and success metrics.",
-  },
-  {
-    title: "Weeks 2-3 — Orchestration",
-    description: "Configure Supabase, connect repos, and codify policy gates in pipelines and IaC.",
-  },
-  {
-    title: "Weeks 4-5 — Enablement",
-    description: "Enable teams with templates, guardrail playbooks, and evidence dashboards.",
-  },
-  {
-    title: "Week 6 — Scale",
-    description: "Review KPIs, expand to additional services, and integrate evidence feeds into trust portals.",
-  },
-];
+export default async function TemplatePage() {
+  const language = await getCurrentLanguage();
+  const template = getSpeckitMessages(language).template;
 
-export default function TemplatePage() {
   return (
     <div className="space-y-16 pb-20">
       <PageHero
-        eyebrow="Template"
-        title="A proven rollout playbook"
-        description="Download the six-week plan Speckit uses to launch with platform, security, and compliance teams."
+        eyebrow={template.hero.eyebrow}
+        title={template.hero.title}
+        description={template.hero.description}
         actions={
-          <Link
-            href="https://github.com/airnub/speckit-templates"
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90"
-          >
-            Get the template
-          </Link>
+          template.hero.actions.primaryLabel ? (
+            <Link
+              href={template.hero.actions.primaryHref ?? "https://github.com/airnub/speckit-templates"}
+              target={template.hero.actions.primaryHref?.startsWith("http") ? "_blank" : undefined}
+              rel={template.hero.actions.primaryHref?.startsWith("http") ? "noreferrer" : undefined}
+              className="inline-flex items-center rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90"
+            >
+              {template.hero.actions.primaryLabel}
+            </Link>
+          ) : null
         }
       />
 
       <section>
         <Container className="grid gap-6 md:grid-cols-2">
-          {steps.map((step) => (
+          {template.steps.map((step) => (
             <div
               key={step.title}
               className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"

--- a/apps/speckit/components/LanguageSwitcher.tsx
+++ b/apps/speckit/components/LanguageSwitcher.tsx
@@ -27,7 +27,7 @@ type LanguageSwitcherProps = {
 
 function persistLanguage(value: SupportedLanguage) {
   if (typeof document !== "undefined") {
-    document.cookie = `${languageCookieName}=${value}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}`;
+    document.cookie = `${languageCookieName}=${value}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
     document.documentElement.lang = value;
   }
   if (typeof window !== "undefined") {

--- a/apps/speckit/i18n/config.ts
+++ b/apps/speckit/i18n/config.ts
@@ -4,4 +4,6 @@ export type SupportedLanguage = (typeof supportedLanguages)[number];
 
 export const defaultLanguage: SupportedLanguage = "en-US";
 
-export const languageCookieName = "speckit-language";
+// Reuse the same cookie as the Airnub app so that locale selection persists
+// across both surfaces.
+export const languageCookieName = "NEXT_LOCALE";

--- a/apps/speckit/i18n/messages.ts
+++ b/apps/speckit/i18n/messages.ts
@@ -12,9 +12,14 @@ type HeroMessages = {
   eyebrow: string;
   title: string;
   description: string;
+};
+
+type DualActionHeroMessages = HeroMessages & {
   actions: {
-    requestDemo: string;
-    exploreDocs: string;
+    primaryLabel: string;
+    primaryHref?: string;
+    secondaryLabel?: string;
+    secondaryHref?: string;
   };
 };
 
@@ -47,14 +52,16 @@ type AlignmentMessages = {
   title: string;
   description: string;
   actions: {
-    howItWorks: string;
-    template: string;
+    primaryLabel: string;
+    primaryHref: string;
+    secondaryLabel: string;
+    secondaryHref: string;
   };
   cards: FeatureMessages[];
 };
 
 type HomeMessages = {
-  hero: HeroMessages;
+  hero: DualActionHeroMessages;
   features: FeatureMessages[];
   workflows: WorkflowMessages;
   guardrails: GuardrailMessages;
@@ -65,11 +72,129 @@ type HomeMessages = {
   };
 };
 
+type PricingMessages = {
+  hero: DualActionHeroMessages;
+  tiers: {
+    name: string;
+    price: string;
+    description: string;
+    highlights: string[];
+    ctaLabel: string;
+  }[];
+};
+
+type ProductMessages = {
+  hero: DualActionHeroMessages;
+  pillars: FeatureMessages[];
+  timeline: {
+    title: string;
+    steps: {
+      name: string;
+      description: string;
+    }[];
+  };
+  integrationsCard: {
+    title: string;
+    description: string;
+    items: string[];
+  };
+  supabaseCard: {
+    title: string;
+    paragraphs: string[];
+  };
+};
+
+type HowItWorksMessages = {
+  hero: HeroMessages;
+  stages: {
+    title: string;
+    description: string;
+  }[];
+  stageLabel: string;
+  audiences: {
+    role: string;
+    value: string;
+  }[];
+  tooling: {
+    title: string;
+    description: string;
+    items: string[];
+  };
+};
+
+type TemplateMessages = {
+  hero: DualActionHeroMessages;
+  steps: FeatureMessages[];
+};
+
+type ContactMessages = {
+  hero: HeroMessages;
+  form: {
+    title: string;
+    description: string;
+    submitLabel: string;
+    fields: {
+      nameLabel: string;
+      emailLabel: string;
+      emailRequiredSuffix: string;
+      companyLabel: string;
+      focusLabel: string;
+    };
+  };
+  shortcuts: {
+    emailHeading: string;
+    productQuestions: string;
+    security: string;
+    docsHeading: string;
+    docsDescription: string;
+    docsCtaLabel: string;
+  };
+};
+
+type SolutionsOverviewMessages = {
+  hero: HeroMessages;
+  personas: {
+    title: string;
+    description: string;
+    href: string;
+    ctaLabel: string;
+  }[];
+};
+
+type CisoSolutionsMessages = {
+  hero: HeroMessages;
+  outcomes: string[];
+  outcomesTitle: string;
+  deliverables: {
+    title: string;
+    cards: FeatureMessages[];
+  };
+};
+
+type DevSecOpsSolutionsMessages = {
+  hero: HeroMessages;
+  benefits: string[];
+  benefitsTitle: string;
+  capabilities: {
+    title: string;
+    cards: FeatureMessages[];
+  };
+};
+
 type LayoutMessages = {
   skipToContent: string;
   themeToggle: string;
-  starLabel: string;
   languageLabel: string;
+  githubLabel: string;
+  nav: {
+    product: string;
+    howItWorks: string;
+    solutions: string;
+    docs: string;
+    pricing: string;
+    trust: string;
+    contact: string;
+  };
   footer: {
     columns: {
       product: {
@@ -108,6 +233,14 @@ type LayoutMessages = {
 export type SpeckitMessages = {
   layout: LayoutMessages;
   home: HomeMessages;
+  pricing: PricingMessages;
+  product: ProductMessages;
+  howItWorks: HowItWorksMessages;
+  template: TemplateMessages;
+  contact: ContactMessages;
+  solutions: SolutionsOverviewMessages;
+  solutionsCiso: CisoSolutionsMessages;
+  solutionsDevSecOps: DevSecOpsSolutionsMessages;
 };
 
 const registry: Record<SupportedLanguage, SpeckitMessages> = {

--- a/apps/speckit/messages/de.json
+++ b/apps/speckit/messages/de.json
@@ -2,39 +2,48 @@
   "layout": {
     "skipToContent": "Überspringen Sie zu Inhalten",
     "themeToggle": "Thema umschalten",
-    "starLabel": "Sternprojekt",
     "languageLabel": "Sprache",
+    "githubLabel": "Speckit auf GitHub",
+    "nav": {
+      "product": "Produkt",
+      "howItWorks": "Wie es funktioniert",
+      "solutions": "Lösungen",
+      "docs": "Dokumente",
+      "pricing": "Preisgestaltung",
+      "trust": "Vertrauen",
+      "contact": "Kontakt"
+    },
     "footer": {
       "columns": {
         "product": {
           "heading": "Produkt",
           "overview": "Überblick",
-          "howItWorks": "Funktionsweise",
+          "howItWorks": "Wie es funktioniert",
           "integrations": "Integrationen"
         },
         "resources": {
           "heading": "Ressourcen",
-          "docs": "Dokumentation",
-          "apiReference": "API-Referenz",
-          "community": "Community"
+          "docs": "Dokumente",
+          "apiReference": "API -Referenz",
+          "community": "Gemeinschaft"
         },
         "openSource": {
           "heading": "Open Source",
-          "repo": "Repository",
+          "repo": "Repo",
           "templates": "Vorlagen",
           "issues": "Probleme",
           "license": "Lizenz"
         },
         "trust": {
           "heading": "Vertrauen",
-          "trustCenter": "Trust Center",
+          "trustCenter": "Vertrauenszentrum",
           "status": "Status",
-          "securityTxt": "security.txt"
+          "securityTxt": "Security.txt"
         }
       },
       "contact": {
-        "label": "speckit@airnub.io",
-        "pricing": "Preise"
+        "label": "speckkit@airnub.io",
+        "pricing": "Preisgestaltung"
       }
     }
   },
@@ -44,8 +53,10 @@
       "title": "End-Vibe-Codierung. ",
       "description": "Speckkit verwandelt die Einhaltung eines Scrambles in eine kontinuierliche Entwicklernative. ",
       "actions": {
-        "requestDemo": "Fordern Sie eine Demo an",
-        "exploreDocs": "Erforschen von Dokumenten"
+        "primaryLabel": "Fordern Sie eine Demo an",
+        "primaryHref": "/Kontakt",
+        "secondaryLabel": "Erforschen von Dokumenten",
+        "secondaryHref": "https://docs.speckit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "Alle Teams sehen die gleiche Quelle der Wahrheit",
       "description": "In einem gemeinsamen Kontext arbeiten die Plattform-, Sicherheit-, Compliance- und Produktführer zusammen. ",
       "actions": {
-        "howItWorks": "Sehen Sie, wie es funktioniert",
-        "template": "Laden Sie die Rollout -Vorlage herunter"
+        "primaryLabel": "Sehen Sie, wie es funktioniert",
+        "primaryHref": "/wie-it-it-arbeitet",
+        "secondaryLabel": "Laden Sie die Rollout -Vorlage herunter",
+        "secondaryHref": "/Vorlage"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Preisgestaltung",
+      "title": "Wählen Sie den Plan aus, der Ihrer Governance -Reise entspricht",
+      "description": "Alle Pläne umfassen die gemeinsam genutzte Supabase -Datenkern, die Richtlinienorchestrierungs -Engine und Evidenz -APIs.",
+      "actions": {
+        "primaryLabel": "Sprechen Sie mit Verkäufen",
+        "primaryHref": "/Kontakt"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Start",
+        "price": "$ 1,250/Mo",
+        "description": "Für Teams, die Governance in drei Diensten steuern.",
+        "highlights": [
+          "Bis zu 20 Ingenieure",
+          "Spezifikation + Richtlinienorchestrierung",
+          "Evidenz Dashboard"
+        ],
+        "ctaLabel": "Anfrage Zitat"
+      },
+      {
+        "name": "Skala",
+        "price": "$ 3.400/Mo",
+        "description": "Für Organisationen, die sich über mehrere Produktleitungen hinweg auswirken.",
+        "highlights": [
+          "Bis zu 75 Ingenieure",
+          "Multi-Project-Supabase-Mietverhältnis",
+          "Kundenvertrauensportalintegration"
+        ],
+        "ctaLabel": "Anfrage Zitat"
+      },
+      {
+        "name": "Unternehmen",
+        "price": "Brauch",
+        "description": "Dedizierte Pods für regulierte Arbeitsbelastungen und komplexe Umgebungen.",
+        "highlights": [
+          "Unbegrenzte Ingenieure",
+          "Private Cloud -Bereitstellungsoptionen",
+          "Compliance -Automatisierungsdienste"
+        ],
+        "ctaLabel": "Anfrage Zitat"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Produkt",
+      "title": "Eine Plattform, um Governance zu modellieren, durchzusetzen und zu beweisen",
+      "description": "Speckit verbindet Planung, Lieferung und Zusicherung. ",
+      "actions": {
+        "primaryLabel": "Siehe Preisgestaltung",
+        "primaryHref": "/Preisgestaltung"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Modell",
+        "description": "Erfassen Sie Architekturentscheidungen, Risiken und politische Eigentümer in kollaborativen Spezifikationen, die mit Git synchronisiert sind."
+      },
+      {
+        "title": "Erzwingen",
+        "description": "Wenden Sie wiederverwendbare Steuerelemente auf Pipelines, Cloud und Service -Kataloge mit erklärbaren Ergebnissen an."
+      },
+      {
+        "title": "Beweisen",
+        "description": "Generieren Sie Beweise und verteilen Sie Beweise an Prüfer, Kunden und Führung automatisch."
+      }
+    ],
+    "timeline": {
+      "title": "Speckit Timeline",
+      "steps": [
+        {
+          "name": "Spezifikationsstart",
+          "description": "Beginnen Sie mit einer mit Code verknüpften Versionen. "
+        },
+        {
+          "name": "Richtlinienorchestrierung",
+          "description": "Die Kontrollen laufen über CI, IAC und Laufzeit. "
+        },
+        {
+          "name": "Beweisstrom",
+          "description": "SBOMS, Bescheinigungen und Kontrollnachweise synchronisieren mit Supabase, GRC -Tools und Kundenportalen."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Integrationen, die Sie dort treffen, wo Sie arbeiten",
+      "description": "Verwenden Sie Speckit UI, CLI oder APIs. ",
+      "items": [
+        "Github",
+        "Gitlab",
+        "Bitbucket",
+        "Jira",
+        "Servicenow",
+        "Pagerduty",
+        "AWS",
+        "Azurblau",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Shared Supabase Data Core",
+      "paragraphs": [
+        "Marketing- und Produktformulare füttern ein Supabase -Projekt. ",
+        "Verwenden Sie die Servicerolle, um Speckit -Beweise mit Vertrauen in Ihr Data Warehouse oder Customer Trust -Portal zu synchronisieren."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "Wie es funktioniert",
+      "title": "Eine kontinuierliche Schleife, die Vertrauen in die tägliche Lieferung bringt",
+      "description": "Speckit vereint Planung, Versand und Nachweis. "
+    },
+    "stages": [
+      {
+        "name": "Erfassen",
+        "description": "Die technischen Daten beginnen in Git-Backed-Dokumenten. "
+      },
+      {
+        "name": "Orchestrieren",
+        "description": "Steuert die Auslöser über Pipelines und Umgebungen. "
+      },
+      {
+        "name": "Veröffentlichen",
+        "description": "Nachweis landet, wo es benötigt wird - Supabase, GRC -Tools, Kundenvertrauensportale und Analysestapel."
+      }
+    ],
+    "stageLabel": "Schritt {count}",
+    "audiences": [
+      {
+        "role": "Plattform",
+        "value": "Goldene Wege mit eingebautem Governance. "
+      },
+      {
+        "role": "Sicherheit",
+        "value": "Richtlinien-als-Code mit Transparenz. "
+      },
+      {
+        "role": "Einhaltung",
+        "value": "Beweise auf Nachfrage. "
+      }
+    ],
+    "tooling": {
+      "title": "Bringen Sie Ihr eigenes Werkzeug mit",
+      "description": "Speckit integriert über Webhooks, Rest -APIs und SDKs. ",
+      "items": [
+        "Github -Aktionen, Circleci, Gitlab -Pipelines",
+        "Terraform, Pulumi, Wolkenformation",
+        "Servicenow, Jira, lineare Workflow -Updates",
+        "Supabase, Snowflake und Customer Trust Portale"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Vorlage",
+      "title": "Ein bewährtes Rollout -Spielbuch",
+      "description": "Laden Sie den sechswöchigen Plan, den Speckit verwendet, mit Plattform-, Sicherheits- und Compliance-Teams.",
+      "actions": {
+        "primaryLabel": "Holen Sie sich die Vorlage",
+        "primaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Woche 1 - Entdeckung",
+        "description": "Kartenstromsteuerungen, Werkzeuge und Evidenzflüsse. "
+      },
+      {
+        "title": "Wochen 2-3-Orchestrierung",
+        "description": "Konfigurieren Sie Supabase, Verbinden Sie Repos und kodifizieren Sie Richtliniengore in Pipelines und IAC."
+      },
+      {
+        "title": "Wochen 4-5-Aktivierung",
+        "description": "Aktivieren Sie Teams mit Vorlagen, Leitplaybooks und Beweis -Dashboards."
+      },
+      {
+        "title": "Woche 6 - Skala",
+        "description": "Überprüfen Sie KPIs, erweitern Sie zusätzliche Dienste und integrieren Sie Evidenzversorgungen in Vertrauensportale."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Kontakt",
+      "title": "Siehe Speckit in Aktion",
+      "description": "Teilen Sie ein wenig über Ihr Plattformprogramm und wir werden eine Exemplar auf Ihre Ziele anpassen."
+    },
+    "form": {
+      "title": "Fordern Sie eine Demo an",
+      "description": "Erzählen Sie uns von Ihrer Umgebung und Ihrer Zielstartzeitleiste.",
+      "submitLabel": "Demo anfordern",
+      "fields": {
+        "nameLabel": "Vollständiger Name",
+        "emailLabel": "Arbeiten Sie E -Mail",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Unternehmen",
+        "focusLabel": "Worauf sollten wir uns konzentrieren?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "E-Mail",
+      "productQuestions": "Produktfragen: speckkit@airnub.io",
+      "security": "Sicherheit: Security@airnub.io",
+      "docsHeading": "Dokumente",
+      "docsDescription": "Erforschen Sie API -Referenzen und Implementierungsleitfäden.",
+      "docsCtaLabel": "docs.speckit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Lösungen",
+      "title": "Speckit passt sich Ihrem Sicherheits- und Plattform -Betriebsmodell an",
+      "description": "Wählen Sie einen maßgeschneiderten Weg, um Richtlinien, Evidenzautomatisierung und Cross-Team-Zusammenarbeit zu orchestrieren."
+    },
+    "personas": [
+      {
+        "title": "Ciso",
+        "description": "Compliance kontinuierlich machen. ",
+        "href": "/Lösungen/Ciso",
+        "ctaLabel": "Erforschen →"
+      },
+      {
+        "title": "DevSecops",
+        "description": "Betten Sie Leitplanken in jede Pipeline ein und befähigen die Teams, schneller Transparenz zu versenden.",
+        "href": "/Lösungen/DevSecops",
+        "ctaLabel": "Erforschen →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Lösungen",
+      "title": "Kontinuierliche Einhaltung ohne manuelles Scramble",
+      "description": "Speckit gibt CISOS Echtzeit-Sichtbarkeit in Kontrollhaltung, Ausnahmen und Prüfungsbereitschaft."
+    },
+    "outcomesTitle": "Warum Cisos Speckit wählen",
+    "outcomes": [
+      "Live -Kontrollstatus, der auf SoC 2, ISO 27001, HIPAA und Fedramp zugeordnet ist",
+      "Automatisierte SSP -Erzählungen und Kundenvertrauensbericht Feeds",
+      "Richtlinien zur Beweisretention, die von Supabase Row-Level-Sicherheit unterstützt werden"
+    ],
+    "deliverables": {
+      "title": "Ergebnisse",
+      "cards": [
+        {
+          "title": "Steuerautomatisierung",
+          "description": "Kodifizierte Leitplanken für Änderungsmanagement, Zugriffsbewertungen, Verwundbarkeitsmanagement und Vorfallreaktion."
+        },
+        {
+          "title": "Executive Reporting",
+          "description": "Dashboards für Board- und Kundenaktualisierungen mit Drill-Down-Beweiswegen."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Lösungen",
+      "title": "Leitplanken und Geschwindigkeit für jedes Lieferteam",
+      "description": "Speckit gibt DevSecops -Teams programmierbare Kontrollen, Beobachtbarkeit und gemeinsame Kontext mit Sicherheit und Einhaltung."
+    },
+    "benefitsTitle": "Was DevSecops gewinnt",
+    "benefits": [
+      "Politik-as-Code-Module für Github-Aktionen, Gitlab CI und Jenkins",
+      "Runtime -Bescheinigungen, die mit Umgebungen und Bereitstellungen verbunden sind",
+      "Servicekataloge mit selbstbediener goldenen Wegen und Leitplanken"
+    ],
+    "capabilities": {
+      "title": "Schlüsselfunktionen",
+      "cards": [
+        {
+          "title": "Workflow -Adapter",
+          "description": "Drop-In-Aktionen, Vorlagen und CLI-Befehle für Pipelines und Infrastruktur."
+        },
+        {
+          "title": "Beobachtbarkeitshaken",
+          "description": "Senden Sie Steuerergebnisse an Datadog, Grafana oder Lack mit tiefen Links in Beweise."
+        }
       ]
     }
   }

--- a/apps/speckit/messages/en-GB.json
+++ b/apps/speckit/messages/en-GB.json
@@ -2,8 +2,17 @@
   "layout": {
     "skipToContent": "Skip to content",
     "themeToggle": "Toggle theme",
-    "starLabel": "Star project",
     "languageLabel": "Language",
+    "githubLabel": "Speckit on GitHub",
+    "nav": {
+      "product": "Product",
+      "howItWorks": "How it works",
+      "solutions": "Solutions",
+      "docs": "Docs",
+      "pricing": "Pricing",
+      "trust": "Trust",
+      "contact": "Contact"
+    },
     "footer": {
       "columns": {
         "product": {
@@ -27,7 +36,7 @@
         },
         "trust": {
           "heading": "Trust",
-          "trustCenter": "Trust Centre",
+          "trustCenter": "Trust Center",
           "status": "Status",
           "securityTxt": "security.txt"
         }
@@ -44,8 +53,10 @@
       "title": "End vibe-coding. Ship secure, auditable releases.",
       "description": "Speckit turns compliance from a scramble into a continuous, developer-native loop. Govern specs, orchestrate policy gates, and ship evidence on demand.",
       "actions": {
-        "requestDemo": "Request a demo",
-        "exploreDocs": "Explore docs"
+        "primaryLabel": "Request a demo",
+        "primaryHref": "/contact",
+        "secondaryLabel": "Explore docs",
+        "secondaryHref": "https://docs.speckit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "All teams see the same source of truth",
       "description": "Platform, security, compliance, and product leaders collaborate in a shared context. Speckit syncs with GitHub, Jira, ServiceNow, and Supabase so your data stays where work already happens.",
       "actions": {
-        "howItWorks": "See how it works",
-        "template": "Download rollout template"
+        "primaryLabel": "See how it works",
+        "primaryHref": "/how-it-works",
+        "secondaryLabel": "Download rollout template",
+        "secondaryHref": "/template"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Pricing",
+      "title": "Pick the plan that matches your governance journey",
+      "description": "All plans include the shared Supabase data core, policy orchestration engine, and evidence APIs.",
+      "actions": {
+        "primaryLabel": "Talk to sales",
+        "primaryHref": "/contact"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Launch",
+        "price": "$1,250/mo",
+        "description": "For teams piloting governance across 3 services.",
+        "highlights": [
+          "Up to 20 engineers",
+          "Spec + policy orchestration",
+          "Evidence dashboard"
+        ],
+        "ctaLabel": "Request quote"
+      },
+      {
+        "name": "Scale",
+        "price": "$3,400/mo",
+        "description": "For organizations rolling Speckit out across multiple product lines.",
+        "highlights": [
+          "Up to 75 engineers",
+          "Multi-project Supabase tenancy",
+          "Customer trust portal integration"
+        ],
+        "ctaLabel": "Request quote"
+      },
+      {
+        "name": "Enterprise",
+        "price": "Custom",
+        "description": "Dedicated pods for regulated workloads and complex environments.",
+        "highlights": [
+          "Unlimited engineers",
+          "Private cloud deployment options",
+          "Compliance automation services"
+        ],
+        "ctaLabel": "Request quote"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Product",
+      "title": "One platform to model, enforce, and prove governance",
+      "description": "Speckit connects planning, delivery, and assurance. Ship faster with guardrails that satisfy platform, security, and compliance leaders.",
+      "actions": {
+        "primaryLabel": "See pricing",
+        "primaryHref": "/pricing"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Model",
+        "description": "Capture architecture decisions, risks, and policy owners in collaborative specs synced to Git."
+      },
+      {
+        "title": "Enforce",
+        "description": "Apply reusable controls across pipelines, cloud, and service catalogs with explainable results."
+      },
+      {
+        "title": "Prove",
+        "description": "Generate and distribute evidence to auditors, customers, and leadership automatically."
+      }
+    ],
+    "timeline": {
+      "title": "Speckit timeline",
+      "steps": [
+        {
+          "name": "Spec kickoff",
+          "description": "Start with a versioned spec linked to code. Assign approvers and risk posture."
+        },
+        {
+          "name": "Policy orchestration",
+          "description": "Controls run across CI, IaC, and runtime. Exceptions are documented and routed for review."
+        },
+        {
+          "name": "Evidence stream",
+          "description": "SBOMs, attestations, and control proofs sync to Supabase, GRC tools, and customer portals."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Integrations that meet you where you work",
+      "description": "Use Speckit UI, CLI, or APIs. Bring your own secrets manager, ticketing, and observability stack.",
+      "items": [
+        "GitHub",
+        "GitLab",
+        "Bitbucket",
+        "Jira",
+        "ServiceNow",
+        "PagerDuty",
+        "AWS",
+        "Azure",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Shared Supabase data core",
+      "paragraphs": [
+        "Marketing and product forms feed one Supabase project. Row-level security keeps leads private while your GTM and product teams analyze performance.",
+        "Use the service role to sync Speckit evidence to your data warehouse or customer trust portal with confidence."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "How it works",
+      "title": "A continuous loop that brings trust into daily delivery",
+      "description": "Speckit unites planning, shipping, and proving. Every step is automated, traceable, and designed for collaboration."
+    },
+    "stages": [
+      {
+        "name": "Capture",
+        "description": "Specs start in Git-backed docs. Risk, controls, and approvers are defined at the beginning, not the end."
+      },
+      {
+        "name": "Orchestrate",
+        "description": "Controls trigger across pipelines and environments. Exceptions kick off review workflows automatically."
+      },
+      {
+        "name": "Publish",
+        "description": "Evidence lands where it is needed — Supabase, GRC tools, customer trust portals, and analytics stacks."
+      }
+    ],
+    "stageLabel": "Step {count}",
+    "audiences": [
+      {
+        "role": "Platform",
+        "value": "Golden paths with governance built-in. No more waiting for approvals or chasing down sign-offs."
+      },
+      {
+        "role": "Security",
+        "value": "Policy-as-code with transparency. Audit every control execution and exception trail."
+      },
+      {
+        "role": "Compliance",
+        "value": "Evidence on demand. Dashboards map controls to frameworks and highlight gaps instantly."
+      }
+    ],
+    "tooling": {
+      "title": "Bring your own tooling",
+      "description": "Speckit integrates via webhooks, REST APIs, and SDKs. Use our Supabase adapters to sync data across environments with RLS intact.",
+      "items": [
+        "GitHub Actions, CircleCI, GitLab pipelines",
+        "Terraform, Pulumi, CloudFormation",
+        "ServiceNow, Jira, Linear workflow updates",
+        "Supabase, Snowflake, and customer trust portals"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Template",
+      "title": "A proven rollout playbook",
+      "description": "Download the six-week plan Speckit uses to launch with platform, security, and compliance teams.",
+      "actions": {
+        "primaryLabel": "Get the template",
+        "primaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Week 1 — Discovery",
+        "description": "Map current controls, tooling, and evidence flows. Identify pilot teams and success metrics."
+      },
+      {
+        "title": "Weeks 2-3 — Orchestration",
+        "description": "Configure Supabase, connect repos, and codify policy gates in pipelines and IaC."
+      },
+      {
+        "title": "Weeks 4-5 — Enablement",
+        "description": "Enable teams with templates, guardrail playbooks, and evidence dashboards."
+      },
+      {
+        "title": "Week 6 — Scale",
+        "description": "Review KPIs, expand to additional services, and integrate evidence feeds into trust portals."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contact",
+      "title": "See Speckit in action",
+      "description": "Share a bit about your platform program and we will tailor a walkthrough to your goals."
+    },
+    "form": {
+      "title": "Request a demo",
+      "description": "Tell us about your environment and target launch timeline.",
+      "submitLabel": "Request demo",
+      "fields": {
+        "nameLabel": "Full name",
+        "emailLabel": "Work email",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Company",
+        "focusLabel": "What should we focus on?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "Email",
+      "productQuestions": "Product questions: speckit@airnub.io",
+      "security": "Security: security@airnub.io",
+      "docsHeading": "Docs",
+      "docsDescription": "Explore API references and implementation guides.",
+      "docsCtaLabel": "docs.speckit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Speckit adapts to your security and platform operating model",
+      "description": "Pick a tailored path to orchestrate policy gates, evidence automation, and cross-team collaboration."
+    },
+    "personas": [
+      {
+        "title": "CISO",
+        "description": "Make compliance continuous. Turn control evidence into a daily signal instead of an annual fire drill.",
+        "href": "/solutions/ciso",
+        "ctaLabel": "Explore →"
+      },
+      {
+        "title": "DevSecOps",
+        "description": "Embed guardrails in every pipeline while empowering teams to ship faster with transparency.",
+        "href": "/solutions/devsecops",
+        "ctaLabel": "Explore →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Continuous compliance without manual scramble",
+      "description": "Speckit gives CISOs real-time visibility into control posture, exceptions, and audit readiness."
+    },
+    "outcomesTitle": "Why CISOs choose Speckit",
+    "outcomes": [
+      "Live control status mapped to SOC 2, ISO 27001, HIPAA, and FedRAMP",
+      "Automated SSP narratives and customer trust report feeds",
+      "Evidence retention policies backed by Supabase row-level security"
+    ],
+    "deliverables": {
+      "title": "Deliverables",
+      "cards": [
+        {
+          "title": "Control automation",
+          "description": "Codified guardrails for change management, access reviews, vulnerability management, and incident response."
+        },
+        {
+          "title": "Executive reporting",
+          "description": "Dashboards for board and customer updates with drill-down evidence trails."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Guardrails and speed for every delivery team",
+      "description": "Speckit gives DevSecOps teams programmable controls, observability, and shared context with security and compliance."
+    },
+    "benefitsTitle": "What DevSecOps gains",
+    "benefits": [
+      "Policy-as-code modules for GitHub Actions, GitLab CI, and Jenkins",
+      "Runtime attestations linked to environments and deployments",
+      "Service catalogs with self-serve golden paths and guardrails"
+    ],
+    "capabilities": {
+      "title": "Key capabilities",
+      "cards": [
+        {
+          "title": "Workflow adapters",
+          "description": "Drop-in actions, templates, and CLI commands for pipelines and infrastructure."
+        },
+        {
+          "title": "Observability hooks",
+          "description": "Send control results to Datadog, Grafana, or Slack with deep links into evidence."
+        }
       ]
     }
   }

--- a/apps/speckit/messages/en-US.json
+++ b/apps/speckit/messages/en-US.json
@@ -2,8 +2,17 @@
   "layout": {
     "skipToContent": "Skip to content",
     "themeToggle": "Toggle theme",
-    "starLabel": "Star project",
     "languageLabel": "Language",
+    "githubLabel": "Speckit on GitHub",
+    "nav": {
+      "product": "Product",
+      "howItWorks": "How it works",
+      "solutions": "Solutions",
+      "docs": "Docs",
+      "pricing": "Pricing",
+      "trust": "Trust",
+      "contact": "Contact"
+    },
     "footer": {
       "columns": {
         "product": {
@@ -44,8 +53,10 @@
       "title": "End vibe-coding. Ship secure, auditable releases.",
       "description": "Speckit turns compliance from a scramble into a continuous, developer-native loop. Govern specs, orchestrate policy gates, and ship evidence on demand.",
       "actions": {
-        "requestDemo": "Request a demo",
-        "exploreDocs": "Explore docs"
+        "primaryLabel": "Request a demo",
+        "primaryHref": "/contact",
+        "secondaryLabel": "Explore docs",
+        "secondaryHref": "https://docs.speckit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "All teams see the same source of truth",
       "description": "Platform, security, compliance, and product leaders collaborate in a shared context. Speckit syncs with GitHub, Jira, ServiceNow, and Supabase so your data stays where work already happens.",
       "actions": {
-        "howItWorks": "See how it works",
-        "template": "Download rollout template"
+        "primaryLabel": "See how it works",
+        "primaryHref": "/how-it-works",
+        "secondaryLabel": "Download rollout template",
+        "secondaryHref": "/template"
       },
       "cards": [
         {
@@ -133,6 +146,269 @@
     "integrations": {
       "eyebrow": "Works with your stack",
       "items": ["GitHub", "GitLab", "Jira", "ServiceNow", "Supabase", "AWS", "Azure"]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Pricing",
+      "title": "Pick the plan that matches your governance journey",
+      "description": "All plans include the shared Supabase data core, policy orchestration engine, and evidence APIs.",
+      "actions": {
+        "primaryLabel": "Talk to sales",
+        "primaryHref": "/contact"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Launch",
+        "price": "$1,250/mo",
+        "description": "For teams piloting governance across 3 services.",
+        "highlights": ["Up to 20 engineers", "Spec + policy orchestration", "Evidence dashboard"],
+        "ctaLabel": "Request quote"
+      },
+      {
+        "name": "Scale",
+        "price": "$3,400/mo",
+        "description": "For organizations rolling Speckit out across multiple product lines.",
+        "highlights": ["Up to 75 engineers", "Multi-project Supabase tenancy", "Customer trust portal integration"],
+        "ctaLabel": "Request quote"
+      },
+      {
+        "name": "Enterprise",
+        "price": "Custom",
+        "description": "Dedicated pods for regulated workloads and complex environments.",
+        "highlights": ["Unlimited engineers", "Private cloud deployment options", "Compliance automation services"],
+        "ctaLabel": "Request quote"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Product",
+      "title": "One platform to model, enforce, and prove governance",
+      "description": "Speckit connects planning, delivery, and assurance. Ship faster with guardrails that satisfy platform, security, and compliance leaders.",
+      "actions": {
+        "primaryLabel": "See pricing",
+        "primaryHref": "/pricing"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Model",
+        "description": "Capture architecture decisions, risks, and policy owners in collaborative specs synced to Git."
+      },
+      {
+        "title": "Enforce",
+        "description": "Apply reusable controls across pipelines, cloud, and service catalogs with explainable results."
+      },
+      {
+        "title": "Prove",
+        "description": "Generate and distribute evidence to auditors, customers, and leadership automatically."
+      }
+    ],
+    "timeline": {
+      "title": "Speckit timeline",
+      "steps": [
+        {
+          "name": "Spec kickoff",
+          "description": "Start with a versioned spec linked to code. Assign approvers and risk posture."
+        },
+        {
+          "name": "Policy orchestration",
+          "description": "Controls run across CI, IaC, and runtime. Exceptions are documented and routed for review."
+        },
+        {
+          "name": "Evidence stream",
+          "description": "SBOMs, attestations, and control proofs sync to Supabase, GRC tools, and customer portals."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Integrations that meet you where you work",
+      "description": "Use Speckit UI, CLI, or APIs. Bring your own secrets manager, ticketing, and observability stack.",
+      "items": ["GitHub", "GitLab", "Bitbucket", "Jira", "ServiceNow", "PagerDuty", "AWS", "Azure", "GCP"]
+    },
+    "supabaseCard": {
+      "title": "Shared Supabase data core",
+      "paragraphs": [
+        "Marketing and product forms feed one Supabase project. Row-level security keeps leads private while your GTM and product teams analyze performance.",
+        "Use the service role to sync Speckit evidence to your data warehouse or customer trust portal with confidence."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "How it works",
+      "title": "A continuous loop that brings trust into daily delivery",
+      "description": "Speckit unites planning, shipping, and proving. Every step is automated, traceable, and designed for collaboration."
+    },
+    "stages": [
+      {
+        "name": "Capture",
+        "description": "Specs start in Git-backed docs. Risk, controls, and approvers are defined at the beginning, not the end."
+      },
+      {
+        "name": "Orchestrate",
+        "description": "Controls trigger across pipelines and environments. Exceptions kick off review workflows automatically."
+      },
+      {
+        "name": "Publish",
+        "description": "Evidence lands where it is needed — Supabase, GRC tools, customer trust portals, and analytics stacks."
+      }
+    ],
+    "stageLabel": "Step {count}",
+    "audiences": [
+      {
+        "role": "Platform",
+        "value": "Golden paths with governance built-in. No more waiting for approvals or chasing down sign-offs."
+      },
+      {
+        "role": "Security",
+        "value": "Policy-as-code with transparency. Audit every control execution and exception trail."
+      },
+      {
+        "role": "Compliance",
+        "value": "Evidence on demand. Dashboards map controls to frameworks and highlight gaps instantly."
+      }
+    ],
+    "tooling": {
+      "title": "Bring your own tooling",
+      "description": "Speckit integrates via webhooks, REST APIs, and SDKs. Use our Supabase adapters to sync data across environments with RLS intact.",
+      "items": [
+        "GitHub Actions, CircleCI, GitLab pipelines",
+        "Terraform, Pulumi, CloudFormation",
+        "ServiceNow, Jira, Linear workflow updates",
+        "Supabase, Snowflake, and customer trust portals"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Template",
+      "title": "A proven rollout playbook",
+      "description": "Download the six-week plan Speckit uses to launch with platform, security, and compliance teams.",
+      "actions": {
+        "primaryLabel": "Get the template",
+        "primaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Week 1 — Discovery",
+        "description": "Map current controls, tooling, and evidence flows. Identify pilot teams and success metrics."
+      },
+      {
+        "title": "Weeks 2-3 — Orchestration",
+        "description": "Configure Supabase, connect repos, and codify policy gates in pipelines and IaC."
+      },
+      {
+        "title": "Weeks 4-5 — Enablement",
+        "description": "Enable teams with templates, guardrail playbooks, and evidence dashboards."
+      },
+      {
+        "title": "Week 6 — Scale",
+        "description": "Review KPIs, expand to additional services, and integrate evidence feeds into trust portals."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contact",
+      "title": "See Speckit in action",
+      "description": "Share a bit about your platform program and we will tailor a walkthrough to your goals."
+    },
+    "form": {
+      "title": "Request a demo",
+      "description": "Tell us about your environment and target launch timeline.",
+      "submitLabel": "Request demo",
+      "fields": {
+        "nameLabel": "Full name",
+        "emailLabel": "Work email",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Company",
+        "focusLabel": "What should we focus on?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "Email",
+      "productQuestions": "Product questions: speckit@airnub.io",
+      "security": "Security: security@airnub.io",
+      "docsHeading": "Docs",
+      "docsDescription": "Explore API references and implementation guides.",
+      "docsCtaLabel": "docs.speckit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Speckit adapts to your security and platform operating model",
+      "description": "Pick a tailored path to orchestrate policy gates, evidence automation, and cross-team collaboration."
+    },
+    "personas": [
+      {
+        "title": "CISO",
+        "description": "Make compliance continuous. Turn control evidence into a daily signal instead of an annual fire drill.",
+        "href": "/solutions/ciso",
+        "ctaLabel": "Explore →"
+      },
+      {
+        "title": "DevSecOps",
+        "description": "Embed guardrails in every pipeline while empowering teams to ship faster with transparency.",
+        "href": "/solutions/devsecops",
+        "ctaLabel": "Explore →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Continuous compliance without manual scramble",
+      "description": "Speckit gives CISOs real-time visibility into control posture, exceptions, and audit readiness."
+    },
+    "outcomesTitle": "Why CISOs choose Speckit",
+    "outcomes": [
+      "Live control status mapped to SOC 2, ISO 27001, HIPAA, and FedRAMP",
+      "Automated SSP narratives and customer trust report feeds",
+      "Evidence retention policies backed by Supabase row-level security"
+    ],
+    "deliverables": {
+      "title": "Deliverables",
+      "cards": [
+        {
+          "title": "Control automation",
+          "description": "Codified guardrails for change management, access reviews, vulnerability management, and incident response."
+        },
+        {
+          "title": "Executive reporting",
+          "description": "Dashboards for board and customer updates with drill-down evidence trails."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Guardrails and speed for every delivery team",
+      "description": "Speckit gives DevSecOps teams programmable controls, observability, and shared context with security and compliance."
+    },
+    "benefitsTitle": "What DevSecOps gains",
+    "benefits": [
+      "Policy-as-code modules for GitHub Actions, GitLab CI, and Jenkins",
+      "Runtime attestations linked to environments and deployments",
+      "Service catalogs with self-serve golden paths and guardrails"
+    ],
+    "capabilities": {
+      "title": "Key capabilities",
+      "cards": [
+        {
+          "title": "Workflow adapters",
+          "description": "Drop-in actions, templates, and CLI commands for pipelines and infrastructure."
+        },
+        {
+          "title": "Observability hooks",
+          "description": "Send control results to Datadog, Grafana, or Slack with deep links into evidence."
+        }
+      ]
     }
   }
 }

--- a/apps/speckit/messages/es.json
+++ b/apps/speckit/messages/es.json
@@ -2,19 +2,28 @@
   "layout": {
     "skipToContent": "Saltar al contenido",
     "themeToggle": "Tema de alternar",
-    "starLabel": "Proyecto estrella",
     "languageLabel": "Idioma",
+    "githubLabel": "Speckit en Github",
+    "nav": {
+      "product": "Producto",
+      "howItWorks": "Cómo funciona",
+      "solutions": "Soluciones",
+      "docs": "Documento",
+      "pricing": "Fijación de precios",
+      "trust": "Confianza",
+      "contact": "Contacto"
+    },
     "footer": {
       "columns": {
         "product": {
           "heading": "Producto",
           "overview": "Descripción general",
           "howItWorks": "Cómo funciona",
-          "integrations": "Integraciones"
+          "integrations": "Integración"
         },
         "resources": {
           "heading": "Recursos",
-          "docs": "Documentación",
+          "docs": "Documento",
           "apiReference": "Referencia de API",
           "community": "Comunidad"
         },
@@ -22,19 +31,19 @@
           "heading": "Código abierto",
           "repo": "Repositorio",
           "templates": "Plantillas",
-          "issues": "Incidencias",
+          "issues": "Asuntos",
           "license": "Licencia"
         },
         "trust": {
           "heading": "Confianza",
           "trustCenter": "Centro de confianza",
           "status": "Estado",
-          "securityTxt": "security.txt"
+          "securityTxt": "Security.txt"
         }
       },
       "contact": {
         "label": "speckit@airnub.io",
-        "pricing": "Precios"
+        "pricing": "Fijación de precios"
       }
     }
   },
@@ -44,8 +53,10 @@
       "title": "Endvibe codificación. ",
       "description": "Speckit convierte el cumplimiento de una lucha en un bucle continuo y nativo del desarrollador. ",
       "actions": {
-        "requestDemo": "Solicitar una demostración",
-        "exploreDocs": "Explorar documentos"
+        "primaryLabel": "Solicitar una demostración",
+        "primaryHref": "/contacto",
+        "secondaryLabel": "Explorar documentos",
+        "secondaryHref": "https://docs.speckit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "Todos los equipos ven la misma fuente de verdad",
       "description": "La plataforma, la seguridad, el cumplimiento y los líderes de productos colaboran en un contexto compartido. ",
       "actions": {
-        "howItWorks": "Mira como funciona",
-        "template": "Descargar la plantilla de despliegue"
+        "primaryLabel": "Mira como funciona",
+        "primaryHref": "/How-it-works",
+        "secondaryLabel": "Descargar la plantilla de despliegue",
+        "secondaryHref": "/plantilla"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Fijación de precios",
+      "title": "Elija el plan que coincida con su viaje de gobierno",
+      "description": "Todos los planes incluyen el núcleo de datos de Supabase compartido, el motor de orquestación de políticas y las API de evidencia.",
+      "actions": {
+        "primaryLabel": "Hablar con ventas",
+        "primaryHref": "/contacto"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Lanzamiento",
+        "price": "$ 1,250/mes",
+        "description": "Para equipos que pilotan el gobierno en 3 servicios.",
+        "highlights": [
+          "Hasta 20 ingenieros",
+          "Spec + Orquestación de Política",
+          "Panel de evidencia"
+        ],
+        "ctaLabel": "Cotización de solicitud"
+      },
+      {
+        "name": "Escala",
+        "price": "$ 3,400/mes",
+        "description": "Para las organizaciones que rodan en múltiples líneas de productos.",
+        "highlights": [
+          "Hasta 75 ingenieros",
+          "Supabase de múltiples proyectos",
+          "Integración del portal de confianza del cliente"
+        ],
+        "ctaLabel": "Cotización de solicitud"
+      },
+      {
+        "name": "Empresa",
+        "price": "Costumbre",
+        "description": "PODS dedicados para cargas de trabajo reguladas y entornos complejos.",
+        "highlights": [
+          "Ingenieros ilimitados",
+          "Opciones de implementación de la nube privada",
+          "Servicios de automatización de cumplimiento"
+        ],
+        "ctaLabel": "Cotización de solicitud"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Producto",
+      "title": "Una plataforma para modelar, hacer cumplir y probar la gobernanza",
+      "description": "Speckit conecta la planificación, la entrega y la seguridad. ",
+      "actions": {
+        "primaryLabel": "Ver precios",
+        "primaryHref": "/Precio"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Modelo",
+        "description": "Capture las decisiones de arquitectura, los riesgos y los propietarios de políticas en especificaciones de colaboración sincronizadas a GIT."
+      },
+      {
+        "title": "Hacer cumplir",
+        "description": "Aplique controles reutilizables en las tuberías, la nube y los catálogos de servicios con resultados explicables."
+      },
+      {
+        "title": "Probar",
+        "description": "Genere y distribuya evidencia a auditores, clientes y liderazgo automáticamente."
+      }
+    ],
+    "timeline": {
+      "title": "Línea de tiempo de Speckit",
+      "steps": [
+        {
+          "name": "Patada de salida de especificaciones",
+          "description": "Comience con una especificación versionada vinculada al código. "
+        },
+        {
+          "name": "Orquestación de políticas",
+          "description": "Los controles se encuentran con CI, IAC y tiempo de ejecución. "
+        },
+        {
+          "name": "Evidencia de la corriente",
+          "description": "SBOMS, certificaciones y pruebas de control Sync para Supabase, GRC Tools y Portales de clientes."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Integraciones que te conocen donde trabajas",
+      "description": "Use Speckit UI, CLI o API. ",
+      "items": [
+        "Github",
+        "Gitlab",
+        "Bitbucket",
+        "Jira",
+        "Servicenow",
+        "Tarta",
+        "AWS",
+        "Azur",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Núcleo de datos de Supabase compartido",
+      "paragraphs": [
+        "Los formularios de marketing y productos alimentan un proyecto de Supabase. ",
+        "Use el rol de servicio para sincronizar evidencia de manchas con su almacén de datos o portal de confianza del cliente con confianza."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "Cómo funciona",
+      "title": "Un bucle continuo que brinda confianza en la entrega diaria",
+      "description": "Speckit une la planificación, el envío y la prueba. "
+    },
+    "stages": [
+      {
+        "name": "Captura",
+        "description": "Las especificaciones comienzan en documentos respaldados por Git. "
+      },
+      {
+        "name": "Orquestar",
+        "description": "Los controles se activan entre tuberías y entornos. "
+      },
+      {
+        "name": "Publicar",
+        "description": "La evidencia aterriza donde se necesita: Supabase, GRC Tools, Client Trust Portals y Analytics Sacks."
+      }
+    ],
+    "stageLabel": "Paso {Count}",
+    "audiences": [
+      {
+        "role": "Plataforma",
+        "value": "Caminos dorados con gobernanza incorporada. "
+      },
+      {
+        "role": "Seguridad",
+        "value": "Política como código con transparencia. "
+      },
+      {
+        "role": "Cumplimiento",
+        "value": "Evidencia bajo demanda. "
+      }
+    ],
+    "tooling": {
+      "title": "Trae tus propias herramientas",
+      "description": "Speckit se integra a través de Webhooks, REST API y SDK. ",
+      "items": [
+        "Github Actions, Circleci, Gitlab Pipelines",
+        "Terraform, Pulumi, CloudFormation",
+        "ServiceNow, Jira, actualizaciones de flujo de trabajo lineal",
+        "Supabase, copos de nieve y portales de confianza del cliente"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Plantilla",
+      "title": "Un libro de jugadas de lanzamiento probado",
+      "description": "Descargue el plan de seis semanas que Speckit usa para lanzar con equipos de plataforma, seguridad y cumplimiento.",
+      "actions": {
+        "primaryLabel": "Obtenga la plantilla",
+        "primaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Semana 1 - Descubrimiento",
+        "description": "Mapee los controles actuales, las herramientas y la evidencia. "
+      },
+      {
+        "title": "Semanas 2-3-Orquestación",
+        "description": "Configure Supabase, conecte Repos y codifique las puertas de políticas en tuberías e IAC."
+      },
+      {
+        "title": "Semanas 4-5-Habilitación",
+        "description": "Habilite equipos con plantillas, libros de jugadas de barandas y paneles de evidencia."
+      },
+      {
+        "title": "Semana 6 - Escala",
+        "description": "Revise los KPI, se expanda a servicios adicionales e integren evidencia de que se alimente en los portales de confianza."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contacto",
+      "title": "Ver Speckit en acción",
+      "description": "Comparta un poco sobre su programa de plataforma y adaptaremos un tutorial a sus objetivos."
+    },
+    "form": {
+      "title": "Solicitar una demostración",
+      "description": "Cuéntanos sobre tu entorno y la línea de tiempo de lanzamiento de Target.",
+      "submitLabel": "Demo de solicitud",
+      "fields": {
+        "nameLabel": "Nombre completo",
+        "emailLabel": "Correo electrónico de trabajo",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Compañía",
+        "focusLabel": "¿En qué debemos centrarnos?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "Correo electrónico",
+      "productQuestions": "Preguntas del producto: speckit@airnub.io",
+      "security": "Seguridad: seguridad@airnub.io",
+      "docsHeading": "Documento",
+      "docsDescription": "Explore las referencias de API y las guías de implementación.",
+      "docsCtaLabel": "docs.speckit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Soluciones",
+      "title": "Speckit se adapta a su modelo de operación de seguridad y plataforma",
+      "description": "Elija un camino a medida para orquestar puertas de políticas, automatización de evidencia y colaboración entre equipos."
+    },
+    "personas": [
+      {
+        "title": "CISO",
+        "description": "Haga que el cumplimiento sea continuo. ",
+        "href": "/Soluciones/CISO",
+        "ctaLabel": "Explorar →"
+      },
+      {
+        "title": "Devsecops",
+        "description": "Incrustar las barandillas en cada tubería mientras empodera a los equipos para enviar más rápido con transparencia.",
+        "href": "/Soluciones/DevSecops",
+        "ctaLabel": "Explorar →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Soluciones",
+      "title": "Cumplimiento continuo sin lucha manual",
+      "description": "Speckit brinda visibilidad en tiempo real de CISOS en la postura de control, excepciones y preparación de auditoría."
+    },
+    "outcomesTitle": "¿Por qué los cisos eligen Speckit?",
+    "outcomes": [
+      "Estado de control en vivo mapeado a SOC 2, ISO 27001, HIPAA y FEDRAMP",
+      "Las narrativas SSP automatizadas y el informe de la confianza del cliente se alimentan",
+      "Políticas de retención de evidencia respaldadas por Supabase Security a nivel de fila"
+    ],
+    "deliverables": {
+      "title": "Entregables",
+      "cards": [
+        {
+          "title": "Automatización de control",
+          "description": "Las barandillas codificadas para la gestión del cambio, las revisiones de acceso, la gestión de vulnerabilidad y la respuesta a los incidentes."
+        },
+        {
+          "title": "Informes ejecutivos",
+          "description": "Paneles para actualizaciones de tableros y clientes con senderos de evidencia de desglose."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Soluciones",
+      "title": "Guardacas y velocidad para cada equipo de entrega",
+      "description": "Speckit ofrece controles programables de los equipos de DevSecops, observabilidad y contexto compartido con seguridad y cumplimiento."
+    },
+    "benefitsTitle": "Lo que gana DevSecops",
+    "benefits": [
+      "Módulos de código de políticas para acciones de Github, Gitlab CI y Jenkins",
+      "Certificaciones de tiempo de ejecución vinculados a entornos e implementaciones",
+      "Catálogos de servicio con caminos dorados y barandillas de autoservicio"
+    ],
+    "capabilities": {
+      "title": "Capacidades clave",
+      "cards": [
+        {
+          "title": "Adaptadores de flujo de trabajo",
+          "description": "Acciones, plantillas y comandos de CLI para tuberías e infraestructura."
+        },
+        {
+          "title": "Ganchos de observabilidad",
+          "description": "Envíe los resultados de control a Datadog, Grafana o Slack con enlaces profundos como evidencia."
+        }
       ]
     }
   }

--- a/apps/speckit/messages/fr.json
+++ b/apps/speckit/messages/fr.json
@@ -2,27 +2,36 @@
   "layout": {
     "skipToContent": "Passer au contenu",
     "themeToggle": "Thème de basculement",
-    "starLabel": "Projet de star",
     "languageLabel": "Langue",
+    "githubLabel": "Speckit sur github",
+    "nav": {
+      "product": "Produit",
+      "howItWorks": "Comment ça marche",
+      "solutions": "Solutions",
+      "docs": "Docs",
+      "pricing": "Prix",
+      "trust": "Confiance",
+      "contact": "Contact"
+    },
     "footer": {
       "columns": {
         "product": {
           "heading": "Produit",
           "overview": "Aperçu",
-          "howItWorks": "Fonctionnement",
+          "howItWorks": "Comment ça marche",
           "integrations": "Intégrations"
         },
         "resources": {
           "heading": "Ressources",
-          "docs": "Documentation",
-          "apiReference": "Référence API",
+          "docs": "Docs",
+          "apiReference": "Référence de l'API",
           "community": "Communauté"
         },
         "openSource": {
           "heading": "Open source",
-          "repo": "Dépôt",
+          "repo": "Repo",
           "templates": "Modèles",
-          "issues": "Tickets",
+          "issues": "Problèmes",
           "license": "Licence"
         },
         "trust": {
@@ -34,7 +43,7 @@
       },
       "contact": {
         "label": "speckit@airnub.io",
-        "pricing": "Tarifs"
+        "pricing": "Prix"
       }
     }
   },
@@ -44,8 +53,10 @@
       "title": "Fin codant d'ambiance. ",
       "description": "Speckit transforme la conformité d'une brouillage en une boucle continue et native du développeur. ",
       "actions": {
-        "requestDemo": "Demander une démo",
-        "exploreDocs": "Explorer les documents"
+        "primaryLabel": "Demander une démo",
+        "primaryHref": "/contact",
+        "secondaryLabel": "Explorer les documents",
+        "secondaryHref": "https://docs.speckit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "Toutes les équipes voient la même source de vérité",
       "description": "La plate-forme, la sécurité, la conformité et les chefs de produit collaborent dans un contexte partagé. ",
       "actions": {
-        "howItWorks": "Voyez comment ça marche",
-        "template": "Télécharger le modèle de déploiement"
+        "primaryLabel": "Voyez comment ça marche",
+        "primaryHref": "/ how-it works",
+        "secondaryLabel": "Télécharger le modèle de déploiement",
+        "secondaryHref": "/modèle"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Prix",
+      "title": "Choisissez le plan qui correspond à votre parcours de gouvernance",
+      "description": "Tous les plans incluent le cœur de données SUPABASE partagé, le moteur d'orchestration politique et les API de preuve.",
+      "actions": {
+        "primaryLabel": "Parler aux ventes",
+        "primaryHref": "/contact"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Lancement",
+        "price": "1 250 $ / mois",
+        "description": "Pour les équipes pilotant la gouvernance à travers 3 services.",
+        "highlights": [
+          "Jusqu'à 20 ingénieurs",
+          "Orchestration de stratégie Spec +",
+          "Tableau de bord de preuve"
+        ],
+        "ctaLabel": "Demander la citation"
+      },
+      {
+        "name": "Échelle",
+        "price": "3 400 $ / mois",
+        "description": "Pour les organisations qui roulent Speckit sur plusieurs gammes de produits.",
+        "highlights": [
+          "Jusqu'à 75 ingénieurs",
+          "Location multi-projets Supabase",
+          "Intégration du portail de confiance client"
+        ],
+        "ctaLabel": "Demander la citation"
+      },
+      {
+        "name": "Entreprise",
+        "price": "Coutume",
+        "description": "Pods dédiés pour les charges de travail réglementées et les environnements complexes.",
+        "highlights": [
+          "Ingénieurs illimités",
+          "Options de déploiement en cloud privé",
+          "Services d'automatisation de la conformité"
+        ],
+        "ctaLabel": "Demander la citation"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Produit",
+      "title": "Une plate-forme pour modéliser, appliquer et prouver la gouvernance",
+      "description": "Speckit relie la planification, la livraison et l'assurance. ",
+      "actions": {
+        "primaryLabel": "Voir les prix",
+        "primaryHref": "/ prix"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Modèle",
+        "description": "Capturez des décisions d'architecture, des risques et des propriétaires de politiques dans des spécifications collaboratives synchronisées avec GIT."
+      },
+      {
+        "title": "Imposer",
+        "description": "Appliquez des contrôles réutilisables entre les pipelines, les cloud et les catalogues de services avec des résultats explicables."
+      },
+      {
+        "title": "Prouver",
+        "description": "Générez et distribuez automatiquement des preuves aux auditeurs, aux clients et au leadership."
+      }
+    ],
+    "timeline": {
+      "title": "Chronologie de speckit",
+      "steps": [
+        {
+          "name": "Coup d'envoi",
+          "description": "Commencez avec une spécification versionnée liée au code. "
+        },
+        {
+          "name": "Orchestration politique",
+          "description": "Les contrôles se déroulent sur CI, IAC et Runtime. "
+        },
+        {
+          "name": "Flux de preuves",
+          "description": "SBOMS, ATTSTATIONS ET CONTRÔLE Les preuves se synchronisent avec Supabase, les outils GRC et les portails clients."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Les intégrations qui vous rencontrent là où vous travaillez",
+      "description": "Utilisez Speckit UI, CLI ou API. ",
+      "items": [
+        "Github",
+        "Gitlab",
+        "Bitbucket",
+        "Jira",
+        "Serviron",
+        "Pager",
+        "AWS",
+        "Azuré",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Core de données Supabase partagée",
+      "paragraphs": [
+        "Les formulaires de marketing et de produits alimentent un projet Supabase. ",
+        "Utilisez le rôle de service pour synchroniser les preuves Speckit à votre entrepôt de données ou votre portail de confiance client en toute confiance."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "Comment ça marche",
+      "title": "Une boucle continue qui apporte la confiance dans la livraison quotidienne",
+      "description": "Speckit unit la planification, l'expédition et la prouvance. "
+    },
+    "stages": [
+      {
+        "name": "Capturer",
+        "description": "Les spécifications commencent dans des documents soutenus par Git. "
+      },
+      {
+        "name": "Orchestrer",
+        "description": "Les commandes se déclenchent entre les pipelines et les environnements. "
+      },
+      {
+        "name": "Publier",
+        "description": "Les preuves atterrissent là où il est nécessaire - Supabase, outils GRC, portails de confiance des clients et piles d'analyse."
+      }
+    ],
+    "stageLabel": "Étape {comte}",
+    "audiences": [
+      {
+        "role": "Plate-forme",
+        "value": "Golden Paths avec gouvernance intégrée. "
+      },
+      {
+        "role": "Sécurité",
+        "value": "Politique en tant que code avec transparence. "
+      },
+      {
+        "role": "Conformité",
+        "value": "Preuve à la demande. "
+      }
+    ],
+    "tooling": {
+      "title": "Apportez vos propres outils",
+      "description": "Speckit s'intègre via les livres Web, les API REST et les SDK. ",
+      "items": [
+        "Actions github, circleci, pipelines gitlab",
+        "Terraform, Pulumi, Cloudformation",
+        "ServiceNow, Jira, mises à jour de flux de travail linéaire",
+        "Supabase, flocon de neige et portails de confiance des clients"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Modèle",
+      "title": "Un livre de jeu de déploiement éprouvé",
+      "description": "Téléchargez le plan de six semaines que Speckit utilise pour lancer avec des équipes de plate-forme, de sécurité et de conformité.",
+      "actions": {
+        "primaryLabel": "Obtenez le modèle",
+        "primaryHref": "https://github.com/airnub/speckittemplates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Semaine 1 - Découverte",
+        "description": "Carte Contrôles de courant, outils et flux de preuves. "
+      },
+      {
+        "title": "Semaines 2-3 - Orchestration",
+        "description": "Configurez Supabase, connectez les références et codifiez les portes de stratégie dans les pipelines et l'IAC."
+      },
+      {
+        "title": "Semaines 4-5 - Activation",
+        "description": "Activez les équipes avec des modèles, des livres de jeu de garde-corps et des preuves de tableaux de bord."
+      },
+      {
+        "title": "Semaine 6 - Échelle",
+        "description": "Examiner les KPI, développer des services supplémentaires et intégrer les preuves alimente les portails de fiducie."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contact",
+      "title": "Voir Speckit en action",
+      "description": "Partagez un peu sur votre programme de plate-forme et nous adapterons une procédure pas à pas à vos objectifs."
+    },
+    "form": {
+      "title": "Demander une démo",
+      "description": "Parlez-nous de votre environnement et de votre calendrier cible.",
+      "submitLabel": "Demander une démo",
+      "fields": {
+        "nameLabel": "Nom et prénom",
+        "emailLabel": "E-mail de travail",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Entreprise",
+        "focusLabel": "Sur quoi devrions-nous nous concentrer?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "E-mail",
+      "productQuestions": "Questions du produit: speckit@airnub.io",
+      "security": "Sécurité: Security@airnub.io",
+      "docsHeading": "Docs",
+      "docsDescription": "Explorez les références API et les guides de mise en œuvre.",
+      "docsCtaLabel": "docs.speckit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Speckit s'adapte à votre modèle d'exploitation de sécurité et de plate-forme",
+      "description": "Choisissez un chemin sur mesure pour orchestrer les portes politiques, l'automatisation des preuves et la collaboration entre les équipes."
+    },
+    "personas": [
+      {
+        "title": "CISO",
+        "description": "Rendre la conformité continue. ",
+        "href": "/ Solutions / CISO",
+        "ctaLabel": "Explorer →"
+      },
+      {
+        "title": "Devsecops",
+        "description": "Embrasser les garde-corps dans chaque pipeline tout en permettant aux équipes d'expédier plus rapidement avec transparence.",
+        "href": "/ Solutions / DevSecops",
+        "ctaLabel": "Explorer →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Conformité continue sans brouette manuelle",
+      "description": "Speckit donne aux CISO une visibilité en temps réel dans la posture de contrôle, les exceptions et la préparation à l'audit."
+    },
+    "outcomesTitle": "Pourquoi les cisos choisissent Speckit",
+    "outcomes": [
+      "Statut de contrôle en direct cartographié à SOC 2, ISO 27001, HIPAA et Fedramp",
+      "Narratives SSP automatisées et Flux de rapport de confiance des clients",
+      "Politiques de conservation des preuves soutenues par la sécurité de Supabase Row au niveau"
+    ],
+    "deliverables": {
+      "title": "Livrables",
+      "cards": [
+        {
+          "title": "Automatisation du contrôle",
+          "description": "Guard-rédacteur codifié pour la gestion du changement, les revues d'accès, la gestion de la vulnérabilité et la réponse aux incidents."
+        },
+        {
+          "title": "Reportage exécutif",
+          "description": "Tableaux de bord pour les mises à jour de la carte et des clients avec des traces de preuves de forage."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Solutions",
+      "title": "Garde-corps et vitesse pour chaque équipe de livraison",
+      "description": "Speckit offre aux équipes de DevSecops, des contrôles programmables, de l'observabilité et du contexte partagé avec la sécurité et la conformité."
+    },
+    "benefitsTitle": "Ce que DevseCops gagne",
+    "benefits": [
+      "Modules politiques à code pour les actions GitHub, Gitlab CI et Jenkins",
+      "ATTESTATIONS DE RUNIE",
+      "Catalogues de service avec des chemins d'or et des garde-corps en libre-service"
+    ],
+    "capabilities": {
+      "title": "Capacités clés",
+      "cards": [
+        {
+          "title": "Adaptateurs de workflow",
+          "description": "Actions, modèles et commandes CLI pour les pipelines et les infrastructures."
+        },
+        {
+          "title": "Crochets d'observabilité",
+          "description": "Envoyez des résultats de contrôle à Datadog, Grafana ou Slack avec des liens profonds en preuves."
+        }
       ]
     }
   }

--- a/apps/speckit/messages/ga.json
+++ b/apps/speckit/messages/ga.json
@@ -2,39 +2,48 @@
   "layout": {
     "skipToContent": "Scipeáil chuig ábhar",
     "themeToggle": "Téama toggle",
-    "starLabel": "Tionscadal réalta",
     "languageLabel": "Teanga",
+    "githubLabel": "Speckit ar GitHub",
+    "nav": {
+      "product": "Toradh",
+      "howItWorks": "Conas a oibríonn sé",
+      "solutions": "Réitigh",
+      "docs": "Docs",
+      "pricing": "Praghsáil",
+      "trust": "Iontaobhas",
+      "contact": "Lionsa tadhaill"
+    },
     "footer": {
       "columns": {
         "product": {
-          "heading": "Táirge",
+          "heading": "Toradh",
           "overview": "Forbhreathnú",
           "howItWorks": "Conas a oibríonn sé",
-          "integrations": "Comhtháthuithe"
+          "integrations": "Comhtháthú"
         },
         "resources": {
-          "heading": "Acmhainní",
-          "docs": "Doiciméadú",
+          "heading": "Caisiún",
+          "docs": "Docs",
           "apiReference": "Tagairt API",
           "community": "Pobal"
         },
         "openSource": {
-          "heading": "Foinse oscailte",
-          "repo": "Stórlann",
+          "heading": "Foinse Oscailte",
+          "repo": "Athmhuintearas",
           "templates": "Teimpléid",
-          "issues": "Ceisteanna",
-          "license": "Ceadúnas"
+          "issues": "Saincheist",
+          "license": "Cead"
         },
         "trust": {
-          "heading": "Muinín",
-          "trustCenter": "Lárionad muiníne",
+          "heading": "Iontaobhas",
+          "trustCenter": "Ionad muiníne",
           "status": "Stádas",
-          "securityTxt": "security.txt"
+          "securityTxt": "slándáil.txt"
         }
       },
       "contact": {
         "label": "speckit@airnub.io",
-        "pricing": "Praghsanna"
+        "pricing": "Praghsáil"
       }
     }
   },
@@ -44,8 +53,10 @@
       "title": "Deireadh a chur le códú vibe. ",
       "description": "Casann Speckit comhlíonadh ó scramble go lúb leanúnach, dúchais forbróra. ",
       "actions": {
-        "requestDemo": "Taispeántas a iarraidh",
-        "exploreDocs": "Docs a iniúchadh"
+        "primaryLabel": "Taispeántas a iarraidh",
+        "primaryHref": "/teagmháil",
+        "secondaryLabel": "Docs a iniúchadh",
+        "secondaryHref": "https://docs.speckit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "Feiceann gach foireann an fhoinse fhírinne chéanna",
       "description": "Comhoibríonn Ardán, Slándáil, Comhlíonadh, agus Ceannairí Táirgí i gcomhthéacs comhroinnte. ",
       "actions": {
-        "howItWorks": "Féach conas a oibríonn sé",
-        "template": "Íoslódáil teimpléad rolladh amach"
+        "primaryLabel": "Féach conas a oibríonn sé",
+        "primaryHref": "/How-it-Works",
+        "secondaryLabel": "Íoslódáil teimpléad rolladh amach",
+        "secondaryHref": "/teimpléad"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Praghsáil",
+      "title": "Roghnaigh an plean a mheaitseálann do thuras rialachais",
+      "description": "I measc na bpleananna go léir tá croílár na sonraí supabase, inneall ceolfhoirne beartais, agus APIs fianaise.",
+      "actions": {
+        "primaryLabel": "Labhair le Díolacháin",
+        "primaryHref": "/teagmháil"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Coltach",
+        "price": "$ 1,250/mo",
+        "description": "I gcás foirne a phíolótú rialachas thar 3 sheirbhís.",
+        "highlights": [
+          "Suas le 20 innealtóir",
+          "Ceolfhoirne beartais spec +",
+          "Painéal na Fianaise"
+        ],
+        "ctaLabel": "Athfhriotail Iarraidh"
+      },
+      {
+        "name": "Scim a bhaint de",
+        "price": "$ 3,400/mo",
+        "description": "I gcás eagraíochtaí a rolladh amach ar fud línte iltháirge.",
+        "highlights": [
+          "Suas le 75 innealtóir",
+          "Tionóntacht supabase il-thionscadail",
+          "Comhtháthú Tairseach Iontaobhais Custaiméirí"
+        ],
+        "ctaLabel": "Athfhriotail Iarraidh"
+      },
+      {
+        "name": "Fiontar",
+        "price": "Cur síos",
+        "description": "Pods tiomnaithe le haghaidh ualaí oibre rialáilte agus timpeallachtaí casta.",
+        "highlights": [
+          "Innealtóirí Neamhtheoranta",
+          "Roghanna imlonnaithe scamall príobháideach",
+          "Seirbhísí uathoibrithe comhlíonta"
+        ],
+        "ctaLabel": "Athfhriotail Iarraidh"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Toradh",
+      "title": "Ardán amháin chun rialachas a mhúnlú, a fhorfheidhmiú agus a chruthú",
+      "description": "Nascann Speckit pleanáil, seachadadh agus dearbhú. ",
+      "actions": {
+        "primaryLabel": "Féach Praghsáil",
+        "primaryHref": "/Praghsáil"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Múnla",
+        "description": "Cinntí ailtireachta, rioscaí, agus úinéirí beartais a ghabháil i sonraíochtaí comhoibritheacha atá sioncronaithe le Git."
+      },
+      {
+        "title": "Éis a fhorfheidhmiú",
+        "description": "Cuir rialuithe ath -inúsáidte i bhfeidhm ar fud na bpíblínte, na scamall, agus na gcatalóga seirbhíse le torthaí inmhianaithe."
+      },
+      {
+        "title": "Ardaigh",
+        "description": "Fianaise a ghiniúint agus a dháileadh ar iniúchóirí, custaiméirí agus ceannaireacht go huathoibríoch."
+      }
+    ],
+    "timeline": {
+      "title": "Amlíne Speckit",
+      "steps": [
+        {
+          "name": "Kickoff spec",
+          "description": "Tosaigh le sonra leagan atá nasctha le cód. "
+        },
+        {
+          "name": "Ceolfhoirne beartais",
+          "description": "Reáchtálann na rialuithe ar fud CI, IAC, agus Runtime. "
+        },
+        {
+          "name": "Sruth fianaise",
+          "description": "Sboms, fianú, agus cruthúnais rialaithe a bhaineann le supabase, uirlisí GRC, agus tairseacha custaiméirí."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Comhtháthú a bhuaileann leat san áit a n -oibríonn tú",
+      "description": "Bain úsáid as Speckit Chomhéadain, CLI, nó APIs. ",
+      "items": [
+        "Github",
+        "GITLAB",
+        "Bitbucket",
+        "Jira",
+        "ServiceNow",
+        "Pasfhocal",
+        "Aws",
+        "(De chuid) na n -asanach",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Croí sonraí supabase comhroinnte",
+      "paragraphs": [
+        "Cuireann foirmeacha margaíochta agus táirgí tionscadal supabase amháin chun cinn. ",
+        "Bain úsáid as ról na seirbhíse chun fianaise a shioncronú le do stóras sonraí nó le do thairseach iontaobhais custaiméirí go muiníneach."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "Conas a oibríonn sé",
+      "title": "Lúb leanúnach a thugann muinín do sheachadadh laethúil",
+      "description": "Aontaíonn Speckit pleanáil, loingseoireacht agus cruthú. "
+    },
+    "stages": [
+      {
+        "name": "Racht",
+        "description": "Tosaíonn specs i ndoiciméid a bhfuil tacaíocht GIT acu. "
+      },
+      {
+        "name": "Ceolfhoirne",
+        "description": "Téann na rialuithe thar phíblínte agus timpeallachtaí. "
+      },
+      {
+        "name": "Foilsigh",
+        "description": "Tailte fianaise ina bhfuil gá leis - supabase, uirlisí GRC, tairseacha iontaobhais custaiméirí, agus stacanna anailísíochta."
+      }
+    ],
+    "stageLabel": "Céim {Count}",
+    "audiences": [
+      {
+        "role": "Ardán",
+        "value": "Cosáin órga le rialachas tógtha isteach. "
+      },
+      {
+        "role": "Slándáil",
+        "value": "Beartas-mar-chód le trédhearcacht. "
+      },
+      {
+        "role": "Comhlíonadh",
+        "value": "Fianaise ar éileamh. "
+      }
+    ],
+    "tooling": {
+      "title": "Tabhair leat do uirlisí féin",
+      "description": "Comhtháthaíonn Speckit trí WebHooks, REST APIs, agus SDKS. ",
+      "items": [
+        "Gníomhartha GitHub, Circleci, Píblínte GitLab",
+        "Terraform, Pulumi, Cloudformation",
+        "ServiceNow, Jira, nuashonruithe ar shreabhadh oibre líneach",
+        "Tairseacha Supabase, Snowflake, agus Custaiméirí"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Teimpléad",
+      "title": "Leabhar súgartha cruthaithe rolladh amach cruthaithe",
+      "description": "Íoslódáil an plean sé seachtaine a úsáideann Speckit le seoladh le foirne ardán, slándála agus comhlíonta.",
+      "actions": {
+        "primaryLabel": "Faigh an teimpléad",
+        "primaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Seachtain 1 - Fionnachtain",
+        "description": "Léarscáil rialuithe reatha, uirlisí, agus sreafaí fianaise. "
+      },
+      {
+        "title": "Seachtainí 2-3-Ceolfhoirne",
+        "description": "Cumraigh supabase, ceangail repos, agus códú geataí beartais i bpíblínte agus IAC."
+      },
+      {
+        "title": "Seachtainí 4-5-Cumasú",
+        "description": "Cumasaigh foirne le teimpléid, leabhair súgartha ráille cosanta, agus dashboards fianaise."
+      },
+      {
+        "title": "Seachtain 6 - Scála",
+        "description": "Athbhreithniú a dhéanamh ar KPIs, leathnaigh go seirbhísí breise, agus comhtháthaítear fianaise i dtairseacha iontaobhais."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Lionsa tadhaill",
+      "title": "Féach Speckit i mbun gnímh",
+      "description": "Roinn beagán faoi do chlár ardán agus déanfaimid siúlóid a chur in oiriúint do do spriocanna."
+    },
+    "form": {
+      "title": "Taispeántas a iarraidh",
+      "description": "Inis dúinn faoi do thimpeallacht agus do sprioc -amlíne seolta.",
+      "submitLabel": "Taispeántas a iarraidh",
+      "fields": {
+        "nameLabel": "Ainm iomlán",
+        "emailLabel": "Ríomhphost oibre",
+        "emailRequiredSuffix": "-",
+        "companyLabel": "Cuideachta",
+        "focusLabel": "Cad ba cheart dúinn díriú air?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "Ríomhphost a chur chuig",
+      "productQuestions": "Ceisteanna Táirgí: specit@airnub.io",
+      "security": "Slándáil: Slándáil@airnub.io",
+      "docsHeading": "Docs",
+      "docsDescription": "Déan iniúchadh ar thagairtí API agus ar threoracha forfheidhmithe.",
+      "docsCtaLabel": "docs.speckit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Réitigh",
+      "title": "Déanann Speckit oiriúnú ar do mhúnla oibriúcháin slándála agus ardáin",
+      "description": "Roghnaigh cosán saincheaptha chun geataí beartais, uathoibriú fianaise, agus comhoibriú tras-fhoireann a eagrú."
+    },
+    "personas": [
+      {
+        "title": "CISO",
+        "description": "Comhlíonadh a dhéanamh leanúnach. ",
+        "href": "/Solutions/ciso",
+        "ctaLabel": "Iniúchadh →"
+      },
+      {
+        "title": "Devsecops",
+        "description": "Ráillí cosanta a leabú i ngach píblíne agus ag an am céanna foirne a chumhachtú chun long a dhéanamh níos tapúla le trédhearcacht.",
+        "href": "/Solutions/Devsecops",
+        "ctaLabel": "Iniúchadh →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Réitigh",
+      "title": "Comhlíonadh leanúnach gan scramble láimhe",
+      "description": "Tugann Speckit infheictheacht fíor-ama CISOS i staidiúir rialaithe, eisceachtaí, agus ullmhacht iniúchta."
+    },
+    "outcomesTitle": "Cén fáth a roghnaíonn cisos speckit",
+    "outcomes": [
+      "Stádas rialaithe beo mapáilte go SOC 2, ISO 27001, HIPAA, agus FedRamp",
+      "Scéalta uathoibrithe SSP agus Tuarascáil ar Iontaobhas Custaiméirí Fothaí",
+      "Polasaithe coinneála fianaise le tacaíocht ó shlándáil ar leibhéal as a chéile"
+    ],
+    "deliverables": {
+      "title": "Nithe ​​insoláthartha",
+      "cards": [
+        {
+          "title": "Uathoibriú rialaithe",
+          "description": "Ráillí cosanta códaithe le haghaidh bainistíochta athraithe, athbhreithnithe rochtana, bainistíocht leochaileachta, agus freagairt teagmhais."
+        },
+        {
+          "title": "Tuairisciú feidhmiúcháin",
+          "description": "Dashboards le haghaidh nuashonruithe boird agus custaiméirí le cosáin fianaise druileála síos."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Réitigh",
+      "title": "Ráillí cosanta agus luas do gach foireann seachadta",
+      "description": "Tugann Speckit rialuithe in -ríomhchláraithe, inbhraite, agus comhthéacs comhroinnte le slándáil agus le comhlíonadh."
+    },
+    "benefitsTitle": "Cad a ghnóthaíonn Devsecops",
+    "benefits": [
+      "Modúil beartais-mar-chód do ghníomhartha GitHub, Gitlab CI, agus Jenkins",
+      "Fianuithe Runtime atá nasctha le timpeallachtaí agus imlonnú",
+      "Catalóga seirbhíse le cosáin órga féinfhreastail agus ráillí cosanta"
+    ],
+    "capabilities": {
+      "title": "Eochairchumais",
+      "cards": [
+        {
+          "title": "Cuibheoirí sreafa oibre",
+          "description": "Gníomhartha, teimpléid, agus orduithe CLI le haghaidh píblínte agus bonneagair."
+        },
+        {
+          "title": "Crúcaí inbhraiteachta",
+          "description": "Seol na torthaí rialaithe chuig DataDog, Grafana, nó slack le naisc dhomhain i bhfianaise."
+        }
       ]
     }
   }

--- a/apps/speckit/messages/it.json
+++ b/apps/speckit/messages/it.json
@@ -2,8 +2,17 @@
   "layout": {
     "skipToContent": "Salta al contenuto",
     "themeToggle": "Attiva tema",
-    "starLabel": "Progetto stellare",
     "languageLabel": "Lingua",
+    "githubLabel": "Speckit su GitHub",
+    "nav": {
+      "product": "Prodotto",
+      "howItWorks": "Come funziona",
+      "solutions": "Soluzioni",
+      "docs": "Documenti",
+      "pricing": "Prezzi",
+      "trust": "Fiducia",
+      "contact": "Contatto"
+    },
     "footer": {
       "columns": {
         "product": {
@@ -14,22 +23,22 @@
         },
         "resources": {
           "heading": "Risorse",
-          "docs": "Documentazione",
+          "docs": "Documenti",
           "apiReference": "Riferimento API",
           "community": "Comunità"
         },
         "openSource": {
           "heading": "Open source",
-          "repo": "Repository",
+          "repo": "Repo",
           "templates": "Modelli",
-          "issues": "Segnalazioni",
+          "issues": "Problemi",
           "license": "Licenza"
         },
         "trust": {
           "heading": "Fiducia",
           "trustCenter": "Centro di fiducia",
           "status": "Stato",
-          "securityTxt": "security.txt"
+          "securityTxt": "Security.txt"
         }
       },
       "contact": {
@@ -44,8 +53,10 @@
       "title": "End Codifica per l'atmosfera. ",
       "description": "Speckit trasforma la conformità da uno scramble in un ciclo continuo e nativo degli sviluppatori. ",
       "actions": {
-        "requestDemo": "Richiedere una demo",
-        "exploreDocs": "Esplora i documenti"
+        "primaryLabel": "Richiedere una demo",
+        "primaryHref": "/contatto",
+        "secondaryLabel": "Esplora i documenti",
+        "secondaryHref": "https://docs.spect.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "Tutte le squadre vedono la stessa fonte di verità",
       "description": "I leader della piattaforma, della sicurezza, della conformità e dei prodotti collaborano in un contesto condiviso. ",
       "actions": {
-        "howItWorks": "Guarda come funziona",
-        "template": "Scarica il modello di lancio"
+        "primaryLabel": "Guarda come funziona",
+        "primaryHref": "/How-It-Works",
+        "secondaryLabel": "Scarica il modello di lancio",
+        "secondaryHref": "/modello"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Prezzi",
+      "title": "Scegli il piano che corrisponda al tuo viaggio di governance",
+      "description": "Tutti i piani includono il core di dati di suvabase condiviso, il motore di orchestrazione delle politiche e le API di prova.",
+      "actions": {
+        "primaryLabel": "Parla con le vendite",
+        "primaryHref": "/contatto"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Lancio",
+        "price": "$ 1.250/mese",
+        "description": "Per le squadre che pilotano la governance in 3 servizi.",
+        "highlights": [
+          "Fino a 20 ingegneri",
+          "Spec + Orchestrazione della politica",
+          "Dashboard di prova"
+        ],
+        "ctaLabel": "Preventivo della richiesta"
+      },
+      {
+        "name": "Scala",
+        "price": "$ 3,400/mese",
+        "description": "Per le organizzazioni che lanciano Speckit su più linee di prodotti.",
+        "highlights": [
+          "Fino a 75 ingegneri",
+          "Locazione di suvabase multi-progetto",
+          "Integrazione del portale di fiducia del cliente"
+        ],
+        "ctaLabel": "Preventivo della richiesta"
+      },
+      {
+        "name": "Impresa",
+        "price": "Costume",
+        "description": "Pod dedicati per carichi di lavoro regolamentati e ambienti complessi.",
+        "highlights": [
+          "Ingegneri illimitati",
+          "Opzioni di distribuzione del cloud privato",
+          "Servizi di automazione della conformità"
+        ],
+        "ctaLabel": "Preventivo della richiesta"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Prodotto",
+      "title": "Una piattaforma per modellare, applicare e dimostrare la governance",
+      "description": "Speckit collega la pianificazione, la consegna e la garanzia. ",
+      "actions": {
+        "primaryLabel": "Vedi i prezzi",
+        "primaryHref": "/Prezzi"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Modello",
+        "description": "Acquisisci decisioni di architettura, rischi e proprietari di politiche nelle specifiche collaborative sincronizzate con Git."
+      },
+      {
+        "title": "Applicare",
+        "description": "Applicare i controlli riutilizzabili tra condotte, cloud e cataloghi di servizio con risultati spiegabili."
+      },
+      {
+        "title": "Dimostrare",
+        "description": "Generare e distribuire prove a revisori, clienti e leadership automaticamente."
+      }
+    ],
+    "timeline": {
+      "title": "Sequenza temporale Speckit",
+      "steps": [
+        {
+          "name": "Kickoff Spec",
+          "description": "Inizia con una specifica versione collegata al codice. "
+        },
+        {
+          "name": "Orchestrazione politica",
+          "description": "I controlli attraversano CI, IAC e runtime. "
+        },
+        {
+          "name": "Flusso di prove",
+          "description": "SBOM, attestazioni e prove di controllo si sincronizzano con supabase, strumenti GRC e portali dei clienti."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Integrazioni che ti incontrano dove lavori",
+      "description": "Usa l'interfaccia utente di Speckit, la CLI o le API. ",
+      "items": [
+        "Github",
+        "Gitlab",
+        "Bitbucket",
+        "Jira",
+        "Servicenow",
+        "PagerDuty",
+        "AWS",
+        "Azzurro",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Core di dati di supabase condiviso",
+      "paragraphs": [
+        "Le forme di marketing e prodotti alimentano un progetto di suvabase. ",
+        "Utilizzare il ruolo del servizio per sincronizzare le prove Speckit al tuo data warehouse o al portale di fiducia dei clienti con fiducia."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "Come funziona",
+      "title": "Un ciclo continuo che porta la fiducia nella consegna giornaliera",
+      "description": "Speckit unisce la pianificazione, la spedizione e la prova. "
+    },
+    "stages": [
+      {
+        "name": "Catturare",
+        "description": "Le specifiche iniziano in documenti con garanzia di GIT. "
+      },
+      {
+        "name": "Orchestrare",
+        "description": "I controlli si innescano attraverso condutture e ambienti. "
+      },
+      {
+        "name": "Pubblicare",
+        "description": "Le prove atterrano dove è necessario: supabase, strumenti GRC, portali di fiducia dei clienti e pile di analisi."
+      }
+    ],
+    "stageLabel": "Passaggio {conta}",
+    "audiences": [
+      {
+        "role": "Piattaforma",
+        "value": "Percorsi d'oro con governance integrata. "
+      },
+      {
+        "role": "Sicurezza",
+        "value": "Politica-come-codice con trasparenza. "
+      },
+      {
+        "role": "Conformità",
+        "value": "Prove su richiesta. "
+      }
+    ],
+    "tooling": {
+      "title": "Porta i tuoi strumenti",
+      "description": "Speckit si integra tramite Webhooks, API REST e SDK. ",
+      "items": [
+        "Github Actions, Circleci, Gitlab Pipelines",
+        "Terraform, Pulumi, CloudFormation",
+        "ServiceNow, Jira, aggiornamenti del flusso di lavoro lineari",
+        "Suptabase, Snowflake e Portali di fiducia dei clienti"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Modello",
+      "title": "Un comprovato playbook di lancio",
+      "description": "Scarica il piano di sei settimane che Speckit utilizza per il lancio con team di piattaforma, sicurezza e conformità.",
+      "actions": {
+        "primaryLabel": "Ottieni il modello",
+        "primaryHref": "https://github.com/airnub/spect-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Settimana 1 - Scoperta",
+        "description": "Mappa Controlli di corrente, strumenti e flussi di prove. "
+      },
+      {
+        "title": "Settimane 2-3-Orchestrazione",
+        "description": "Configurare Suptabase, connettere repository e codificare le porte della politica in pipeline e IAC."
+      },
+      {
+        "title": "Settimane 4-5-Abilitazione",
+        "description": "Abilita squadre con modelli, playbook di Guardrail e dashboard di prove."
+      },
+      {
+        "title": "Settimana 6 - Scala",
+        "description": "Rivedi i KPI, espandi su ulteriori servizi e integra i feed di evidenza nei portali di fiducia."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contatto",
+      "title": "Vedi Speckit in azione",
+      "description": "Condividi un po 'del programma della piattaforma e adatteremo una procedura dettagliata per i tuoi obiettivi."
+    },
+    "form": {
+      "title": "Richiedere una demo",
+      "description": "Parlaci del tuo ambiente e della tua sequenza temporale di lancio target.",
+      "submitLabel": "Richiedi demo",
+      "fields": {
+        "nameLabel": "Nome e cognome",
+        "emailLabel": "Email di lavoro",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Azienda",
+        "focusLabel": "Su cosa dovremmo concentrarci?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "E-mail",
+      "productQuestions": "Domande sul prodotto: speckit@airnub.io",
+      "security": "Sicurezza: security@airnub.io",
+      "docsHeading": "Documenti",
+      "docsDescription": "Esplora i riferimenti API e le guide di implementazione.",
+      "docsCtaLabel": "docs.specit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Soluzioni",
+      "title": "Speckit si adatta al tuo modello operativo per la sicurezza e la piattaforma",
+      "description": "Scegli un percorso su misura per orchestrare cancelli della politica, automazione delle prove e collaborazione tra team."
+    },
+    "personas": [
+      {
+        "title": "Ciso",
+        "description": "Rendere la conformità continua. ",
+        "href": "/Soluzioni/CISO",
+        "ctaLabel": "Esplora →"
+      },
+      {
+        "title": "Devsecops",
+        "description": "Incorpora i guardrail in ogni pipeline mentre consente alle squadre di spedire più velocemente con trasparenza.",
+        "href": "/soluzioni/devsecops",
+        "ctaLabel": "Esplora →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Soluzioni",
+      "title": "Conformità continua senza scramble manuale",
+      "description": "Speckit offre la visibilità in tempo reale dei CISO sulla postura di controllo, sulle eccezioni e sulla prontezza alla revisione contabile."
+    },
+    "outcomesTitle": "Perché i cisos scelgono Speckit",
+    "outcomes": [
+      "Stato di controllo dal vivo mappato a SOC 2, ISO 27001, HIPAA e FEDRAMPM",
+      "Narrazioni SSP automatizzate e feed del rapporto di fiducia dei clienti",
+      "Politiche di ritenzione delle prove sostenute dalla sicurezza a livello di riga di suvabase"
+    ],
+    "deliverables": {
+      "title": "Risultati",
+      "cards": [
+        {
+          "title": "Automazione del controllo",
+          "description": "Guardrails codificati per la gestione delle modifiche, revisioni di accesso, gestione della vulnerabilità e risposta agli incidenti."
+        },
+        {
+          "title": "Segnalazione esecutiva",
+          "description": "Dashboard per gli aggiornamenti di bordo e clienti con percorsi di prove di perforazione."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Soluzioni",
+      "title": "Guardrails e velocità per ogni squadra di consegna",
+      "description": "Speckit offre ai team Devsecops controlli programmabili, osservabilità e contesto condiviso con sicurezza e conformità."
+    },
+    "benefitsTitle": "Ciò che Devsecops guadagna",
+    "benefits": [
+      "Moduli politici-come-code per le azioni GitHub, Gitlab CI e Jenkins",
+      "Attestazioni di runtime collegate ad ambienti e distribuzioni",
+      "Cataloghi di servizio con percorsi dorati e guardrail self-service"
+    ],
+    "capabilities": {
+      "title": "Capacità chiave",
+      "cards": [
+        {
+          "title": "Adattatori del flusso di lavoro",
+          "description": "Azioni di drop-in, modelli e comandi CLI per condutture e infrastrutture."
+        },
+        {
+          "title": "Ganci di osservabilità",
+          "description": "Invia i risultati del controllo a Datadog, Grafana o Slack con profondi collegamenti in evidenza."
+        }
       ]
     }
   }

--- a/apps/speckit/messages/pt.json
+++ b/apps/speckit/messages/pt.json
@@ -2,8 +2,17 @@
   "layout": {
     "skipToContent": "Pule para o conteúdo",
     "themeToggle": "Tema de alternância",
-    "starLabel": "Projeto Star",
     "languageLabel": "Linguagem",
+    "githubLabel": "Speckit no Github",
+    "nav": {
+      "product": "Produto",
+      "howItWorks": "Como funciona",
+      "solutions": "Soluções",
+      "docs": "Documentos",
+      "pricing": "Preço",
+      "trust": "Confiar",
+      "contact": "Contato"
+    },
     "footer": {
       "columns": {
         "product": {
@@ -14,27 +23,27 @@
         },
         "resources": {
           "heading": "Recursos",
-          "docs": "Documentação",
+          "docs": "Documentos",
           "apiReference": "Referência da API",
           "community": "Comunidade"
         },
         "openSource": {
           "heading": "Código aberto",
-          "repo": "Repositório",
+          "repo": "Repo",
           "templates": "Modelos",
           "issues": "Problemas",
           "license": "Licença"
         },
         "trust": {
-          "heading": "Confiança",
+          "heading": "Confiar",
           "trustCenter": "Centro de confiança",
           "status": "Status",
-          "securityTxt": "security.txt"
+          "securityTxt": "segurança.txt"
         }
       },
       "contact": {
         "label": "speckit@airnub.io",
-        "pricing": "Preços"
+        "pricing": "Preço"
       }
     }
   },
@@ -44,8 +53,10 @@
       "title": "End Coding Vibe. ",
       "description": "Speckit transforma a conformidade de uma disputa em um loop contínuo e nativo do desenvolvedor. ",
       "actions": {
-        "requestDemo": "Solicite uma demonstração",
-        "exploreDocs": "Explore os documentos"
+        "primaryLabel": "Solicite uma demonstração",
+        "primaryHref": "/contato",
+        "secondaryLabel": "Explore os documentos",
+        "secondaryHref": "https://docs.spececkit.dev"
       }
     },
     "features": [
@@ -108,8 +119,10 @@
       "title": "Todas as equipes veem a mesma fonte de verdade",
       "description": "Os líderes de plataforma, segurança, conformidade e produtos colaboram em um contexto compartilhado. ",
       "actions": {
-        "howItWorks": "Veja como funciona",
-        "template": "Faça o download do modelo de lançamento"
+        "primaryLabel": "Veja como funciona",
+        "primaryHref": "/Como se trabalhe",
+        "secondaryLabel": "Faça o download do modelo de lançamento",
+        "secondaryHref": "/modelo"
       },
       "cards": [
         {
@@ -140,6 +153,291 @@
         "Supabase",
         "AWS",
         "Azure"
+      ]
+    }
+  },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Preço",
+      "title": "Escolha o plano que corresponde à sua jornada de governança",
+      "description": "Todos os planos incluem o núcleo de dados Supabase compartilhado, o mecanismo de orquestração de políticas e as APIs de evidência.",
+      "actions": {
+        "primaryLabel": "Fale com vendas",
+        "primaryHref": "/contato"
+      }
+    },
+    "tiers": [
+      {
+        "name": "Lançar",
+        "price": "$ 1.250/mês",
+        "description": "Para equipes pilotando governança em três serviços.",
+        "highlights": [
+          "Até 20 engenheiros",
+          "Spec + Política Orquestração",
+          "Painel de evidências"
+        ],
+        "ctaLabel": "Solicitar cotação"
+      },
+      {
+        "name": "Escala",
+        "price": "$ 3.400/mês",
+        "description": "Para organizações rolando Speckit em várias linhas de produtos.",
+        "highlights": [
+          "Até 75 engenheiros",
+          "Arrendamento de supabase de vários projetos",
+          "Integração do portal de confiança do cliente"
+        ],
+        "ctaLabel": "Solicitar cotação"
+      },
+      {
+        "name": "Empresa",
+        "price": "Personalizado",
+        "description": "Pods dedicados para cargas de trabalho regulamentadas e ambientes complexos.",
+        "highlights": [
+          "Engenheiros ilimitados",
+          "Opções de implantação privada em nuvem",
+          "Serviços de automação de conformidade"
+        ],
+        "ctaLabel": "Solicitar cotação"
+      }
+    ]
+  },
+  "product": {
+    "hero": {
+      "eyebrow": "Produto",
+      "title": "Uma plataforma para modelar, aplicar e provar governança",
+      "description": "Speckit conecta planejamento, entrega e garantia. ",
+      "actions": {
+        "primaryLabel": "Veja preços",
+        "primaryHref": "/preço"
+      }
+    },
+    "pillars": [
+      {
+        "title": "Modelo",
+        "description": "Capture decisões de arquitetura, riscos e proprietários de políticas em especificações colaborativas sincronizadas para git."
+      },
+      {
+        "title": "Aplicar",
+        "description": "Aplique controles reutilizáveis ​​entre os catálogos de pipelines, nuvem e serviços com resultados explicáveis."
+      },
+      {
+        "title": "Provar",
+        "description": "Gere e distribua evidências para auditores, clientes e liderança automaticamente."
+      }
+    ],
+    "timeline": {
+      "title": "Speckit Linha do tempo",
+      "steps": [
+        {
+          "name": "Kickoff de especificações",
+          "description": "Comece com uma especificação de versão vinculada ao código. "
+        },
+        {
+          "name": "Orquestração de políticas",
+          "description": "Os controles são executados em CI, IAC e tempo de execução. "
+        },
+        {
+          "name": "Fluxo de evidências",
+          "description": "SBOMs, atestados e provas de controle sincronizam a supabase, ferramentas GRC e portais de clientes."
+        }
+      ]
+    },
+    "integrationsCard": {
+      "title": "Integrações que o encontram onde você trabalha",
+      "description": "Use Speckit UI, CLI ou APIs. ",
+      "items": [
+        "Github",
+        "Gitlab",
+        "Bitbucket",
+        "Jira",
+        "ServiceNow",
+        "PagerDuty",
+        "AWS",
+        "Azure",
+        "GCP"
+      ]
+    },
+    "supabaseCard": {
+      "title": "Núcleo de dados compartilhados supabase",
+      "paragraphs": [
+        "Os formulários de marketing e produtos alimentam um projeto Supabase. ",
+        "Use a função de serviço para sincronizar evidências de speckit com o seu armazém de dados ou portal de confiança do cliente com confiança."
+      ]
+    }
+  },
+  "howItWorks": {
+    "hero": {
+      "eyebrow": "Como funciona",
+      "title": "Um loop contínuo que traz confiança na entrega diária",
+      "description": "Speckit une planejamento, envio e provação. "
+    },
+    "stages": [
+      {
+        "name": "Capturar",
+        "description": "As especificações começam em documentos apoiados pelo Git. "
+      },
+      {
+        "name": "Orquestrar",
+        "description": "Controles gatilho entre pipelines e ambientes. "
+      },
+      {
+        "name": "Publicar",
+        "description": "Evidência aterrina onde é necessário - Supabase, GRC Tools, Client Trust Portais e pilhas de análise."
+      }
+    ],
+    "stageLabel": "Etapa {contagem}",
+    "audiences": [
+      {
+        "role": "Plataforma",
+        "value": "Caminhos dourados com governança embutida. "
+      },
+      {
+        "role": "Segurança",
+        "value": "Política como código com transparência. "
+      },
+      {
+        "role": "Conformidade",
+        "value": "Evidência sob demanda. "
+      }
+    ],
+    "tooling": {
+      "title": "Traga sua própria ferramenta",
+      "description": "Speckit se integra através de webhooks, APIs REST e SDKs. ",
+      "items": [
+        "Ações do Github, Circleci, Gitlab Pipelines",
+        "Terraform, Pulumi, CloudFormation",
+        "ServiceNow, Jira, atualizações lineares de fluxo de trabalho",
+        "Supabase, Snowflake e Portais de confiança do cliente"
+      ]
+    }
+  },
+  "template": {
+    "hero": {
+      "eyebrow": "Modelo",
+      "title": "Um manual de lançamento comprovado",
+      "description": "Faça o download do plano de seis semanas que Speckit usa para ser lançado com equipes de plataforma, segurança e conformidade.",
+      "actions": {
+        "primaryLabel": "Obtenha o modelo",
+        "primaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "steps": [
+      {
+        "title": "Semana 1 - Descoberta",
+        "description": "Mapear controles de corrente, ferramentas e fluxos de evidência. "
+      },
+      {
+        "title": "Semanas 2-3-Orquestração",
+        "description": "Configure supabase, conectar repositórios e codificar portões de política em pipelines e IAC."
+      },
+      {
+        "title": "Semanas 4-5-Habitação",
+        "description": "Habilite equipes com modelos, manuais de guarda e painéis de evidência."
+      },
+      {
+        "title": "Semana 6 - Escala",
+        "description": "Revise os KPIs, expanda -se para serviços adicionais e integre as alimentação de evidências em portais de confiança."
+      }
+    ]
+  },
+  "contact": {
+    "hero": {
+      "eyebrow": "Contato",
+      "title": "Veja Speckit em ação",
+      "description": "Compartilhe um pouco sobre o seu programa de plataforma e adaptaremos um passo a passo aos seus objetivos."
+    },
+    "form": {
+      "title": "Solicite uma demonstração",
+      "description": "Conte -nos sobre o seu ambiente e a linha do tempo de lançamento de destino.",
+      "submitLabel": "Demonstração de solicitação",
+      "fields": {
+        "nameLabel": "Nome completo",
+        "emailLabel": "E -mail de trabalho",
+        "emailRequiredSuffix": "*",
+        "companyLabel": "Empresa",
+        "focusLabel": "Em que devemos nos concentrar?"
+      }
+    },
+    "shortcuts": {
+      "emailHeading": "E-mail",
+      "productQuestions": "Perguntas do produto: speckit@airnub.io",
+      "security": "Segurança: Security@airnub.io",
+      "docsHeading": "Documentos",
+      "docsDescription": "Explore referências e guias de implementação da API.",
+      "docsCtaLabel": "docs.spececkit.dev →"
+    }
+  },
+  "solutions": {
+    "hero": {
+      "eyebrow": "Soluções",
+      "title": "Speckit se adapta ao seu modelo operacional de segurança e plataforma",
+      "description": "Escolha um caminho personalizado para orquestrar portões de política, automação de evidências e colaboração entre equipes."
+    },
+    "personas": [
+      {
+        "title": "Ciso",
+        "description": "Tornar a conformidade contínua. ",
+        "href": "/Solutions/CISO",
+        "ctaLabel": "Explore →"
+      },
+      {
+        "title": "DevSecops",
+        "description": "Incorporar os corrimãos em todos os pipelines enquanto capacita as equipes a enviar mais rápido com transparência.",
+        "href": "/soluções/devSecops",
+        "ctaLabel": "Explore →"
+      }
+    ]
+  },
+  "solutionsCiso": {
+    "hero": {
+      "eyebrow": "Soluções",
+      "title": "Conformidade contínua sem luta manual",
+      "description": "O Speckit oferece a visibilidade em tempo real do CISOS na postura de controle, exceções e prontidão para auditar."
+    },
+    "outcomesTitle": "Por que os CISOs escolhem Speckit",
+    "outcomes": [
+      "Status de controle ao vivo mapeado para o SOC 2, ISO 27001, HIPAA e FedRamp",
+      "Narrativas automatizadas de SSP e Feeds de relatório de confiança do cliente",
+      "Políticas de retenção de evidências apoiadas pela Supabase Row-Nível Security"
+    ],
+    "deliverables": {
+      "title": "Entregas",
+      "cards": [
+        {
+          "title": "Controle automação",
+          "description": "Codificou o Guardrails para gerenciamento de mudanças, revisões de acesso, gerenciamento de vulnerabilidades e resposta a incidentes."
+        },
+        {
+          "title": "Relatórios executivos",
+          "description": "Os painéis para atualizações de placa e clientes com trilhas de evidências de perfuração."
+        }
+      ]
+    }
+  },
+  "solutionsDevSecOps": {
+    "hero": {
+      "eyebrow": "Soluções",
+      "title": "Guardrails e velocidade para cada equipe de entrega",
+      "description": "O Speckit oferece aos controles programáveis ​​das equipes de devSecops, observabilidade e contexto compartilhado com segurança e conformidade."
+    },
+    "benefitsTitle": "Quais ganhos de devSecOps",
+    "benefits": [
+      "Módulos políticos como código para ações do GitHub, Gitlab CI e Jenkins",
+      "Atestados de tempo de execução vinculados a ambientes e implantações",
+      "Catálogos de serviço com caminhos e corrimãos de ouro auto-atendidos"
+    ],
+    "capabilities": {
+      "title": "Capacidades -chave",
+      "cards": [
+        {
+          "title": "Adaptadores de fluxo de trabalho",
+          "description": "Ações, modelos e comandos de CLI para oleodutos e infraestrutura."
+        },
+        {
+          "title": "Ganchos de observabilidade",
+          "description": "Envie os resultados do controle para Datadog, Grafana ou Slack com links profundos em evidências."
+        }
       ]
     }
   }

--- a/packages/ui/src/HeaderSpeckit.tsx
+++ b/packages/ui/src/HeaderSpeckit.tsx
@@ -4,13 +4,14 @@ import { Header, type HeaderProps, type NavItem } from "./components/client/Head
 import { ThemeToggle } from "./components/client/ThemeToggle";
 import type { ReactNode } from "react";
 
-const navItems: NavItem[] = [
+const defaultNavItems: NavItem[] = [
   { label: "Product", href: "/product" },
   { label: "How it works", href: "/how-it-works" },
   { label: "Solutions", href: "/solutions" },
   { label: "Docs", href: "https://docs.speckit.dev", external: true },
   { label: "Pricing", href: "/pricing" },
   { label: "Trust", href: "https://trust.airnub.io", external: true },
+  { label: "Contact", href: "/contact" },
 ];
 
 function GithubIcon({ className }: { className?: string }) {
@@ -31,35 +32,21 @@ function GithubIcon({ className }: { className?: string }) {
   );
 }
 
-function StarIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      className={className}
-      viewBox="0 0 24 24"
-      fill="currentColor"
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path d="M12 3.5 14.09 9h5.66l-4.58 3.32L16.66 18 12 14.89 7.34 18l1.49-5.68L4.25 9h5.66L12 3.5Z" />
-    </svg>
-  );
-}
-
 type HeaderSpeckitProps = Omit<HeaderProps, "logo" | "navItems" | "rightSlot" | "homeAriaLabel"> & {
   homeAriaLabel?: string;
+  navItems?: NavItem[];
   additionalRightSlot?: ReactNode;
   githubHref?: string;
-  starHref?: string;
-  starLabel?: string;
+  githubLabel?: string;
   themeToggleLabel?: string;
 };
 
 export function HeaderSpeckit({
   homeAriaLabel = "Speckit home",
+  navItems = defaultNavItems,
   additionalRightSlot,
   githubHref = "https://github.com/airnub/speckit",
-  starHref = "https://github.com/airnub/speckit",
-  starLabel = "Star project",
+  githubLabel = "Speckit on GitHub",
   themeToggleLabel = "Toggle theme",
   ...props
 }: HeaderSpeckitProps) {
@@ -72,20 +59,12 @@ export function HeaderSpeckit({
         <div className="flex items-center gap-3">
           <Link
             href={githubHref}
-            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-white/10 dark:text-slate-200 dark:hover:text-white lg:inline-flex"
-            aria-label="Speckit on GitHub"
+            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white lg:inline-flex"
+            aria-label={githubLabel}
             target="_blank"
             rel="noreferrer"
           >
             <GithubIcon className="h-4 w-4" />
-          </Link>
-          <Link
-            href={starHref}
-            className="hidden items-center gap-2 rounded-full bg-gradient-to-r from-speckit-indigo to-speckit-violet px-4 py-2 text-sm font-semibold text-white shadow-lg transition hover:opacity-90 lg:inline-flex"
-            target="_blank"
-            rel="noreferrer"
-          >
-            <StarIcon className="h-4 w-4" /> {starLabel}
           </Link>
           <ThemeToggle className="inline-flex" label={themeToggleLabel} />
           {additionalRightSlot}

--- a/scripts/translate-speckit.mjs
+++ b/scripts/translate-speckit.mjs
@@ -6,7 +6,9 @@ const root = path.resolve(".");
 const basePath = path.join(root, "apps/speckit/messages/en-US.json");
 const base = JSON.parse(fs.readFileSync(basePath, "utf8"));
 
-const languages = ["en-GB", "fr", "es", "de", "pt", "it", "ga"];
+const defaultLanguages = ["en-GB", "fr", "es", "de", "pt", "it", "ga"];
+const requestedLanguages = process.argv.slice(2);
+const languages = requestedLanguages.length > 0 ? requestedLanguages : defaultLanguages;
 
 const API_URL = "https://translate.googleapis.com/translate_a/single";
 


### PR DESCRIPTION
## Summary
- align the Speckit layout with the Airnub header experience by sourcing navigation and footer copy from the locale bundles and reusing the shared header component
- update every Speckit route to load hero/content text and metadata from the new translation schema instead of static strings, ensuring cookie-driven language persistence
- regenerate the Speckit language packs with the expanded structure and add a script option for targeting specific locales when translating

## Testing
- pnpm lint --filter @airnub/speckit-app

------
https://chatgpt.com/codex/tasks/task_e_68d9c6d9f9108324b319716b6d5e41d1