### PR TITLE
Remove duplicate Link import from Speckit template page

### DIFF
--- a/apps/speckit/app/template/page.tsx
+++ b/apps/speckit/app/template/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { Container } from "@airnub/ui";
 import { PageHero } from "../../components/PageHero";
 import { getCurrentLanguage } from "../../lib/language";


### PR DESCRIPTION
## Summary
- remove the redundant second Link import from the Speckit template page so it is only imported once

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d8c52eec832481c9fa6dca551bf8