### PR TITLE
ci: ensure pnpm is installed via action

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
     default: .nvmrc
   pnpm-version:
-    description: pnpm version to activate via Corepack
+    description: pnpm version to install via pnpm/action-setup
     required: false
     default: 10.17.1
 runs:
@@ -17,9 +17,8 @@ runs:
       with:
         node-version-file: ${{ inputs.node-version-file }}
         cache: pnpm
-    - name: Enable Corepack
-      shell: bash
-      run: corepack enable
-    - name: Activate pnpm
-      shell: bash
-      run: corepack prepare pnpm@${{ inputs.pnpm-version }} --activate
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: ${{ inputs.pnpm-version }}
+        run_install: false


### PR DESCRIPTION
## Summary
- replace corepack-based pnpm setup with pnpm/action-setup so workflows install pnpm reliably

## Testing
- not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68da6843f4488324973eae094bd7215a