### PR TITLE
refactor: adopt shared UI theme for app layouts

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -1,3 +1,4 @@
+import "@airnub/ui/styles.css";
 import "../globals.css";
 import { FooterAirnub, HeaderAirnub, ThemeProvider, ToastProvider, type FooterColumn } from "@airnub/ui";
 import type { Metadata } from "next";
@@ -171,7 +172,7 @@ export default async function LocaleLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       </head>
-      <body className="flex min-h-screen flex-col bg-white text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-100">
+      <body className="flex min-h-screen flex-col">
         <NextIntlClientProvider locale={locale} messages={messages}>
           <ThemeProvider>
             <ToastProvider>

--- a/apps/airnub/app/globals.css
+++ b/apps/airnub/app/globals.css
@@ -1,21 +1,5 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-:root {
-  color-scheme: dark;
-}
-
 html {
   scroll-behavior: smooth;
-}
-
-body {
-  background-color: #020617; /* slate-950 */
-  color: #e2e8f0; /* slate-300 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 a:focus-visible {

--- a/apps/speckit/app/globals.css
+++ b/apps/speckit/app/globals.css
@@ -1,21 +1,5 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
-:root {
-  color-scheme: dark;
-}
-
 html {
   scroll-behavior: smooth;
-}
-
-body {
-  background-color: #020617; /* slate-950 */
-  color: #f1f5f9; /* slate-100 */
-  font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 a:focus-visible {

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import "@airnub/ui/styles.css";
 import "./globals.css";
 import { FooterSpeckit, HeaderSpeckit, ThemeProvider, type FooterColumn, type NavItem } from "@airnub/ui";
 import { JsonLd } from "../components/JsonLd";
@@ -120,7 +121,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       <head>
         <JsonLd data={jsonLd} />
       </head>
-      <body className="flex min-h-screen flex-col bg-white text-slate-900 transition-colors dark:bg-slate-950 dark:text-slate-100">
+      <body className="flex min-h-screen flex-col">
         <ThemeProvider>
           <a href="#content" className="skip-link">
             {layoutMessages.skipToContent}


### PR DESCRIPTION
## Summary
- load the shared @airnub/ui stylesheet in both app layouts and remove redundant body theme classes
- ensure the layouts wrap content with the shared ThemeProvider alongside the shared header and footer components
- slim each app's globals.css down to skip-link and focus tweaks now that base theming comes from the shared CSS

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da5c8b0f548324bbceccacb96bfb12