### PR TITLE
docs: streamline README and extract detailed guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,333 +1,52 @@
-# Airnub‑Site Monorepo
+# Airnub-Site Monorepo
 
-Monorepo for public‑facing sites using **one shared Supabase database** and a **single migrations directory**. Built with **Next.js (App Router) + TypeScript + Tailwind**, **PNPM workspaces + Turborepo**, and a **hybrid ISR/SSR** rendering model.
+Marketing sites for Airnub and Speckit that share a Supabase backend, a component library, and Turborepo-powered tooling. Both apps run on the Next.js App Router with incremental static regeneration by default.
 
----
+## What's inside
 
-## Apps
+- **Airnub marketing site** (`apps/airnub`) — [airnub.io](https://airnub.io)
+- **Speckit microsite** (`apps/speckit`) — [speckit.airnub.io](https://speckit.airnub.io)
+- Shared packages under `packages/` for UI, brand assets, SEO helpers, and Supabase access
 
-* **Airnub company site** — [https://airnub.io](https://airnub.io) (`apps/airnub`)
-* **Speckit microsite** — [https://speckit.airnub.io](https://speckit.airnub.io) (`apps/speckit`)
+See [Architecture & Rendering](./docs/architecture.md) for the full layout and rendering guidelines.
 
-## Packages
+## Prerequisites
 
-* **`@airnub/ui`** — shared UI (headers/footers, buttons, cards)
-* **`@airnub/brand`** — brand assets (logos, OG templates)
-* **`@airnub/seo`** — JSON‑LD & Open Graph helpers
-* **`@airnub/db`** — shared Supabase client + generated DB types
+- Node.js 24.x
+- [pnpm](https://pnpm.io/) 10+
+- [Supabase CLI](https://supabase.com/docs/guides/cli)
 
----
+## Quick start
 
-## Repository layout
-
-```
-airnub-site/
-├─ apps/
-│  ├─ airnub/
-│  └─ speckit/
-├─ packages/
-│  ├─ ui/
-│  ├─ brand/
-│  ├─ seo/
-│  └─ db/
-├─ supabase/
-│  ├─ config.toml
-│  ├─ migrations/
-│  └─ seed.sql (optional)
-├─ .github/workflows/
-│  ├─ ci.yml
-│  ├─ a11y.yml
-│  ├─ links.yml
-│  └─ db-migrate.yml
-├─ turbo.json
-├─ pnpm-workspace.yaml
-├─ package.json
-└─ README.md
-```
-
----
-
-## Hybrid rendering policy
-
-All layouts stay Server Components. Marketing and content routes use **Incremental Static Regeneration** with per-route refresh schedules, and we only opt into request-time rendering when a page truly requires `cookies()`/`headers()` access.
-
-### Airnub revalidate schedule
-
-| Route | Revalidate |
-| --- | --- |
-| `/` | 86,400s (24h) |
-| `/products` | 86,400s |
-| `/solutions` | 604,800s (7d) |
-| `/services` | 86,400s |
-| `/resources` | 21,600s (6h) |
-| `/company` | 604,800s |
-| `/contact` | 86,400s |
-| `/trust` | static redirect |
-
-### Speckit revalidate schedule
-
-| Route | Revalidate |
-| --- | --- |
-| `/` | 86,400s |
-| `/product` | 86,400s |
-| `/how-it-works` | 604,800s |
-| `/solutions` | 604,800s |
-| `/solutions/ciso` | 604,800s |
-| `/solutions/devsecops` | 604,800s |
-| `/template` | 604,800s |
-| `/pricing` | 3,600s |
-| `/contact` | 86,400s |
-| `/trust` | static redirect |
-
-> Need true SSR? Set `export const dynamic = 'force-dynamic'` (and `fetchCache = 'force-no-store'` if you must read per-request data) **per route** instead of globally.
-
-### Forms & Supabase
-
-* Contact forms in both apps post to Server Actions (`submitLead`) that call `getServerClient(cookies)` from `@airnub/db`.
-* Inserts happen on the server only; no Supabase client is shipped to the browser.
-* Client Components belong under `components/client/`. The repo ships `scripts/assert-no-client.js`, which CI runs to prevent stray `"use client"` directives elsewhere.
-
-JSON-LD, Metadata API, sitemaps, robots.txt, and OG image routes are part of every app’s surface.
-
----
-
-## Runtime configuration
-
-* **Internationalization:** The Airnub app uses [`next-intl`](https://next-intl.dev/) with path-based routing. Supported locales live in `apps/airnub/i18n/routing.ts` (default `en`, secondary `es`). Add translations in `apps/airnub/messages/<locale>.json` and they’ll be picked up automatically.
-* **Maintenance gate:** Set `MAINTENANCE_MODE=true` in the environment to swap every page for the “coming soon” message while keeping APIs online. Update the copy via `apps/airnub/messages/*`.
-
----
-
-## Supabase
-
-* **Migrations:** live in `/supabase/migrations/` (single source of truth)
-* **Local dev:** `supabase start` → `pnpm db:env:local` (sync keys) → edit schema → `pnpm db:diff -m "change"`
-* **Env sync helper:** `pnpm db:env:local` reads `supabase status` and updates `.env.local`, `apps/airnub/.env.local`, and
-  `apps/speckit/.env.local` without clobbering any other variables. Re-run after Supabase regenerates credentials (for example,
-  after `supabase start` or `supabase stop && supabase start`). The Codespaces devcontainer runs this automatically on boot.
-* **Types:** `pnpm db:types` → writes to `packages/db/src/types.ts`
-* **Remote apply:** `pnpm db:link:staging && pnpm db:push` (CI handles staging/prod)
-
-### Shared schema (lead capture)
-
-```sql
-create table if not exists public.contact_leads (
-  id uuid primary key default gen_random_uuid(),
-  created_at timestamptz not null default now(),
-  full_name text,
-  email text not null check (position('@' in email) > 1),
-  company text,
-  message text,
-  source text check (source in ('airnub','speckit')) default 'airnub',
-  consent boolean default false,
-  user_agent text,
-  ip_hash text
-);
-
-alter table public.contact_leads enable row level security;
-
--- Option A (public forms): anon inserts allowed
-create policy "leads_insert_anon" on public.contact_leads
-  for insert to anon with check (true);
-
--- Reads restricted to service_role only
-create policy "leads_read_service" on public.contact_leads
-  for select to service_role using (true);
-
-create index if not exists idx_contact_leads_created_at on public.contact_leads (created_at desc);
-```
-
-> Prefer **server‑action only** inserts for stricter control: remove the anon insert policy and call with the service role from the server.
-
-### Local ports quick‑fix (avoid clashes)
-
-If you run multiple local Supabase projects, set unique ports in **`supabase/config.toml`**:
-
-```toml
-project_id = "airnub-site-local"
-
-[api]     # default 54321
-port = 55421
-
-[db]      # default 54322
-port = 55422
-shadow_port = 55420  # default 54320
-
-[studio]  # default 54323
-port = 55423
-
-[inbucket]        # defaults 54324/54325/54326
-port = 55424
-smtp_port = 55425
-pop3_port = 55426
-
-[analytics]       # optional; defaults 54327/54328
-port = 55427
-vector_port = 55428
-```
-
-Restart:
-
-```bash
-supabase stop && supabase start
-```
-
----
-
-## Environment
-
-Copy `.env.example` to `.env.local` (and to each app if you maintain separate files) and update it with your Supabase project keys:
-
-```env
-NEXT_PUBLIC_SUPABASE_URL=...
-NEXT_PUBLIC_SUPABASE_GRAPHQL_URL=...
-NEXT_PUBLIC_SUPABASE_ANON_KEY=...
-```
-
-(Use different keys per environment.) After `supabase start`, run `pnpm db:env:local` to sync the latest keys—including the GraphQL endpoint, Studio/Mailpit URLs, and S3 credentials—into `.env.local`, `apps/airnub/.env.local`, and `apps/speckit/.env.local`. The helper parses `supabase status` and preserves any existing variables or comments. Codespaces runs the command automatically after the workspace boots; rerun it whenever you restart the local Supabase stack so rotated keys stay current.
-
-## GitHub Codespaces
-
-The repo ships with a `.devcontainer/` that provisions Node 24, pnpm, and the Supabase CLI. We install pnpm through the official Node feature so the build does not rely on the deprecated standalone pnpm feature, which now requires authenticated access and caused Codespace creation to fail. To spin up a Codespace with a fully local Supabase stack:
-
-1. Create a Codespace from the repository (the first boot runs `pnpm install` automatically).
-2. Copy environment files inside the Codespace:
-
+1. Install dependencies:
    ```bash
-   cp .env.example .env.local
-   cp .env.example apps/airnub/.env.local
-   cp .env.example apps/speckit/.env.local
+   pnpm install
    ```
-
-3. The devcontainer post-start hook automatically runs `supabase start` and `pnpm db:env:local` so the Docker services boot and every `.env.local` file picks up the current keys. If you need to refresh them later (for example, after `supabase stop`), rerun:
-
+2. Copy `.env.example` to `.env.local` (and to each app if you maintain app-specific files).
+3. Start the local Supabase stack and sync credentials:
    ```bash
    supabase start
    pnpm db:env:local
    ```
-
-   Set `NEXT_PUBLIC_SUPABASE_URL` to the forwarded Codespace URL for port **54321** (for example, `https://<codespace-id>-54321.app.github.dev`) so that browser requests reach the local Supabase API. Keep the Postgres connection string values pointing at `127.0.0.1` for server-side access.
-
-4. Forward the dev servers and Supabase ports:
-   * 3000 → Airnub app (`apps/airnub`)
-   * 3001 → Speckit app (`apps/speckit`)
-   * 54321 → Supabase API
-   * 54323 → Supabase Studio (optional, if you want the GUI)
-
-5. In one terminal tab, run both apps concurrently:
-
+4. Run the development servers:
    ```bash
    pnpm dev
    ```
 
-   Turborepo starts `next dev` in parallel for both apps; accept the port prompt if Next.js asks to increment from 3000. If you prefer isolated processes, use `pnpm --filter ./apps/airnub dev` and `pnpm --filter ./apps/speckit dev` in separate terminals.
+`pnpm dev` launches both apps in parallel. Use `pnpm --filter ./apps/airnub dev` or `pnpm --filter ./apps/speckit dev` to run a single app.
 
-6. The Supabase containers continue running in the background once started; keep the Codespace alive while you work, and run `supabase stop` when you are finished to free resources.
+## Additional documentation
 
----
-
-## Getting started
-
-```bash
-pnpm i
-pnpm dev
-# or: pnpm --filter ./apps/airnub dev
-#     pnpm --filter ./apps/speckit dev
-```
-
----
-
-## Scripts & Turborepo
-
-Root `package.json` (scripts use Turbo):
-
-```json
-{
-  "name": "airnub-site",
-  "private": true,
-  "packageManager": "pnpm@9",
-  "scripts": {
-    "dev": "turbo run dev --parallel --no-cache",
-    "build": "turbo run build",
-    "lint": "turbo run lint",
-    "typecheck": "turbo run typecheck",
-    "a11y": "turbo run a11y",
-    "links": "turbo run links",
-    "sbom": "turbo run sbom",
-    "db:types": "supabase gen types typescript --local --schema public > packages/db/src/types.ts",
-    "db:link:staging": "supabase link --project-ref $SUPABASE_STAGING_REF",
-    "db:link:prod": "supabase link --project-ref $SUPABASE_PROD_REF",
-    "db:push": "supabase db push",
-    "db:diff": "supabase db diff --use-mig-dir supabase/migrations",
-    "db:reset:local": "supabase stop || true && supabase start && supabase db reset",
-    "prepare": "husky"
-  },
-  "devDependencies": {
-    "@commitlint/cli": "^20.0.0",
-    "@commitlint/config-conventional": "^20.0.0",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
-    "globby": "^14.1.0",
-    "husky": "^9.1.7",
-    "pa11y-ci": "^3.1.0",
-    "turbo": "^2.0.0"
-  }
-}
-```
-
-`turbo.json`:
-
-```json
-{
-  "$schema": "https://turbo.build/schema.json",
-  "globalDependencies": ["pnpm-lock.yaml"],
-  "pipeline": {
-    "build": { "dependsOn": ["^build"], "outputs": [".next/**", "dist/**", "!.next/cache/**"] },
-    "dev": { "cache": false, "persistent": true },
-    "lint": { "outputs": [] },
-    "typecheck": { "outputs": [] },
-    "a11y": { "outputs": [] },
-    "links": { "outputs": [] },
-    "sbom": { "outputs": ["sbom-*.json"] }
-  }
-}
-```
-
-**Remote cache:** add GitHub secrets `TURBO_TEAM` and `TURBO_TOKEN` (from Vercel → Turborepo) to enable cross‑env caching.
-
----
-
-## SEO, Accessibility & Performance
-
-* **SEO:** per‑route `generateMetadata`, `app/sitemap.ts`, `app/robots.ts`, dynamic OG images, JSON‑LD (`Organization` on Airnub, `ItemList` on `/products`, `SoftwareApplication` on Speckit).
-* **A11y:** WCAG 2.2 AA; skip link; keyboard nav; visible focus; color contrast.
-* **CWV budgets:** LCP ≤ 2.5s, INP < 200ms, CLS < 0.1. Avoid layout shift and unnecessary hydration.
-
----
-
-## CI & commit rules
-
-* **Conventional commits:** Husky installs a `commit-msg` hook (`pnpm prepare`) that runs `pnpm commitlint --edit $1`.
-* **Semantic PR title:** `amannn/action-semantic-pull-request` enforces PR titles that follow Conventional Commits.
-* **CI pipeline (`ci.yml`):** checkout → install → commitlint (PRs) → semantic title (PRs) → lint → typecheck → `node scripts/assert-no-client.js` → build (Turbo remote cache ready).
-* **Additional workflows:** pa11y (`a11y.yml`), link checking (`links.yml`), and Supabase staging deploys (`db-migrate.yml`).
-
----
-
-## Trust
-
-* **Trust Center:** [https://trust.airnub.io](https://trust.airnub.io) (VDP + `/.well-known/security.txt`)
-* Link clearly from headers/footers of both apps.
-
----
+- [Architecture & Rendering](./docs/architecture.md)
+- [Supabase Guide](./docs/supabase.md)
+- [Local Development](./docs/development.md)
+- [CI & Contribution Workflow](./docs/ci.md)
+- [Remote Operations](./docs/remote-operations.md)
 
 ## Contributing
 
-* Conventional Commits (`feat:`, `fix:`, `docs:`…)
-* No secrets in the repo; use `.env`/secrets. Prefer server‑action‑only Supabase writes.
-
----
+Follow Conventional Commits (`feat:`, `fix:`, `docs:` …) and keep secrets out of the repository. See the [CI & Contribution Workflow](./docs/ci.md) for enforcement details.
 
 ## License
 
-* See individual package/app licenses or the root LICENSE if present.
+Licensed under the terms described in [`LICENSE`](./LICENSE) unless noted otherwise by an individual package or app.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,94 @@
+# Architecture & Rendering
+
+This monorepo hosts two Next.js App Router sites that share a Supabase backend and a set of UI packages. The apps are deployed with incremental static regeneration (ISR) wherever possible and only opt into fully dynamic rendering on a per-route basis.
+
+## Apps
+
+- **Airnub marketing site** (`apps/airnub`) — production at [airnub.io](https://airnub.io)
+- **Speckit microsite** (`apps/speckit`) — production at [speckit.airnub.io](https://speckit.airnub.io)
+
+## Shared packages
+
+- `@airnub/ui` — shared UI primitives and layout components
+- `@airnub/brand` — brand assets, logos, and OG templates
+- `@airnub/seo` — helpers for JSON-LD and Open Graph metadata
+- `@airnub/db` — Supabase client helpers and generated database types
+
+## Repository layout
+
+```
+airnub-site/
+├─ apps/
+│  ├─ airnub/
+│  └─ speckit/
+├─ packages/
+│  ├─ ui/
+│  ├─ brand/
+│  ├─ seo/
+│  └─ db/
+├─ supabase/
+│  ├─ config.toml
+│  ├─ migrations/
+│  └─ seed.sql (optional)
+├─ .github/workflows/
+│  ├─ ci.yml
+│  ├─ a11y.yml
+│  ├─ links.yml
+│  └─ db-migrate.yml
+├─ turbo.json
+├─ pnpm-workspace.yaml
+├─ package.json
+└─ README.md
+```
+
+## Rendering guidelines
+
+All layouts stay Server Components. Marketing and content routes use **incremental static regeneration** with route-specific refresh cadences. Opt into request-time rendering only when a page genuinely needs `cookies()` or `headers()`.
+
+### Airnub revalidate schedule
+
+| Route | Revalidate |
+| --- | --- |
+| `/` | 86,400s (24h) |
+| `/products` | 86,400s |
+| `/solutions` | 604,800s (7d) |
+| `/services` | 86,400s |
+| `/resources` | 21,600s (6h) |
+| `/company` | 604,800s |
+| `/contact` | 86,400s |
+| `/trust` | static redirect |
+
+### Speckit revalidate schedule
+
+| Route | Revalidate |
+| --- | --- |
+| `/` | 86,400s |
+| `/product` | 86,400s |
+| `/how-it-works` | 604,800s |
+| `/solutions` | 604,800s |
+| `/solutions/ciso` | 604,800s |
+| `/solutions/devsecops` | 604,800s |
+| `/template` | 604,800s |
+| `/pricing` | 3,600s |
+| `/contact` | 86,400s |
+| `/trust` | static redirect |
+
+> Need true SSR? Set `export const dynamic = 'force-dynamic'` (and `fetchCache = 'force-no-store'` if you must read per-request data) on the specific route instead of globally.
+
+## Forms & Supabase usage
+
+- Contact forms post to Server Actions (`submitLead`) that call `getServerClient(cookies)` from `@airnub/db`.
+- Inserts happen only on the server; no Supabase client is shipped to the browser.
+- Client Components belong under `components/client/`. CI runs `scripts/assert-no-client.js` to prevent stray `"use client"` directives elsewhere.
+
+## Metadata, SEO, and accessibility
+
+- Each route implements `generateMetadata`, and both apps expose `app/sitemap.ts`, `app/robots.ts`, and dynamic OG images.
+- JSON-LD covers `Organization` for Airnub, `ItemList` for `/products`, and `SoftwareApplication` across Speckit pages.
+- Accessibility targets WCAG 2.2 AA with a skip link, keyboard navigation, visible focus states, and maintained contrast ratios.
+- Core Web Vitals budgets: LCP ≤ 2.5s, INP < 200ms, CLS < 0.1.
+
+## Trust center
+
+- Trust Center lives at [trust.airnub.io](https://trust.airnub.io) with the vulnerability disclosure program and `/.well-known/security.txt`.
+- Link prominently from the shared headers and footers in both apps.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,28 @@
+# CI & Contribution Workflow
+
+## Conventional commits
+
+Husky installs a `commit-msg` hook (`pnpm prepare`) that runs `pnpm commitlint --edit $1` to enforce Conventional Commit messages.
+
+## Pull request requirements
+
+The repository uses `amannn/action-semantic-pull-request` to ensure PR titles follow the Conventional Commits specification.
+
+## Pipeline overview
+
+The primary workflow (`.github/workflows/ci.yml`) runs the following steps:
+
+1. Checkout and install dependencies
+2. Commit message linting (for pull requests)
+3. Semantic PR title check
+4. `turbo run lint`
+5. `turbo run typecheck`
+6. `node scripts/assert-no-client.js`
+7. `turbo run build` (remote cache ready)
+
+Additional workflows cover accessibility (`a11y.yml`), link checking (`links.yml`), and Supabase staging deploys (`db-migrate.yml`).
+
+## Trust & security
+
+- Keep secrets out of the repository—use environment variables and secret stores.
+- Prefer server-action-only Supabase writes for tighter control.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,65 @@
+# Local Development
+
+## Prerequisites
+
+- Node.js 24.x (see the `package.json` engines field)
+- [pnpm](https://pnpm.io/) 10+
+- [Supabase CLI](https://supabase.com/docs/guides/cli)
+
+## Install dependencies
+
+```bash
+pnpm install
+```
+
+## Running the apps
+
+Start the Supabase stack (see [Supabase Guide](./supabase.md)), then run the development servers:
+
+```bash
+pnpm dev
+```
+
+Turborepo launches both apps in parallel (`apps/airnub` on port 3000 and `apps/speckit` on 3001). Use `pnpm --filter ./apps/airnub dev` or `pnpm --filter ./apps/speckit dev` for individual processes.
+
+## Useful scripts
+
+The root `package.json` exposes the following Turbo-powered scripts:
+
+```json
+{
+  "dev": "turbo run dev --parallel --cache=local:r,remote:r",
+  "build": "turbo run build",
+  "lint": "turbo run lint",
+  "typecheck": "turbo run typecheck",
+  "a11y": "turbo run a11y",
+  "links": "turbo run links",
+  "sbom": "turbo run sbom",
+  "db:types": "supabase gen types typescript --local --schema public > packages/db/src/types.ts",
+  "db:link:staging": "supabase link --project-ref $SUPABASE_STAGING_REF",
+  "db:link:prod": "supabase link --project-ref $SUPABASE_PROD_REF",
+  "db:push": "supabase db push",
+  "db:diff": "supabase db diff --use-mig-dir supabase/migrations",
+  "db:env:local": "node scripts/sync-supabase-env.mjs",
+  "db:reset:local": "supabase stop || true && supabase start && supabase db reset"
+}
+```
+
+Remote caching is available once `TURBO_TEAM` and `TURBO_TOKEN` are configured in the repository secrets.
+
+## GitHub Codespaces workflow
+
+The `.devcontainer` sets up Node 24, pnpm, and the Supabase CLI. When a Codespace starts:
+
+1. Copy the example environment file into each location:
+
+   ```bash
+   cp .env.example .env.local
+   cp .env.example apps/airnub/.env.local
+   cp .env.example apps/speckit/.env.local
+   ```
+
+2. The post-start hooks run `supabase start` and `pnpm db:env:local` so Docker services boot and environment files receive current credentials.
+3. If the Supabase stack stops, rerun `supabase start` followed by `pnpm db:env:local`.
+4. Forward ports 3000 (Airnub), 3001 (Speckit), 54321 (Supabase API), and optionally 54323 (Supabase Studio).
+5. Keep the Codespace running while Supabase containers are needed; stop them with `supabase stop` when done.

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -1,0 +1,94 @@
+# Supabase Guide
+
+The monorepo uses a single Supabase project for both sites. Migrations, types, and helpers are shared through `@airnub/db`.
+
+## Migrations & schema
+
+- Author schema changes through files in `supabase/migrations/`. Avoid editing production directly.
+- Generate new migrations with `pnpm db:diff -m "descriptive_message"` after updating the local database.
+- Regenerate TypeScript types with `pnpm db:types`; the command writes to `packages/db/src/types.ts`.
+
+### Shared lead capture table
+
+```sql
+create table if not exists public.contact_leads (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  full_name text,
+  email text not null check (position('@' in email) > 1),
+  company text,
+  message text,
+  source text check (source in ('airnub','speckit')) default 'airnub',
+  consent boolean default false,
+  user_agent text,
+  ip_hash text
+);
+
+alter table public.contact_leads enable row level security;
+
+-- Option A (public forms): anon inserts allowed
+create policy "leads_insert_anon" on public.contact_leads
+  for insert to anon with check (true);
+
+-- Reads restricted to service_role only
+create policy "leads_read_service" on public.contact_leads
+  for select to service_role using (true);
+
+create index if not exists idx_contact_leads_created_at on public.contact_leads (created_at desc);
+```
+
+Prefer server-action-only inserts for stricter control: omit the anon policy and call with the service role from the server.
+
+## Local development
+
+1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and run `supabase start` from the repo root.
+2. Sync environment files with `pnpm db:env:local`. The script reads `supabase status` and updates `.env.local`, `apps/airnub/.env.local`, and `apps/speckit/.env.local` without overwriting other values.
+3. When credentials rotate (for example after `supabase stop && supabase start`), rerun `pnpm db:env:local`.
+4. Link to remote projects when needed:
+   - `pnpm db:link:staging && pnpm db:push`
+   - `pnpm db:link:prod` (production is gated through CI)
+
+## Environment variables
+
+Copy `.env.example` to `.env.local` and to each app (if you keep separate files), then fill in the Supabase project keys:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_GRAPHQL_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+```
+
+`pnpm db:env:local` also records the GraphQL endpoint, Studio/Mailpit URLs, and S3 credentials. Codespaces runs it automatically after startup.
+
+## Port management
+
+If you maintain multiple local Supabase projects, customize the ports in `supabase/config.toml` to avoid clashes:
+
+```toml
+project_id = "airnub-site-local"
+
+[api]     # default 54321
+port = 55421
+
+[db]      # default 54322
+port = 55422
+shadow_port = 55420  # default 54320
+
+[studio]  # default 54323
+port = 55423
+
+[inbucket]        # defaults 54324/54325/54326
+port = 55424
+smtp_port = 55425
+pop3_port = 55426
+
+[analytics]       # optional; defaults 54327/54328
+port = 55427
+vector_port = 55428
+```
+
+Restart the stack after changing ports:
+
+```bash
+supabase stop && supabase start
+```


### PR DESCRIPTION
## Summary
- simplify the root README with a quick overview, prerequisites, and setup steps
- move architecture, supabase, development, and CI details into focused docs under docs/
- link the README to the new guides for deeper references

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da554bd9008324b356af28364e60d8