### PR TITLE
fix: align locale cookie domain across apps

### DIFF
--- a/apps/airnub/components/LocaleSwitcher.tsx
+++ b/apps/airnub/components/LocaleSwitcher.tsx
@@ -8,10 +8,25 @@ import { defaultLocale, locales, type Locale } from "../i18n/routing";
 
 const LANGUAGE_COOKIE_NAME = "NEXT_LOCALE";
 const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+const COOKIE_DOMAIN =
+  process.env.NEXT_PUBLIC_LOCALE_COOKIE_DOMAIN ??
+  process.env.NEXT_PUBLIC_COOKIE_DOMAIN ??
+  ".airnub.io";
 
 function persistLocale(value: Locale) {
   if (typeof document !== "undefined") {
-    document.cookie = `${LANGUAGE_COOKIE_NAME}=${value}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
+    const cookieAttributes = [
+      `${LANGUAGE_COOKIE_NAME}=${value}`,
+      "path=/",
+      `max-age=${COOKIE_MAX_AGE_SECONDS}`,
+      "SameSite=Lax",
+    ];
+
+    if (COOKIE_DOMAIN) {
+      cookieAttributes.splice(1, 0, `domain=${COOKIE_DOMAIN}`);
+    }
+
+    document.cookie = cookieAttributes.join("; ");
     document.documentElement.lang = value;
   }
 }

--- a/apps/speckit/components/LanguageSwitcher.tsx
+++ b/apps/speckit/components/LanguageSwitcher.tsx
@@ -7,6 +7,10 @@ import { languageCookieName, supportedLanguages, type SupportedLanguage } from "
 
 const STORAGE_KEY = "speckit.language";
 const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+const COOKIE_DOMAIN =
+  process.env.NEXT_PUBLIC_LOCALE_COOKIE_DOMAIN ??
+  process.env.NEXT_PUBLIC_COOKIE_DOMAIN ??
+  ".airnub.io";
 
 type LanguageSwitcherProps = {
   className?: string;
@@ -17,7 +21,18 @@ type LanguageSwitcherProps = {
 
 function persistLanguage(value: SupportedLanguage) {
   if (typeof document !== "undefined") {
-    document.cookie = `${languageCookieName}=${value}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
+    const cookieAttributes = [
+      `${languageCookieName}=${value}`,
+      "path=/",
+      `max-age=${COOKIE_MAX_AGE_SECONDS}`,
+      "SameSite=Lax",
+    ];
+
+    if (COOKIE_DOMAIN) {
+      cookieAttributes.splice(1, 0, `domain=${COOKIE_DOMAIN}`);
+    }
+
+    document.cookie = cookieAttributes.join("; ");
     document.documentElement.lang = value;
   }
   if (typeof window !== "undefined") {


### PR DESCRIPTION
## Summary
- ensure the Airnub locale switcher writes NEXT_LOCALE with a shared domain attribute sourced from configuration
- update the Speckit language switcher to reuse the same domain handling so both apps emit identical cookies

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d9d9ba9ab083248b3995578b981e45