### PR TITLE
refactor: replace neutral colors with tokens

### DIFF
--- a/apps/airnub/app/[locale]/company/page.tsx
+++ b/apps/airnub/app/[locale]/company/page.tsx
@@ -70,7 +70,7 @@ export default async function CompanyPage({
   };
 
   return (
-    <div className="space-y-16 pb-24 text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero eyebrow={hero.eyebrow} title={hero.title} description={hero.description} />
 
       <section>
@@ -78,26 +78,26 @@ export default async function CompanyPage({
           {values.map((value) => (
             <div
               key={value.id}
-              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40"
+              className="rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40"
             >
-              <h2 className="text-xl font-semibold text-white">{value.name}</h2>
-              <p className="mt-3 text-sm text-slate-300">{value.description}</p>
+              <h2 className="text-xl font-semibold text-foreground">{value.name}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{value.description}</p>
             </div>
           ))}
         </Container>
       </section>
 
       <section id="careers">
-        <Container className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 text-slate-200 shadow-lg shadow-slate-950/40">
+        <Container className="rounded-3xl border border-border bg-card/70 p-10 text-foreground shadow-lg shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-white">{careers.title}</h2>
-              <p className="mt-4 text-sm text-slate-300">{careers.description}</p>
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground">{careers.title}</h2>
+              <p className="mt-4 text-sm text-muted-foreground">{careers.description}</p>
             </div>
             <div>
               <Link
                 href={careers.ctaHref}
-                className="inline-flex items-center rounded-full bg-white px-5 py-2 text-sm font-semibold text-slate-900 transition hover:bg-slate-200"
+                className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
               >
                 {careers.ctaLabel}
               </Link>
@@ -109,9 +109,9 @@ export default async function CompanyPage({
       <section id="press">
         <Container className="grid gap-6 md:grid-cols-2">
           {press.cards.map((card) => (
-            <div key={card.id} className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40">
-              <h2 className="text-xl font-semibold text-white">{card.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{card.description}</p>
+            <div key={card.id} className="rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40">
+              <h2 className="text-xl font-semibold text-foreground">{card.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{card.description}</p>
               <Link
                 href={card.ctaHref}
                 className="mt-4 inline-flex text-sm font-semibold text-sky-400"
@@ -126,13 +126,13 @@ export default async function CompanyPage({
       </section>
 
       <section id="legal">
-        <Container className="rounded-3xl border border-slate-800 bg-slate-900/60 p-10 shadow-lg shadow-slate-950/40">
-          <h2 className="text-2xl font-semibold text-white">{legal.title}</h2>
+        <Container className="rounded-3xl border border-border bg-card/60 p-10 shadow-lg shadow-slate-950/40">
+          <h2 className="text-2xl font-semibold text-foreground">{legal.title}</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-2">
             {legal.items.map((item) => (
               <div key={item.id}>
-                <h3 className="text-lg font-semibold text-white">{item.title}</h3>
-                <p className="mt-2 text-sm text-slate-300">{item.description}</p>
+                <h3 className="text-lg font-semibold text-foreground">{item.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
                 <LocaleLink href={item.ctaHref} className="mt-3 inline-flex text-sm font-semibold text-sky-400">
                   {item.ctaLabel} →
                 </LocaleLink>

--- a/apps/airnub/app/[locale]/contact/ContactForm.tsx
+++ b/apps/airnub/app/[locale]/contact/ContactForm.tsx
@@ -93,7 +93,7 @@ export function ContactForm({ action, initialState, labels, toastDismissLabel }:
     <form ref={formRef} action={formAction} className="mt-8 space-y-6" noValidate>
       <div className="grid gap-6 md:grid-cols-2">
         <div>
-          <label htmlFor="full_name" className="block text-sm font-semibold text-slate-900 dark:text-white">
+          <label htmlFor="full_name" className="block text-sm font-semibold text-foreground">
             {labels.name}
           </label>
           <input
@@ -101,11 +101,11 @@ export function ContactForm({ action, initialState, labels, toastDismissLabel }:
             name="full_name"
             type="text"
             autoComplete="name"
-            className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
         <div>
-          <label htmlFor="email" className="block text-sm font-semibold text-slate-900 dark:text-white">
+          <label htmlFor="email" className="block text-sm font-semibold text-foreground">
             {labels.email} <span className="text-rose-500" aria-hidden="true">*</span>
             <span className="sr-only">({labels.required})</span>
           </label>
@@ -116,7 +116,7 @@ export function ContactForm({ action, initialState, labels, toastDismissLabel }:
             required
             autoComplete="email"
             aria-describedby={emailErrorId}
-            className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
           />
           {emailErrorMessage ? (
             <FormMessage id={emailErrorId} variant="error" className="mt-3 text-sm font-medium">
@@ -127,7 +127,7 @@ export function ContactForm({ action, initialState, labels, toastDismissLabel }:
       </div>
       <div className="grid gap-6 md:grid-cols-2">
         <div>
-          <label htmlFor="company" className="block text-sm font-semibold text-slate-900 dark:text-white">
+          <label htmlFor="company" className="block text-sm font-semibold text-foreground">
             {labels.company}
           </label>
           <input
@@ -135,18 +135,18 @@ export function ContactForm({ action, initialState, labels, toastDismissLabel }:
             name="company"
             type="text"
             autoComplete="organization"
-            className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
         <div>
-          <label htmlFor="message" className="block text-sm font-semibold text-slate-900 dark:text-white">
+          <label htmlFor="message" className="block text-sm font-semibold text-foreground">
             {labels.message}
           </label>
           <textarea
             id="message"
             name="message"
             rows={4}
-            className="mt-2 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500 dark:border-slate-700 dark:bg-slate-950 dark:text-white"
+            className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
       </div>

--- a/apps/airnub/app/[locale]/contact/page.tsx
+++ b/apps/airnub/app/[locale]/contact/page.tsx
@@ -1,4 +1,4 @@
-import { Container } from "@airnub/ui";
+import { Card, Container } from "@airnub/ui";
 import { getTranslations } from "next-intl/server";
 import type { Metadata } from "next";
 import { PageHero } from "../../../components/PageHero";
@@ -43,18 +43,18 @@ function ContactShortcuts({
 }: ContactShortcutsProps) {
   return (
     <div className="space-y-6">
-      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-900/5 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/40">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">{emailTitle}</h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+      <Card className="rounded-3xl bg-card/80 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{emailTitle}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
           {emailSales}: <a className="text-sky-600 underline-offset-4 hover:underline dark:text-sky-400" href="mailto:hello@airnub.io">hello@airnub.io</a>
         </p>
-        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+        <p className="mt-1 text-sm text-muted-foreground">
           {emailSecurity}: <a className="text-sky-600 underline-offset-4 hover:underline dark:text-sky-400" href="mailto:security@airnub.io">security@airnub.io</a>
         </p>
-      </div>
-      <div className="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-900/5 backdrop-blur dark:border-slate-800 dark:bg-slate-900/60 dark:shadow-slate-950/40">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">{officeTitle}</h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{officeDescription}</p>
+      </Card>
+      <Card className="rounded-3xl bg-card/80 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">{officeTitle}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">{officeDescription}</p>
         <a
           href="https://cal.com/airnub/office-hours"
           className="mt-3 inline-flex text-sm font-semibold text-sky-600 underline-offset-4 hover:underline dark:text-sky-400"
@@ -63,7 +63,7 @@ function ContactShortcuts({
         >
           {officeCta} →
         </a>
-      </div>
+      </Card>
     </div>
   );
 }
@@ -97,7 +97,7 @@ export default async function ContactPage({ params }: { params: Promise<{ locale
   };
 
   return (
-    <div className="space-y-16 pb-24 text-slate-700 dark:text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero
         eyebrow={t("hero.eyebrow")}
         title={t("hero.title")}
@@ -106,16 +106,16 @@ export default async function ContactPage({ params }: { params: Promise<{ locale
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
-          <div className="rounded-3xl border border-slate-200 bg-white/80 p-10 shadow-lg shadow-slate-900/5 backdrop-blur dark:border-slate-800 dark:bg-slate-900/70 dark:shadow-slate-950/40">
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{t("form.title")}</h2>
-            <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">{t("form.description")}</p>
+          <Card className="rounded-3xl bg-card/80 p-10 shadow-lg shadow-slate-900/5 backdrop-blur">
+            <h2 className="text-xl font-semibold text-foreground">{t("form.title")}</h2>
+            <p className="mt-3 text-sm text-muted-foreground">{t("form.description")}</p>
             <ContactForm
               action={submitLead}
               initialState={initialLeadFormState}
               labels={formLabels}
               toastDismissLabel={toastTranslations("dismiss")}
             />
-          </div>
+          </Card>
           <ContactShortcuts
             emailTitle={t("shortcuts.email.title")}
             emailSales={t("shortcuts.email.sales")}

--- a/apps/airnub/app/[locale]/maintenance/MaintenanceGate.tsx
+++ b/apps/airnub/app/[locale]/maintenance/MaintenanceGate.tsx
@@ -15,14 +15,14 @@ export function MaintenanceGate({ enabled, title, description, cta, children }: 
   }
 
   return (
-    <div className="flex min-h-[60vh] items-center bg-gradient-to-b from-slate-900 via-slate-950 to-slate-950 text-slate-100">
+    <div className="flex min-h-[60vh] items-center bg-gradient-to-b from-muted via-background to-background text-foreground">
       <Container className="max-w-3xl py-24 text-center">
         <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-400/70">Airnub</p>
         <h1 className="mt-6 text-4xl font-semibold tracking-tight sm:text-5xl">{title}</h1>
-        <p className="mt-4 text-lg text-slate-300">{description}</p>
+        <p className="mt-4 text-lg text-muted-foreground">{description}</p>
         <a
           href="mailto:hello@airnub.io"
-          className="mt-8 inline-flex items-center justify-center rounded-full bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+          className="mt-8 inline-flex items-center justify-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
         >
           {cta}
         </a>

--- a/apps/airnub/app/[locale]/products/page.tsx
+++ b/apps/airnub/app/[locale]/products/page.tsx
@@ -60,7 +60,7 @@ export default async function ProductsPage({
   }[];
 
   return (
-    <div className="space-y-16 pb-24 text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero
         eyebrow={hero.eyebrow}
         title={hero.title}
@@ -84,18 +84,18 @@ export default async function ProductsPage({
             return (
               <article
                 key={offering.id}
-                className="flex h-full flex-col justify-between rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40"
+                className="flex h-full flex-col justify-between rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40"
               >
                 <div>
                   <div className="flex items-center gap-3">
-                    <h2 className="text-2xl font-semibold text-white">{offering.name}</h2>
+                    <h2 className="text-2xl font-semibold text-foreground">{offering.name}</h2>
                     {offering.badge ? (
                       <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-300">
                         {offering.badge}
                       </span>
                     ) : null}
                   </div>
-                  <p className="mt-3 text-sm text-slate-300">{offering.description}</p>
+                  <p className="mt-3 text-sm text-muted-foreground">{offering.description}</p>
                 </div>
                 <div className="mt-8">
                   <LinkComponent
@@ -115,20 +115,20 @@ export default async function ProductsPage({
       <section>
         <Container className="grid gap-8 lg:grid-cols-2">
           {insights.map((insight) => (
-            <div key={insight.id} className="rounded-3xl border border-slate-800 bg-slate-900/70 p-8 shadow-lg shadow-slate-950/40">
-              <h3 className="text-xl font-semibold text-white">{insight.title}</h3>
+            <div key={insight.id} className="rounded-3xl border border-border bg-card/70 p-8 shadow-lg shadow-slate-950/40">
+              <h3 className="text-xl font-semibold text-foreground">{insight.title}</h3>
               {insight.description ? (
-                <p className="mt-3 text-sm text-slate-300">{insight.description}</p>
+                <p className="mt-3 text-sm text-muted-foreground">{insight.description}</p>
               ) : null}
               {insight.bullets ? (
-                <ul className="mt-4 space-y-2 text-sm text-slate-300">
+                <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
                   {insight.bullets.map((bullet) => (
                     <li key={bullet}>→ {bullet}</li>
                   ))}
                 </ul>
               ) : null}
               {insight.paragraphs ? (
-                <div className="mt-3 space-y-3 text-sm text-slate-300">
+                <div className="mt-3 space-y-3 text-sm text-muted-foreground">
                   {insight.paragraphs.map((paragraph) => (
                     <p key={paragraph}>{paragraph}</p>
                   ))}

--- a/apps/airnub/app/[locale]/resources/page.tsx
+++ b/apps/airnub/app/[locale]/resources/page.tsx
@@ -59,22 +59,22 @@ export default async function ResourcesPage({
   };
 
   return (
-    <div className="space-y-16 pb-24 text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero eyebrow={hero.eyebrow} title={hero.title} description={hero.description} />
 
       <section>
         <Container>
-          <h2 className="text-xl font-semibold text-white">{resources("guidesHeading")}</h2>
+          <h2 className="text-xl font-semibold text-foreground">{resources("guidesHeading")}</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-3">
             {guides.map((guide) => (
               <Link
                 key={guide.id}
                 href={guide.href}
-                className="group rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:-translate-y-1 hover:border-sky-500/40"
+                className="group rounded-3xl border border-border bg-card/60 p-6 shadow-lg shadow-slate-950/40 transition hover:-translate-y-1 hover:border-ring/40"
               >
                 <p className="text-sm font-semibold text-sky-400 group-hover:text-sky-300">{guideLabel}</p>
-                <h3 className="mt-2 text-lg font-semibold text-white">{guide.title}</h3>
-                <p className="mt-2 text-sm text-slate-300">{guide.description}</p>
+                <h3 className="mt-2 text-lg font-semibold text-foreground">{guide.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{guide.description}</p>
               </Link>
             ))}
           </div>
@@ -83,16 +83,16 @@ export default async function ResourcesPage({
 
       <section>
         <Container>
-          <h2 className="text-xl font-semibold text-white">{resources("updatesHeading")}</h2>
+          <h2 className="text-xl font-semibold text-foreground">{resources("updatesHeading")}</h2>
           <div className="mt-6 space-y-4">
             {updates.map((update) => (
               <Link
                 key={update.id}
                 href={update.href}
-                className="flex flex-col rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40 transition hover:border-sky-500/40"
+                className="flex flex-col rounded-3xl border border-border bg-card/60 p-6 shadow-lg shadow-slate-950/40 transition hover:border-ring/40"
               >
-                <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">{update.date}</span>
-                <h3 className="mt-2 text-lg font-semibold text-white">{update.title}</h3>
+                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{update.date}</span>
+                <h3 className="mt-2 text-lg font-semibold text-foreground">{update.title}</h3>
                 <span className="mt-2 text-sm font-semibold text-sky-400">{updateCta} →</span>
               </Link>
             ))}
@@ -101,16 +101,16 @@ export default async function ResourcesPage({
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 shadow-lg shadow-slate-950/40">
+        <Container className="rounded-3xl border border-border bg-card/70 p-10 shadow-lg shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-2xl font-semibold text-white">{officeHours.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{officeHours.description}</p>
+              <h2 className="text-2xl font-semibold text-foreground">{officeHours.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{officeHours.description}</p>
             </div>
             <div>
               <LocaleLink
                 href={officeHours.ctaHref}
-                className="inline-flex items-center rounded-full bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
+                className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
               >
                 {officeHours.ctaLabel}
               </LocaleLink>

--- a/apps/airnub/app/[locale]/services/page.tsx
+++ b/apps/airnub/app/[locale]/services/page.tsx
@@ -51,7 +51,7 @@ export default async function ServicesPage({
   };
 
   return (
-    <div className="space-y-16 pb-24 text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero
         eyebrow={hero.eyebrow}
         title={hero.title}
@@ -69,16 +69,16 @@ export default async function ServicesPage({
             <article
               key={engagement.id}
               id={engagement.id}
-              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-10 shadow-lg shadow-slate-950/40"
+              className="rounded-3xl border border-border bg-card/60 p-10 shadow-lg shadow-slate-950/40"
             >
               <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
                 <div className="lg:max-w-2xl">
-                  <h2 className="text-2xl font-semibold text-white">{engagement.title}</h2>
-                  <p className="mt-3 text-sm text-slate-300">{engagement.description}</p>
+                  <h2 className="text-2xl font-semibold text-foreground">{engagement.title}</h2>
+                  <p className="mt-3 text-sm text-muted-foreground">{engagement.description}</p>
                 </div>
                 <div className="lg:min-w-[16rem]">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{deliverablesLabel}</p>
-                  <ul className="mt-3 space-y-2 text-sm text-slate-300">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{deliverablesLabel}</p>
+                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
                     {engagement.deliverables.map((item) => (
                       <li key={item}>→ {item}</li>
                     ))}
@@ -91,13 +91,13 @@ export default async function ServicesPage({
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-800 bg-slate-900/80 p-10 text-slate-200 shadow-xl shadow-slate-950/40">
+        <Container className="rounded-3xl border border-border bg-card/80 p-10 text-foreground shadow-xl shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-white">{outcomes.title}</h2>
-              <p className="mt-4 text-sm text-slate-300">{outcomes.description}</p>
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground">{outcomes.title}</h2>
+              <p className="mt-4 text-sm text-muted-foreground">{outcomes.description}</p>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200">
+            <div className="rounded-2xl border border-border/10 bg-card/5 p-6 text-sm text-foreground">
               <p>{outcomes.note}</p>
             </div>
           </div>

--- a/apps/airnub/app/[locale]/solutions/page.tsx
+++ b/apps/airnub/app/[locale]/solutions/page.tsx
@@ -49,7 +49,7 @@ export default async function SolutionsPage({
   };
 
   return (
-    <div className="space-y-16 pb-24 text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero eyebrow={hero.eyebrow} title={hero.title} description={hero.description} />
 
       <section>
@@ -57,11 +57,11 @@ export default async function SolutionsPage({
           {sectors.map((sector) => (
             <div
               key={sector.id}
-              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 shadow-lg shadow-slate-950/40"
+              className="rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40"
             >
-              <h2 className="text-xl font-semibold text-white">{sector.name}</h2>
-              <p className="mt-3 text-sm text-slate-300">{sector.summary}</p>
-              <ul className="mt-4 space-y-2 text-sm text-slate-300">
+              <h2 className="text-xl font-semibold text-foreground">{sector.name}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{sector.summary}</p>
+              <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
                 {sector.bullets.map((bullet) => (
                   <li key={bullet}>→ {bullet}</li>
                 ))}
@@ -72,14 +72,14 @@ export default async function SolutionsPage({
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-800 bg-gradient-to-br from-slate-900 via-slate-950 to-slate-900 p-10 text-slate-100 shadow-xl shadow-slate-950/40">
+        <Container className="rounded-3xl border border-border bg-gradient-to-br from-muted via-background to-muted p-10 text-foreground shadow-xl shadow-slate-950/40">
           <div className="grid gap-10 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-white">{partner.title}</h2>
-              <p className="mt-4 text-sm text-slate-300">{partner.description}</p>
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground">{partner.title}</h2>
+              <p className="mt-4 text-sm text-muted-foreground">{partner.description}</p>
             </div>
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200">
-              <p className="font-semibold text-white">{partner.expectationsTitle}</p>
+            <div className="rounded-2xl border border-border/10 bg-card/5 p-6 text-sm text-muted-foreground">
+              <p className="font-semibold text-foreground">{partner.expectationsTitle}</p>
               <ul className="mt-3 space-y-2">
                 {partner.expectations.map((item) => (
                   <li key={item}>→ {item}</li>

--- a/apps/airnub/app/[locale]/trust/page.tsx
+++ b/apps/airnub/app/[locale]/trust/page.tsx
@@ -52,7 +52,7 @@ export default async function TrustPage({
   };
 
   return (
-    <div className="space-y-16 pb-24 text-slate-300">
+    <div className="space-y-16 pb-24 text-muted-foreground">
       <PageHero eyebrow={hero.eyebrow} title={hero.title} description={hero.description} />
 
       <section>
@@ -61,12 +61,12 @@ export default async function TrustPage({
             <Link
               key={item.id}
               href={item.href}
-              className="rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-left shadow-lg shadow-slate-950/40 transition hover:border-sky-500/40"
+              className="rounded-3xl border border-border bg-card/60 p-8 text-left shadow-lg shadow-slate-950/40 transition hover:border-ring/40"
               target="_blank"
               rel="noreferrer"
             >
-              <h2 className="text-xl font-semibold text-white">{item.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{item.description}</p>
+              <h2 className="text-xl font-semibold text-foreground">{item.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{item.description}</p>
               <span className="mt-4 inline-flex text-sm font-semibold text-sky-400">{highlightCta} →</span>
             </Link>
           ))}
@@ -74,16 +74,16 @@ export default async function TrustPage({
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-800 bg-slate-900/70 p-10 shadow-lg shadow-slate-950/40">
+        <Container className="rounded-3xl border border-border bg-card/70 p-10 shadow-lg shadow-slate-950/40">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
             <div>
-              <h2 className="text-2xl font-semibold text-white">{request.title}</h2>
-              <p className="mt-3 text-sm text-slate-300">{request.description}</p>
+              <h2 className="text-2xl font-semibold text-foreground">{request.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{request.description}</p>
             </div>
             <div>
               <LocaleLink
                 href={request.ctaHref}
-                className="inline-flex items-center rounded-full bg-sky-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-sky-500"
+                className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
               >
                 {request.ctaLabel}
               </LocaleLink>

--- a/apps/airnub/app/admin/(protected)/layout.tsx
+++ b/apps/airnub/app/admin/(protected)/layout.tsx
@@ -23,22 +23,22 @@ export default async function ProtectedAdminLayout({ children }: { children: Rea
 
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-10 px-6 py-12 sm:px-10 lg:px-16">
-      <header className="flex flex-col gap-6 border-b border-slate-800/60 pb-6">
+      <header className="flex flex-col gap-6 border-b border-border/60 pb-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-400/70">Airnub</p>
-            <h1 className="text-3xl font-semibold tracking-tight text-white">Operations console</h1>
-            <p className="max-w-2xl text-sm text-slate-300">
+            <h1 className="text-3xl font-semibold tracking-tight text-foreground">Operations console</h1>
+            <p className="max-w-2xl text-sm text-muted-foreground">
               Securely manage inbound leads and runtime toggles from any device. Supabase Auth protects this console; sessions
               refresh automatically while you work.
             </p>
           </div>
-          <form action={signOut} className="flex w-full flex-col items-start gap-2 text-sm text-slate-300 sm:w-auto sm:items-end">
-            <span className="text-xs uppercase tracking-wide text-slate-500">Signed in</span>
-            <span className="text-sm font-medium text-slate-100">{userEmail}</span>
+          <form action={signOut} className="flex w-full flex-col items-start gap-2 text-sm text-muted-foreground sm:w-auto sm:items-end">
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">Signed in</span>
+            <span className="text-sm font-medium text-foreground">{userEmail}</span>
             <button
               type="submit"
-              className="rounded-full border border-slate-700/70 bg-slate-900/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.25em] text-slate-200 transition hover:border-slate-600 hover:bg-slate-900"
+              className="rounded-full border border-border/70 bg-card/60 px-4 py-1.5 text-xs font-semibold uppercase tracking-[0.25em] text-foreground transition hover:border-ring hover:bg-card/80"
             >
               Sign out
             </button>
@@ -46,7 +46,7 @@ export default async function ProtectedAdminLayout({ children }: { children: Rea
         </div>
       </header>
       <main className="flex-1 pb-16">{children}</main>
-      <footer className="border-t border-slate-800/60 pt-6 text-xs text-slate-500">
+      <footer className="border-t border-border/60 pt-6 text-xs text-muted-foreground">
         © {new Date().getFullYear()} Airnub. Remote updates are tracked via Supabase service role.
       </footer>
     </div>

--- a/apps/airnub/app/admin/(protected)/leads/LeadActionForm.tsx
+++ b/apps/airnub/app/admin/(protected)/leads/LeadActionForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useFormState, useFormStatus } from "react-dom";
+import { Button } from "@airnub/ui";
 import type { LeadActionFormState } from "./actions";
 import { submitLeadAction } from "./actions";
 import { LEAD_STATUSES, LEAD_STATUS_LABELS } from "./statuses";
@@ -19,13 +20,9 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
 
   return (
-    <button
-      type="submit"
-      className="inline-flex items-center justify-center rounded-full bg-sky-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300 disabled:cursor-not-allowed disabled:bg-slate-500"
-      disabled={pending}
-    >
+    <Button type="submit" disabled={pending} aria-disabled={pending} className="min-w-[8rem] justify-center">
       {pending ? "Saving…" : label}
-    </button>
+    </Button>
   );
 }
 
@@ -43,18 +40,18 @@ export function LeadActionForm({ leadId, latestStatus, latestAssignee, actorSugg
     <form
       ref={formRef}
       action={formAction}
-      className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4"
+      className="space-y-4 rounded-2xl border border-border/60 bg-card/40 p-4"
     >
       <input type="hidden" name="leadId" value={leadId} />
       <div>
-        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Status</label>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Status</label>
         <select
           name="status"
           defaultValue={latestStatus && LEAD_STATUSES.includes(latestStatus as any) ? latestStatus : "new"}
-          className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner focus:outline-none focus:ring-2 focus:ring-sky-400"
+          className="mt-2 w-full rounded-xl border border-border bg-card/60 px-3 py-2 text-sm text-foreground shadow-inner focus:outline-none focus:ring-2 focus:ring-ring"
         >
           {LEAD_STATUSES.map((status) => (
-            <option key={status} value={status} className="bg-slate-950 text-slate-900">
+            <option key={status} value={status}>
               {LEAD_STATUS_LABELS[status]}
             </option>
           ))}
@@ -62,33 +59,33 @@ export function LeadActionForm({ leadId, latestStatus, latestAssignee, actorSugg
       </div>
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
-          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Assign to</label>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Assign to</label>
           <input
             type="text"
             name="assignee"
             placeholder="Owner or teammate"
             defaultValue={latestAssignee ?? ""}
-            className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            className="mt-2 w-full rounded-xl border border-border bg-card/60 px-3 py-2 text-sm text-foreground shadow-inner placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
         <div>
-          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Recorded by</label>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Recorded by</label>
           <input
             type="text"
             name="actor"
             placeholder="Your name"
             defaultValue={actorSuggestion ?? ""}
-            className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            className="mt-2 w-full rounded-xl border border-border bg-card/60 px-3 py-2 text-sm text-foreground shadow-inner placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
       </div>
       <div>
-        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Notes</label>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</label>
         <textarea
           name="note"
           rows={3}
           placeholder="Context, reply summary, or next steps"
-          className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          className="mt-2 w-full rounded-xl border border-border bg-card/60 px-3 py-2 text-sm text-foreground shadow-inner placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
         />
       </div>
       {state.status === "error" ? (

--- a/apps/airnub/app/admin/(protected)/leads/MaintenanceToggleForm.tsx
+++ b/apps/airnub/app/admin/(protected)/leads/MaintenanceToggleForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { useFormState, useFormStatus } from "react-dom";
+import { Button } from "@airnub/ui";
 import type { MaintenanceFormState } from "./actions";
 import { updateMaintenanceMode } from "./actions";
 
@@ -17,13 +18,9 @@ function SubmitButton() {
   const { pending } = useFormStatus();
 
   return (
-    <button
-      type="submit"
-      className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300 disabled:cursor-not-allowed disabled:bg-slate-500"
-      disabled={pending}
-    >
+    <Button type="submit" disabled={pending} aria-disabled={pending} className="min-w-[12rem] justify-center">
       {pending ? "Saving…" : "Save maintenance setting"}
-    </button>
+    </Button>
   );
 }
 
@@ -43,37 +40,37 @@ export function MaintenanceToggleForm({ enabled, updatedAt, updatedBy }: Mainten
     <form
       ref={formRef}
       action={formAction}
-      className="space-y-4 rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4"
+      className="space-y-4 rounded-2xl border border-border/60 bg-card/40 p-4"
     >
       <div>
-        <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Maintenance mode</label>
+        <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Maintenance mode</label>
         <select
           name="enabled"
           defaultValue={String(enabled)}
-          className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner focus:outline-none focus:ring-2 focus:ring-emerald-400"
+          className="mt-2 w-full rounded-xl border border-border bg-card/60 px-3 py-2 text-sm text-foreground shadow-inner focus:outline-none focus:ring-2 focus:ring-ring"
         >
-          <option value="false" className="bg-slate-950 text-slate-900">
+          <option value="false">
             Off — public site stays live
           </option>
-          <option value="true" className="bg-slate-950 text-slate-900">
+          <option value="true">
             On — show downtime banner everywhere
           </option>
         </select>
       </div>
       <div className="grid gap-4 sm:grid-cols-[1fr,1fr]">
         <div>
-          <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400">Recorded by</label>
+          <label className="block text-xs font-semibold uppercase tracking-wide text-muted-foreground">Recorded by</label>
           <input
             type="text"
             name="actor"
             placeholder="Your name"
             defaultValue={updatedBy ?? ""}
-            className="mt-2 w-full rounded-xl border border-slate-700 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+            className="mt-2 w-full rounded-xl border border-border bg-card/60 px-3 py-2 text-sm text-foreground shadow-inner placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
           />
         </div>
-        <div className="text-xs text-slate-400">
+        <div className="text-xs text-muted-foreground">
           <p className="font-semibold uppercase tracking-wide">Last updated</p>
-          <p className="mt-2 text-slate-300">
+          <p className="mt-2 text-muted-foreground">
             {formattedUpdatedAt ? formattedUpdatedAt : "No changes yet"}
             {updatedBy ? ` • ${updatedBy}` : ""}
           </p>

--- a/apps/airnub/app/admin/(protected)/leads/page.tsx
+++ b/apps/airnub/app/admin/(protected)/leads/page.tsx
@@ -29,12 +29,12 @@ function formatTimestamp(value: string | null | undefined) {
 export default async function LeadsPage() {
   if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
     return (
-      <div className="space-y-6 text-slate-100">
+      <div className="space-y-6 text-foreground">
         <h1 className="text-3xl font-semibold">Admin configuration missing</h1>
-        <p className="text-sm text-slate-300">
-          Add <code className="rounded bg-slate-800 px-1 py-0.5 text-xs">SUPABASE_SERVICE_ROLE_KEY</code>,
-          <code className="ml-1 rounded bg-slate-800 px-1 py-0.5 text-xs">NEXT_PUBLIC_SUPABASE_URL</code>, and
-          <code className="ml-1 rounded bg-slate-800 px-1 py-0.5 text-xs">NEXT_PUBLIC_SUPABASE_ANON_KEY</code> to your
+        <p className="text-sm text-muted-foreground">
+          Add <code className="rounded bg-card px-1 py-0.5 text-xs">SUPABASE_SERVICE_ROLE_KEY</code>,
+          <code className="ml-1 rounded bg-card px-1 py-0.5 text-xs">NEXT_PUBLIC_SUPABASE_URL</code>, and
+          <code className="ml-1 rounded bg-card px-1 py-0.5 text-xs">NEXT_PUBLIC_SUPABASE_ANON_KEY</code> to your
           environment variables to unlock the remote operations console.
         </p>
       </div>
@@ -56,7 +56,7 @@ export default async function LeadsPage() {
 
   if (leadError) {
     return (
-      <div className="space-y-4 text-slate-100">
+      <div className="space-y-4 text-foreground">
         <h1 className="text-3xl font-semibold">Unable to load leads</h1>
         <p className="text-sm text-rose-300">
           Supabase returned an error. Confirm the service role credentials and network reachability, then refresh.
@@ -68,7 +68,7 @@ export default async function LeadsPage() {
 
   if (maintenanceError) {
     return (
-      <div className="space-y-4 text-slate-100">
+      <div className="space-y-4 text-foreground">
         <h1 className="text-3xl font-semibold">Unable to load runtime flags</h1>
         <p className="text-sm text-rose-300">
           Supabase returned an error while loading runtime flags. Double-check the service role key and try again.
@@ -104,11 +104,11 @@ export default async function LeadsPage() {
     typeof maintenanceFlag?.value === "boolean" ? maintenanceFlag.value : process.env.MAINTENANCE_MODE === "true";
 
   return (
-    <div className="space-y-10 text-slate-100">
+    <div className="space-y-10 text-foreground">
       <header className="space-y-3">
         <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-400/70">Airnub</p>
         <h1 className="text-4xl font-semibold tracking-tight">Remote operations</h1>
-        <p className="max-w-2xl text-sm text-slate-300">
+        <p className="max-w-2xl text-sm text-muted-foreground">
           Review inbound leads from both marketing sites, assign follow-ups, and toggle the maintenance banner without opening the
           cloud console.
         </p>
@@ -126,11 +126,11 @@ export default async function LeadsPage() {
       <section className="space-y-6">
         <div>
           <h2 className="text-xl font-semibold">Inbound leads</h2>
-          <p className="text-sm text-slate-300">Showing the 100 most recent submissions across the Airnub and Speckit funnels.</p>
+          <p className="text-sm text-muted-foreground">Showing the 100 most recent submissions across the Airnub and Speckit funnels.</p>
         </div>
 
         {leads.length === 0 ? (
-          <p className="rounded-3xl border border-dashed border-slate-800/60 bg-slate-950/40 p-6 text-sm text-slate-400">
+          <p className="rounded-3xl border border-dashed border-border/60 bg-card/40 p-6 text-sm text-muted-foreground">
             No leads yet. Check back after the next launch.
           </p>
         ) : null}
@@ -154,15 +154,15 @@ export default async function LeadsPage() {
                   return (
                     <article
                       key={lead.id}
-                      className="flex h-full flex-col justify-between gap-4 rounded-3xl border border-slate-800/70 bg-slate-950/60 p-6 shadow-lg shadow-slate-950/40"
+                      className="flex h-full flex-col justify-between gap-4 rounded-3xl border border-border/70 bg-card/60 p-6 shadow-lg shadow-slate-950/40"
                     >
                       <div className="space-y-4">
                         <div>
-                          <p className="text-xs uppercase tracking-wide text-slate-400">Submitted</p>
-                          <p className="text-sm text-slate-200">{formatTimestamp(lead.created_at)}</p>
+                          <p className="text-xs uppercase tracking-wide text-muted-foreground">Submitted</p>
+                          <p className="text-sm text-foreground">{formatTimestamp(lead.created_at)}</p>
                         </div>
                         <div>
-                          <h4 className="text-2xl font-semibold text-white">{lead.full_name ?? lead.email}</h4>
+                          <h4 className="text-2xl font-semibold text-foreground">{lead.full_name ?? lead.email}</h4>
                           <a
                             href={`mailto:${lead.email}`}
                             className="text-sm text-sky-300 underline-offset-4 hover:underline"
@@ -170,32 +170,32 @@ export default async function LeadsPage() {
                             {lead.email}
                           </a>
                           {lead.company ? (
-                            <p className="text-sm text-slate-300">{lead.company}</p>
+                            <p className="text-sm text-muted-foreground">{lead.company}</p>
                           ) : null}
                         </div>
                         {lead.message ? (
                           <div>
-                            <p className="text-xs uppercase tracking-wide text-slate-400">Message</p>
-                            <p className="mt-1 whitespace-pre-line text-sm text-slate-200">{lead.message}</p>
+                            <p className="text-xs uppercase tracking-wide text-muted-foreground">Message</p>
+                            <p className="mt-1 whitespace-pre-line text-sm text-foreground">{lead.message}</p>
                           </div>
                         ) : null}
                         {latestAction ? (
-                          <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-4">
-                            <p className="text-xs uppercase tracking-wide text-slate-400">Latest triage</p>
-                            <p className="mt-1 text-sm text-slate-200">
+                          <div className="rounded-2xl border border-border/60 bg-card/40 p-4">
+                            <p className="text-xs uppercase tracking-wide text-muted-foreground">Latest triage</p>
+                            <p className="mt-1 text-sm text-foreground">
                               {STATUS_LABELS[latestAction.status] ?? latestAction.status}
                               {latestAction.assignee ? ` • Assigned to ${latestAction.assignee}` : ""}
                             </p>
                             {latestAction.note ? (
-                              <p className="mt-2 text-sm text-slate-300 whitespace-pre-line">{latestAction.note}</p>
+                              <p className="mt-2 text-sm text-muted-foreground whitespace-pre-line">{latestAction.note}</p>
                             ) : null}
-                            <p className="mt-2 text-xs text-slate-500">
+                            <p className="mt-2 text-xs text-muted-foreground">
                               {latestAction.created_by ? `${latestAction.created_by} — ` : ""}
                               {formatTimestamp(latestAction.created_at)}
                             </p>
                           </div>
                         ) : (
-                          <div className="rounded-2xl border border-dashed border-slate-800/60 bg-slate-900/20 p-4 text-sm text-slate-400">
+                          <div className="rounded-2xl border border-dashed border-border/60 bg-card/20 p-4 text-sm text-muted-foreground">
                             No triage recorded yet.
                           </div>
                         )}
@@ -203,16 +203,16 @@ export default async function LeadsPage() {
                       <div className="space-y-4">
                         {lead.lead_actions.length > 1 ? (
                           <div className="space-y-2">
-                            <p className="text-xs uppercase tracking-wide text-slate-400">History</p>
-                            <ul className="space-y-2 text-xs text-slate-400">
+                            <p className="text-xs uppercase tracking-wide text-muted-foreground">History</p>
+                            <ul className="space-y-2 text-xs text-muted-foreground">
                               {lead.lead_actions.slice(1, 5).map((action) => (
-                                <li key={action.id} className="rounded-xl border border-slate-800/60 bg-slate-900/30 p-3">
-                                  <p className="text-slate-300">
+                                <li key={action.id} className="rounded-xl border border-border/60 bg-card/30 p-3">
+                                  <p className="text-muted-foreground">
                                     {STATUS_LABELS[action.status] ?? action.status}
                                     {action.assignee ? ` • ${action.assignee}` : ""}
                                   </p>
-                                  {action.note ? <p className="mt-1 whitespace-pre-line text-slate-400">{action.note}</p> : null}
-                                  <p className="mt-1 text-[0.7rem] text-slate-500">
+                                  {action.note ? <p className="mt-1 whitespace-pre-line text-muted-foreground">{action.note}</p> : null}
+                                  <p className="mt-1 text-[0.7rem] text-muted-foreground">
                                     {action.created_by ? `${action.created_by} — ` : ""}
                                     {formatTimestamp(action.created_at)}
                                   </p>

--- a/apps/airnub/app/admin/(public)/sign-in/SignInForm.tsx
+++ b/apps/airnub/app/admin/(public)/sign-in/SignInForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useFormState, useFormStatus } from "react-dom";
+import { Button } from "@airnub/ui";
 import type { SignInFormState } from "./actions";
 
 type Props = {
@@ -13,13 +14,14 @@ function SubmitButton() {
   const { pending } = useFormStatus();
 
   return (
-    <button
+    <Button
       type="submit"
       disabled={pending}
-      className="inline-flex items-center justify-center rounded-full border border-slate-700/70 bg-sky-500/90 px-6 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white transition hover:bg-sky-400/90 disabled:cursor-not-allowed disabled:opacity-70"
+      aria-disabled={pending}
+      className="px-6 py-2 text-xs font-semibold uppercase tracking-[0.25em]"
     >
       {pending ? "Signing in…" : "Sign in"}
-    </button>
+    </Button>
   );
 }
 
@@ -29,7 +31,7 @@ export function SignInForm({ action }: Props) {
   return (
     <form action={formAction} className="space-y-6" noValidate>
       <div className="space-y-2">
-        <label htmlFor="email" className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-300">
+        <label htmlFor="email" className="text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground">
           Email address
         </label>
         <input
@@ -37,12 +39,12 @@ export function SignInForm({ action }: Props) {
           name="email"
           type="email"
           autoComplete="email"
-          className="w-full rounded-2xl border border-slate-800 bg-slate-950 px-4 py-3 text-sm text-white shadow-inner shadow-slate-950 focus:border-sky-400 focus:outline-none"
+          className="w-full rounded-2xl border border-border bg-card px-4 py-3 text-sm text-foreground shadow-inner shadow-slate-950 focus:border-ring focus:outline-none"
           required
         />
       </div>
       <div className="space-y-2">
-        <label htmlFor="password" className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-300">
+        <label htmlFor="password" className="text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground">
           Password
         </label>
         <input
@@ -50,14 +52,14 @@ export function SignInForm({ action }: Props) {
           name="password"
           type="password"
           autoComplete="current-password"
-          className="w-full rounded-2xl border border-slate-800 bg-slate-950 px-4 py-3 text-sm text-white shadow-inner shadow-slate-950 focus:border-sky-400 focus:outline-none"
+          className="w-full rounded-2xl border border-border bg-card px-4 py-3 text-sm text-foreground shadow-inner shadow-slate-950 focus:border-ring focus:outline-none"
           required
         />
       </div>
       {state?.error ? <p className="text-sm text-rose-300">{state.error}</p> : null}
       <div className="flex items-center justify-between gap-4">
         <SubmitButton />
-        <p className="text-xs text-slate-400">Supabase manages the session cookie for this device.</p>
+        <p className="text-xs text-muted-foreground">Supabase manages the session cookie for this device.</p>
       </div>
     </form>
   );

--- a/apps/airnub/app/admin/(public)/sign-in/page.tsx
+++ b/apps/airnub/app/admin/(public)/sign-in/page.tsx
@@ -10,11 +10,11 @@ export const metadata: Metadata = {
 export default function SignInPage() {
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-lg items-center justify-center px-6 py-12">
-      <div className="w-full space-y-8 rounded-3xl border border-slate-800/60 bg-slate-950/60 p-10 shadow-2xl shadow-slate-950/40">
+      <div className="w-full space-y-8 rounded-3xl border border-border/60 bg-card/60 p-10 shadow-2xl shadow-slate-950/40">
         <div className="space-y-3 text-center">
           <p className="text-xs font-semibold uppercase tracking-[0.3em] text-sky-400/70">Airnub</p>
-          <h1 className="text-3xl font-semibold tracking-tight text-white">Operations console access</h1>
-          <p className="text-sm text-slate-300">
+          <h1 className="text-3xl font-semibold tracking-tight text-foreground">Operations console access</h1>
+          <p className="text-sm text-muted-foreground">
             Use the Supabase credentials for your admin user. Sessions are stored securely in HttpOnly cookies and refresh in the
             background.
           </p>

--- a/apps/airnub/app/admin/layout.tsx
+++ b/apps/airnub/app/admin/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 export default function AdminRootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <body className="min-h-screen bg-gradient-to-br from-background via-muted to-background text-foreground">
         {children}
       </body>
     </html>

--- a/apps/airnub/app/globals.css
+++ b/apps/airnub/app/globals.css
@@ -3,20 +3,13 @@ html {
 }
 
 a:focus-visible {
-  outline: 2px solid #38bdf8; /* sky-400 */
+  outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
 }
 
 .skip-link {
-  position: absolute;
+  @apply absolute left-1/2 -translate-x-1/2 rounded-full bg-foreground px-5 py-3 font-semibold text-background;
   top: -100px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #0ea5e9;
-  color: white;
-  padding: 0.75rem 1.25rem;
-  border-radius: 9999px;
-  font-weight: 600;
   transition: top 0.2s ease;
   z-index: 50;
 }

--- a/apps/airnub/components/LocaleSwitcher.tsx
+++ b/apps/airnub/components/LocaleSwitcher.tsx
@@ -82,7 +82,7 @@ export function LocaleSwitcher({ className }: LocaleSwitcherProps) {
         id="locale-switcher"
         name="locale"
         className={clsx(
-          "appearance-none rounded-full border border-slate-200 bg-white px-3 py-2 pr-8 text-sm font-medium text-slate-700 transition hover:border-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-600",
+          "appearance-none rounded-full border border-border bg-card px-3 py-2 pr-8 text-sm font-medium text-foreground transition hover:border-ring focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
           isPending && "opacity-75"
         )}
         value={locale}
@@ -99,7 +99,7 @@ export function LocaleSwitcher({ className }: LocaleSwitcherProps) {
       <svg
         aria-hidden="true"
         focusable="false"
-        className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-500 dark:text-slate-400"
+        className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground"
         viewBox="0 0 12 8"
       >
         <path d="M1.41.59 6 5.17l4.59-4.58L12 2l-6 6-6-6z" fill="currentColor" />

--- a/apps/airnub/components/PageHero.tsx
+++ b/apps/airnub/components/PageHero.tsx
@@ -18,7 +18,7 @@ export function PageHero({
   return (
     <section
       className={clsx(
-        "relative overflow-hidden border-b border-slate-200 bg-slate-50 py-16 text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100",
+        "relative overflow-hidden border-b border-border bg-muted py-16 text-foreground",
         className,
       )}
     >
@@ -30,8 +30,8 @@ export function PageHero({
         {eyebrow ? (
           <p className="text-sm font-semibold uppercase tracking-wide text-sky-600 dark:text-sky-400/80">{eyebrow}</p>
         ) : null}
-        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-slate-900 dark:text-white sm:text-5xl">{title}</h1>
-        {description ? <p className="mt-6 text-lg text-slate-600 dark:text-slate-300">{description}</p> : null}
+        <h1 className="mt-4 text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">{title}</h1>
+        {description ? <p className="mt-6 text-lg text-muted-foreground">{description}</p> : null}
         {actions ? <div className="mt-8 flex flex-wrap gap-4">{actions}</div> : null}
       </Container>
     </section>

--- a/apps/speckit/app/contact/page.tsx
+++ b/apps/speckit/app/contact/page.tsx
@@ -23,18 +23,18 @@ type ContactShortcutsProps = {
 function ContactShortcuts({ shortcuts }: ContactShortcutsProps) {
   return (
     <div className="space-y-6">
-      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-white/10 dark:bg-white/10">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+      <div className="rounded-3xl border border-border bg-card p-6 shadow-lg">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           {shortcuts.emailHeading}
         </h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">{shortcuts.productQuestions}</p>
-        <p className="mt-1 text-sm text-slate-600 dark:text-slate-200">{shortcuts.security}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{shortcuts.productQuestions}</p>
+        <p className="mt-1 text-sm text-muted-foreground">{shortcuts.security}</p>
       </div>
-      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg dark:border-white/10 dark:bg-white/10">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-300">
+      <div className="rounded-3xl border border-border bg-card p-6 shadow-lg">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
           {shortcuts.docsHeading}
         </h3>
-        <p className="mt-2 text-sm text-slate-600 dark:text-slate-200">{shortcuts.docsDescription}</p>
+        <p className="mt-2 text-sm text-muted-foreground">{shortcuts.docsDescription}</p>
         <a
           href="https://docs.speckit.dev"
           className="mt-3 inline-flex text-sm font-semibold text-indigo-600 transition hover:text-indigo-700 dark:text-indigo-300 dark:hover:text-indigo-200"
@@ -62,13 +62,13 @@ export default async function ContactPage() {
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
-          <div className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{contact.form.title}</h2>
-            <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{contact.form.description}</p>
+          <div className="rounded-3xl border border-border bg-card p-10 shadow-xl">
+            <h2 className="text-xl font-semibold text-foreground">{contact.form.title}</h2>
+            <p className="mt-3 text-sm text-muted-foreground">{contact.form.description}</p>
             <form action={submitLead} className="mt-8 space-y-6">
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
-                  <label htmlFor="full_name" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  <label htmlFor="full_name" className="block text-sm font-semibold text-foreground">
                     {contact.form.fields.nameLabel}
                   </label>
                   <input
@@ -76,11 +76,11 @@ export default async function ContactPage() {
                     name="full_name"
                     type="text"
                     autoComplete="name"
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
+                    className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
                 <div>
-                  <label htmlFor="email" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  <label htmlFor="email" className="block text-sm font-semibold text-foreground">
                     {contact.form.fields.emailLabel} <span className="text-rose-400">{contact.form.fields.emailRequiredSuffix}</span>
                   </label>
                   <input
@@ -89,13 +89,13 @@ export default async function ContactPage() {
                     type="email"
                     required
                     autoComplete="email"
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
+                    className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
               </div>
               <div className="grid gap-6 md:grid-cols-2">
                 <div>
-                  <label htmlFor="company" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  <label htmlFor="company" className="block text-sm font-semibold text-foreground">
                     {contact.form.fields.companyLabel}
                   </label>
                   <input
@@ -103,18 +103,18 @@ export default async function ContactPage() {
                     name="company"
                     type="text"
                     autoComplete="organization"
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
+                    className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
                 <div>
-                  <label htmlFor="message" className="block text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  <label htmlFor="message" className="block text-sm font-semibold text-foreground">
                     {contact.form.fields.focusLabel}
                   </label>
                   <textarea
                     id="message"
                     name="message"
                     rows={4}
-                    className="mt-2 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm placeholder:text-slate-500 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:border-white/10 dark:bg-white/10 dark:text-white dark:placeholder:text-slate-400"
+                    className="mt-2 w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
               </div>

--- a/apps/speckit/app/globals.css
+++ b/apps/speckit/app/globals.css
@@ -3,20 +3,13 @@ html {
 }
 
 a:focus-visible {
-  outline: 2px solid #818cf8; /* indigo-400 */
+  outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
 }
 
 .skip-link {
-  position: absolute;
+  @apply absolute left-1/2 -translate-x-1/2 rounded-full bg-foreground px-5 py-3 font-semibold text-background;
   top: -100px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: #6366f1;
-  color: white;
-  padding: 0.75rem 1.25rem;
-  border-radius: 9999px;
-  font-weight: 600;
   transition: top 0.2s ease;
   z-index: 50;
 }

--- a/apps/speckit/app/how-it-works/page.tsx
+++ b/apps/speckit/app/how-it-works/page.tsx
@@ -32,28 +32,28 @@ export default async function HowItWorksPage() {
           {messages.stages.map((stage, index) => (
             <div
               key={stage.name}
-              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+              className="rounded-3xl border border-border bg-card p-8 shadow-lg"
             >
               <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
                 {messages.stageLabel.replace(/\{[^}]+\}/g, String(index + 1))}
               </span>
-              <h2 className="mt-4 text-xl font-semibold text-slate-900 dark:text-white">{stage.name}</h2>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{stage.description}</p>
+              <h2 className="mt-4 text-xl font-semibold text-foreground">{stage.name}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{stage.description}</p>
             </div>
           ))}
         </Container>
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
+        <Container className="rounded-3xl border border-border bg-card p-10 shadow-xl">
           <div className="grid gap-8 lg:grid-cols-3">
             {messages.audiences.map((audience) => (
               <div
                 key={audience.role}
-                className="rounded-2xl border border-slate-200 bg-slate-50 p-6 dark:border-white/10 dark:bg-slate-950/40"
+                className="rounded-2xl border border-border bg-muted p-6"
               >
-                <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{audience.role}</h3>
-                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{audience.value}</p>
+                <h3 className="text-lg font-semibold text-foreground">{audience.role}</h3>
+                <p className="mt-3 text-sm text-muted-foreground">{audience.value}</p>
               </div>
             ))}
           </div>
@@ -61,10 +61,10 @@ export default async function HowItWorksPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100 p-10 shadow-xl dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950">
-          <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{messages.tooling.title}</h2>
-          <p className="mt-4 text-sm text-slate-600 dark:text-slate-300">{messages.tooling.description}</p>
-          <ul className="mt-6 grid gap-4 text-sm text-slate-700 dark:text-slate-200 md:grid-cols-2">
+        <Container className="rounded-3xl border border-border bg-gradient-to-br from-muted via-background to-muted p-10 shadow-xl">
+          <h2 className="text-3xl font-semibold text-foreground">{messages.tooling.title}</h2>
+          <p className="mt-4 text-sm text-muted-foreground">{messages.tooling.description}</p>
+          <ul className="mt-6 grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
             {messages.tooling.items.map((item) => (
               <li key={item}>→ {item}</li>
             ))}

--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -54,10 +54,10 @@ export default async function SpeckitHome() {
           {home.features.map((feature) => (
             <div
               key={feature.title}
-              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+              className="rounded-3xl border border-border bg-card p-8 shadow-lg"
             >
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{feature.title}</h3>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{feature.description}</p>
+              <h3 className="text-xl font-semibold text-foreground">{feature.title}</h3>
+              <p className="mt-3 text-sm text-muted-foreground">{feature.description}</p>
             </div>
           ))}
         </Container>
@@ -66,30 +66,30 @@ export default async function SpeckitHome() {
       <section>
         <Container className="grid gap-12 lg:grid-cols-[3fr,2fr] lg:items-center">
           <div>
-            <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{home.workflows.title}</h2>
-            <p className="mt-4 text-base text-slate-600 dark:text-slate-300">{home.workflows.description}</p>
+            <h2 className="text-3xl font-semibold text-foreground">{home.workflows.title}</h2>
+            <p className="mt-4 text-base text-muted-foreground">{home.workflows.description}</p>
             <div className="mt-6 grid gap-4">
               {home.workflows.items.map((workflow) => (
                 <div
                   key={workflow.name}
-                  className="rounded-2xl border border-slate-200 bg-white p-4 dark:border-white/10 dark:bg-white/5"
+                  className="rounded-2xl border border-border bg-card p-4"
                 >
-                  <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{workflow.name}</h3>
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{workflow.description}</p>
+                  <h3 className="text-lg font-semibold text-foreground">{workflow.name}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{workflow.description}</p>
                 </div>
               ))}
             </div>
           </div>
-          <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 dark:border-white/10 dark:bg-white/5">
+          <div className="relative overflow-hidden rounded-3xl border border-border bg-card p-6">
             <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.15),_transparent_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.25),_transparent_55%)]" aria-hidden="true" />
-            <div className="relative space-y-6 text-sm text-slate-700 dark:text-slate-200">
+            <div className="relative space-y-6 text-sm text-muted-foreground">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
                   {home.guardrails.cardTitle}
                 </p>
-                <div className="mt-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 dark:border-white/10 dark:bg-slate-950/60">
-                  <p className="font-semibold text-slate-900 dark:text-white">{home.guardrails.specTitle}</p>
-                  <ul className="mt-3 space-y-2 text-xs text-slate-600 dark:text-slate-300">
+                <div className="mt-3 rounded-2xl border border-border bg-muted p-4">
+                  <p className="font-semibold text-foreground">{home.guardrails.specTitle}</p>
+                  <ul className="mt-3 space-y-2 text-xs text-muted-foreground">
                     {home.guardrails.checklist.map((item) => (
                       <li key={item}>{item}</li>
                     ))}
@@ -100,11 +100,11 @@ export default async function SpeckitHome() {
                 <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
                   {home.guardrails.evidenceTitle}
                 </p>
-                <div className="mt-3 space-y-2 text-xs text-slate-700 dark:text-slate-200">
+                <div className="mt-3 space-y-2 text-xs text-muted-foreground">
                   {home.guardrails.evidence.map((item) => (
                     <div
                       key={item.label}
-                      className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-3 py-2 dark:border-white/10 dark:bg-white/5"
+                      className="flex items-center justify-between rounded-xl border border-border bg-card px-3 py-2"
                     >
                       <span>{item.label}</span>
                       <span className="text-indigo-600 dark:text-indigo-300">{item.status}</span>
@@ -118,11 +118,11 @@ export default async function SpeckitHome() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-slate-200 bg-white p-10 shadow-xl dark:border-white/10 dark:bg-white/10">
+        <Container className="rounded-3xl border border-border bg-card p-10 shadow-xl">
           <div className="grid gap-10 lg:grid-cols-[2fr,3fr] lg:items-center">
             <div>
-              <h2 className="text-3xl font-semibold text-slate-900 dark:text-white">{home.alignment.title}</h2>
-              <p className="mt-4 text-base text-slate-600 dark:text-slate-200">{home.alignment.description}</p>
+              <h2 className="text-3xl font-semibold text-foreground">{home.alignment.title}</h2>
+              <p className="mt-4 text-base text-muted-foreground">{home.alignment.description}</p>
               <div className="mt-6 flex flex-wrap gap-4">
                 <Button variant="ghost" asChild>
                   <Link href={home.alignment.actions.primaryHref}>{home.alignment.actions.primaryLabel}</Link>
@@ -136,10 +136,10 @@ export default async function SpeckitHome() {
               {home.alignment.cards.map((card) => (
                 <div
                   key={card.title}
-                  className="rounded-2xl border border-slate-200 bg-slate-50 p-6 dark:border-white/10 dark:bg-slate-950/40"
+                  className="rounded-2xl border border-border bg-muted p-6"
                 >
-                  <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{card.title}</h3>
-                  <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{card.description}</p>
+                  <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">{card.description}</p>
                 </div>
               ))}
             </div>
@@ -152,13 +152,13 @@ export default async function SpeckitHome() {
           <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
             {home.integrations.eyebrow}
           </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-slate-600 dark:text-slate-300">
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-muted-foreground">
             {home.integrations.items.map((logo) => (
               <div
                 key={logo}
-                className="flex h-16 w-36 items-center justify-center rounded-2xl border border-slate-200 bg-white dark:border-white/10 dark:bg-white/5"
+                className="flex h-16 w-36 items-center justify-center rounded-2xl border border-border bg-card"
               >
-                <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">{logo}</span>
+                <span className="text-sm font-semibold text-foreground">{logo}</span>
               </div>
             ))}
           </div>

--- a/apps/speckit/app/pricing/page.tsx
+++ b/apps/speckit/app/pricing/page.tsx
@@ -40,13 +40,13 @@ export default async function PricingPage() {
           {pricing.tiers.map((tier) => (
             <div
               key={tier.name}
-              className="flex h-full flex-col rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+              className="flex h-full flex-col rounded-3xl border border-border bg-card p-8 shadow-lg"
             >
               <div className="flex-1">
-                <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{tier.name}</h2>
+                <h2 className="text-2xl font-semibold text-foreground">{tier.name}</h2>
                 <p className="mt-3 text-lg font-semibold text-indigo-600 dark:text-indigo-300">{tier.price}</p>
-                <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{tier.description}</p>
-                <ul className="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate-200">
+                <p className="mt-3 text-sm text-muted-foreground">{tier.description}</p>
+                <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
                   {tier.highlights.map((highlight) => (
                     <li key={highlight}>→ {highlight}</li>
                   ))}

--- a/apps/speckit/app/product/page.tsx
+++ b/apps/speckit/app/product/page.tsx
@@ -40,10 +40,10 @@ export default async function ProductPage() {
           {product.pillars.map((pillar) => (
             <div
               key={pillar.title}
-              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+              className="rounded-3xl border border-border bg-card p-8 shadow-lg"
             >
-              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{pillar.title}</h2>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{pillar.description}</p>
+              <h2 className="text-2xl font-semibold text-foreground">{pillar.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{pillar.description}</p>
             </div>
           ))}
         </Container>
@@ -51,36 +51,36 @@ export default async function ProductPage() {
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-start">
-          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl dark:border-white/10 dark:bg-white/10">
-            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{product.timeline.title}</h2>
-            <ol className="mt-6 space-y-6 text-sm text-slate-600 dark:text-slate-300">
+          <div className="rounded-3xl border border-border bg-card p-8 shadow-xl">
+            <h2 className="text-2xl font-semibold text-foreground">{product.timeline.title}</h2>
+            <ol className="mt-6 space-y-6 text-sm text-muted-foreground">
               {product.timeline.steps.map((step, index) => (
                 <li key={step.name}>
-                  <div className="font-semibold text-slate-900 dark:text-white">{`${index + 1}. ${step.name}`}</div>
+                  <div className="font-semibold text-foreground">{`${index + 1}. ${step.name}`}</div>
                   <p className="mt-1">{step.description}</p>
                 </li>
               ))}
             </ol>
           </div>
           <div className="space-y-8">
-            <div className="rounded-3xl border border-slate-200 bg-white p-8 dark:border-white/10 dark:bg-white/5">
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{product.integrationsCard.title}</h3>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{product.integrationsCard.description}</p>
-              <div className="mt-6 flex flex-wrap gap-3 text-xs text-slate-700 dark:text-slate-200">
+            <div className="rounded-3xl border border-border bg-card p-8">
+              <h3 className="text-xl font-semibold text-foreground">{product.integrationsCard.title}</h3>
+              <p className="mt-3 text-sm text-muted-foreground">{product.integrationsCard.description}</p>
+              <div className="mt-6 flex flex-wrap gap-3 text-xs text-muted-foreground">
                 {product.integrationsCard.items.map((integration) => (
                   <span
                     key={integration}
-                    className="rounded-full border border-slate-200 bg-white px-4 py-2 dark:border-white/10 dark:bg-white/5"
+                    className="rounded-full border border-border bg-card px-4 py-2"
                   >
                     {integration}
                   </span>
                 ))}
               </div>
             </div>
-            <div className="rounded-3xl border border-slate-200 bg-white p-8 dark:border-white/10 dark:bg-white/5">
-              <h3 className="text-xl font-semibold text-slate-900 dark:text-white">{product.supabaseCard.title}</h3>
+            <div className="rounded-3xl border border-border bg-card p-8">
+              <h3 className="text-xl font-semibold text-foreground">{product.supabaseCard.title}</h3>
               {product.supabaseCard.paragraphs.map((paragraph) => (
-                <p key={paragraph} className="mt-3 text-sm text-slate-600 dark:text-slate-300">
+                <p key={paragraph} className="mt-3 text-sm text-muted-foreground">
                   {paragraph}
                 </p>
               ))}

--- a/apps/speckit/app/solutions/ciso/page.tsx
+++ b/apps/speckit/app/solutions/ciso/page.tsx
@@ -28,9 +28,9 @@ export default async function CisoSolutionsPage() {
       />
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">{messages.outcomesTitle}</h2>
-          <ul className="mt-6 space-y-3 text-sm text-slate-300">
+        <Container className="rounded-3xl border border-border/10 bg-card/10 p-10 shadow-xl">
+          <h2 className="text-2xl font-semibold text-foreground">{messages.outcomesTitle}</h2>
+          <ul className="mt-6 space-y-3 text-sm text-muted-foreground">
             {messages.outcomes.map((outcome) => (
               <li key={outcome}>→ {outcome}</li>
             ))}
@@ -39,12 +39,12 @@ export default async function CisoSolutionsPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">{messages.deliverables.title}</h2>
-          <div className="mt-6 grid gap-6 md:grid-cols-2 text-sm text-slate-300">
+        <Container className="rounded-3xl border border-border/10 bg-gradient-to-br from-muted via-background to-muted p-10 shadow-xl">
+          <h2 className="text-2xl font-semibold text-foreground">{messages.deliverables.title}</h2>
+          <div className="mt-6 grid gap-6 md:grid-cols-2 text-sm text-muted-foreground">
             {messages.deliverables.cards.map((card) => (
-              <div key={card.title} className="rounded-2xl border border-white/10 bg-white/5 p-6">
-                <h3 className="text-lg font-semibold text-white">{card.title}</h3>
+              <div key={card.title} className="rounded-2xl border border-border/10 bg-card/5 p-6">
+                <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
                 <p className="mt-2">{card.description}</p>
               </div>
             ))}

--- a/apps/speckit/app/solutions/devsecops/page.tsx
+++ b/apps/speckit/app/solutions/devsecops/page.tsx
@@ -28,9 +28,9 @@ export default async function DevSecOpsSolutionsPage() {
       />
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-white/10 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">{messages.benefitsTitle}</h2>
-          <ul className="mt-6 space-y-3 text-sm text-slate-300">
+        <Container className="rounded-3xl border border-border/10 bg-card/10 p-10 shadow-xl">
+          <h2 className="text-2xl font-semibold text-foreground">{messages.benefitsTitle}</h2>
+          <ul className="mt-6 space-y-3 text-sm text-muted-foreground">
             {messages.benefits.map((benefit) => (
               <li key={benefit}>→ {benefit}</li>
             ))}
@@ -39,12 +39,12 @@ export default async function DevSecOpsSolutionsPage() {
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-white/10 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-10 shadow-xl">
-          <h2 className="text-2xl font-semibold text-white">{messages.capabilities.title}</h2>
-          <div className="mt-6 grid gap-6 md:grid-cols-2 text-sm text-slate-300">
+        <Container className="rounded-3xl border border-border/10 bg-gradient-to-br from-muted via-background to-muted p-10 shadow-xl">
+          <h2 className="text-2xl font-semibold text-foreground">{messages.capabilities.title}</h2>
+          <div className="mt-6 grid gap-6 md:grid-cols-2 text-sm text-muted-foreground">
             {messages.capabilities.cards.map((card) => (
-              <div key={card.title} className="rounded-2xl border border-white/10 bg-white/5 p-6">
-                <h3 className="text-lg font-semibold text-white">{card.title}</h3>
+              <div key={card.title} className="rounded-2xl border border-border/10 bg-card/5 p-6">
+                <h3 className="text-lg font-semibold text-foreground">{card.title}</h3>
                 <p className="mt-2">{card.description}</p>
               </div>
             ))}

--- a/apps/speckit/app/solutions/page.tsx
+++ b/apps/speckit/app/solutions/page.tsx
@@ -34,10 +34,10 @@ export default async function SolutionsOverviewPage() {
             <Link
               key={persona.title}
               href={persona.href}
-              className="group rounded-3xl border border-slate-200 bg-white p-8 text-left shadow-lg transition hover:border-indigo-500 dark:border-white/10 dark:bg-white/10"
+              className="group rounded-3xl border border-border bg-card p-8 text-left shadow-lg transition hover:border-indigo-500"
             >
-              <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">{persona.title}</h2>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{persona.description}</p>
+              <h2 className="text-2xl font-semibold text-foreground">{persona.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{persona.description}</p>
               <span className="mt-6 inline-flex text-sm font-semibold text-indigo-600 transition group-hover:text-indigo-700 dark:text-indigo-300 dark:group-hover:text-indigo-200">
                 {persona.ctaLabel}
               </span>

--- a/apps/speckit/app/template/page.tsx
+++ b/apps/speckit/app/template/page.tsx
@@ -45,10 +45,10 @@ export default async function TemplatePage() {
           {template.steps.map((step) => (
             <div
               key={step.title}
-              className="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg dark:border-white/10 dark:bg-white/10"
+              className="rounded-3xl border border-border bg-card p-8 shadow-lg"
             >
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-white">{step.title}</h2>
-              <p className="mt-3 text-sm text-slate-600 dark:text-slate-300">{step.description}</p>
+              <h2 className="text-xl font-semibold text-foreground">{step.title}</h2>
+              <p className="mt-3 text-sm text-muted-foreground">{step.description}</p>
             </div>
           ))}
         </Container>

--- a/apps/speckit/components/LanguageSwitcher.tsx
+++ b/apps/speckit/components/LanguageSwitcher.tsx
@@ -64,7 +64,7 @@ export function LanguageSwitcher({ className, initialLanguage, label, options }:
         name="language"
         value={language}
         onChange={handleChange}
-        className="appearance-none rounded-full border border-slate-200 bg-white px-3 py-2 pr-8 text-sm font-medium text-slate-700 transition hover:border-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-600"
+        className="appearance-none rounded-full border border-border bg-card px-3 py-2 pr-8 text-sm font-medium text-foreground transition hover:border-ring focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
@@ -75,7 +75,7 @@ export function LanguageSwitcher({ className, initialLanguage, label, options }:
       <svg
         aria-hidden="true"
         focusable="false"
-        className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-slate-500 dark:text-slate-400"
+        className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground"
         viewBox="0 0 12 8"
       >
         <path d="M1.41.59 6 5.17l4.59-4.58L12 2l-6 6-6-6z" fill="currentColor" />

--- a/apps/speckit/components/PageHero.tsx
+++ b/apps/speckit/components/PageHero.tsx
@@ -18,20 +18,20 @@ export function PageHero({
   return (
     <section
       className={clsx(
-        "relative overflow-hidden border-b border-slate-200 bg-gradient-to-br from-slate-50 via-white to-slate-100 py-16 dark:border-white/10 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950",
+        "relative overflow-hidden border-b border-border bg-gradient-to-br from-muted via-background to-muted py-16 text-foreground",
         className
       )}
     >
       <div className="absolute inset-0 opacity-20 dark:opacity-40" aria-hidden="true">
         <div className="h-full w-full bg-[radial-gradient(circle_at_top_right,_rgba(99,102,241,0.2),_transparent_45%)] dark:bg-[radial-gradient(circle_at_top_right,_rgba(99,102,241,0.4),_transparent_45%)]" />
       </div>
-      <Container className="relative max-w-4xl text-slate-900 dark:text-slate-100">
+      <Container className="relative max-w-4xl text-foreground">
         {eyebrow ? (
           <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">{eyebrow}</p>
         ) : null}
         <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">{title}</h1>
         {description ? (
-          <p className="mt-6 text-lg text-slate-600 dark:text-slate-300">{description}</p>
+          <p className="mt-6 text-lg text-muted-foreground">{description}</p>
         ) : null}
         {actions ? <div className="mt-8 flex flex-wrap gap-4">{actions}</div> : null}
       </Container>

--- a/packages/ui/src/Footer.tsx
+++ b/packages/ui/src/Footer.tsx
@@ -17,18 +17,18 @@ export type FooterProps = {
 
 export function Footer({ logo, columns, copyright, bottomSlot, description }: FooterProps) {
   return (
-    <footer className="border-t border-slate-200 bg-white py-12 text-sm text-slate-600 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-300">
+    <footer className="border-t border-border bg-background py-12 text-sm text-muted-foreground">
       <Container>
         <div className="grid gap-8 lg:grid-cols-5">
           <div className="lg:col-span-2">
-            <div className="flex items-center gap-3 text-slate-900 dark:text-white">{logo}</div>
+            <div className="flex items-center gap-3 text-foreground">{logo}</div>
             {description ? (
-              <p className="mt-4 max-w-sm text-sm text-slate-500 dark:text-slate-400">{description}</p>
+              <p className="mt-4 max-w-sm text-sm text-muted-foreground">{description}</p>
             ) : null}
           </div>
           {columns.map((column) => (
             <div key={column.heading}>
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">
+              <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 {column.heading}
               </h3>
               <ul className="mt-3 space-y-2">
@@ -36,13 +36,13 @@ export function Footer({ logo, columns, copyright, bottomSlot, description }: Fo
                   <li key={link.href}>
                     <Link
                       href={link.href}
-                      className="transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:hover:text-white"
+                      className="transition hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                       target={link.external ? "_blank" : undefined}
                       rel={link.external ? "noreferrer" : undefined}
                     >
                       <span className="font-medium">{link.label}</span>
                       {link.description ? (
-                        <span className="block text-xs text-slate-400 dark:text-slate-500">{link.description}</span>
+                        <span className="block text-xs text-muted-foreground">{link.description}</span>
                       ) : null}
                     </Link>
                   </li>
@@ -51,7 +51,7 @@ export function Footer({ logo, columns, copyright, bottomSlot, description }: Fo
             </div>
           ))}
         </div>
-        <div className="mt-10 flex flex-col justify-between gap-4 border-t border-slate-200 pt-6 text-xs text-slate-400 dark:border-slate-800 dark:text-slate-500 sm:flex-row">
+        <div className="mt-10 flex flex-col justify-between gap-4 border-t border-border pt-6 text-xs text-muted-foreground sm:flex-row">
           <p>{copyright}</p>
           {bottomSlot}
         </div>

--- a/packages/ui/src/FooterAirnub.tsx
+++ b/packages/ui/src/FooterAirnub.tsx
@@ -41,7 +41,7 @@ export function FooterAirnub({
       description={description}
       bottomSlot={
         bottomSlot ?? (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-slate-500 dark:text-slate-400">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-muted-foreground">
             {resolvedBottomLinks.map((link, index) => (
               <div key={`${link.href}-${link.label}`} className="flex items-center gap-3">
                 {index > 0 ? <span aria-hidden="true">•</span> : null}

--- a/packages/ui/src/FooterSpeckit.tsx
+++ b/packages/ui/src/FooterSpeckit.tsx
@@ -26,7 +26,7 @@ export function FooterSpeckit({
       columns={columns}
       description={description}
       bottomSlot={
-        <div className="flex items-center gap-3 text-slate-500 dark:text-slate-400">
+        <div className="flex items-center gap-3 text-muted-foreground">
           <Link href={contactHref}>{contactLabel}</Link>
           <span aria-hidden="true">•</span>
           <Link href={pricingHref}>{pricingLabel}</Link>

--- a/packages/ui/src/HeaderAirnub.tsx
+++ b/packages/ui/src/HeaderAirnub.tsx
@@ -57,7 +57,7 @@ export function HeaderAirnub({
         <div className="flex items-center gap-3">
           <Link
             href="https://github.com/airnub"
-            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white lg:inline-flex"
+            className="hidden rounded-full border border-border p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring lg:inline-flex"
             aria-label={githubLabel}
             target="_blank"
             rel="noreferrer"

--- a/packages/ui/src/HeaderSpeckit.tsx
+++ b/packages/ui/src/HeaderSpeckit.tsx
@@ -59,7 +59,7 @@ export function HeaderSpeckit({
         <div className="flex items-center gap-3">
           <Link
             href={githubHref}
-            className="hidden rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white lg:inline-flex"
+            className="hidden rounded-full border border-border p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring lg:inline-flex"
             aria-label={githubLabel}
             target="_blank"
             rel="noreferrer"

--- a/packages/ui/src/components/client/Button.tsx
+++ b/packages/ui/src/components/client/Button.tsx
@@ -15,11 +15,11 @@ type ButtonProps = PropsWithChildren<
 
 const variantStyles: Record<Variant, string> = {
   primary:
-    "bg-sky-600 text-white hover:bg-sky-500 focus-visible:outline-sky-500",
+    "bg-foreground text-background hover:bg-foreground/90 focus-visible:outline-ring",
   secondary:
-    "bg-slate-900 text-white hover:bg-slate-800 focus-visible:outline-slate-800",
+    "bg-muted text-foreground hover:bg-muted/80 focus-visible:outline-ring",
   ghost:
-    "bg-transparent text-slate-900 hover:bg-slate-100 focus-visible:outline-slate-300 dark:text-white dark:hover:bg-white/10",
+    "bg-transparent text-foreground hover:bg-muted focus-visible:outline-ring",
 };
 
 export function Button({ variant = "primary", asChild = false, className, children, ...props }: ButtonProps) {

--- a/packages/ui/src/components/client/FormMessage.tsx
+++ b/packages/ui/src/components/client/FormMessage.tsx
@@ -9,7 +9,7 @@ export type FormMessageProps = {
 };
 
 const variantClasses: Record<NonNullable<FormMessageProps["variant"]>, string> = {
-  info: "bg-slate-100 text-slate-700 dark:bg-slate-900/70 dark:text-slate-300",
+  info: "bg-muted text-muted-foreground",
   success: "bg-emerald-100 text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-100",
   error: "bg-rose-100 text-rose-800 dark:bg-rose-500/10 dark:text-rose-100",
 };

--- a/packages/ui/src/components/client/Header.tsx
+++ b/packages/ui/src/components/client/Header.tsx
@@ -30,10 +30,10 @@ export function Header({ logo, navItems, rightSlot, homeHref = "/", homeAriaLabe
   const [open, setOpen] = useState(false);
 
   return (
-    <header className={clsx("sticky top-0 z-40 border-b border-slate-200/60 bg-white/90 backdrop-blur dark:border-slate-700/60 dark:bg-slate-900/90", className)}>
+    <header className={clsx("sticky top-0 z-40 border-b border-border/60 bg-background/90 backdrop-blur", className)}>
       <Container className="flex items-center justify-between py-4">
         <div className="flex items-center gap-8">
-          <Link href={homeHref} aria-label={homeAriaLabel} className="flex items-center gap-2 text-slate-900 dark:text-white">
+          <Link href={homeHref} aria-label={homeAriaLabel} className="flex items-center gap-2 text-foreground">
             {logo}
           </Link>
           <nav className="hidden lg:flex" aria-label="Primary">
@@ -42,7 +42,7 @@ export function Header({ logo, navItems, rightSlot, homeHref = "/", homeAriaLabe
                 <li key={item.href}>
                   <Link
                     href={item.href}
-                    className="rounded-full px-3 py-2 text-slate-700 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-slate-200 dark:hover:bg-white/10"
+                    className="rounded-full px-3 py-2 text-muted-foreground transition hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                     target={item.external ? "_blank" : undefined}
                     rel={item.external ? "noreferrer" : undefined}
                   >
@@ -58,14 +58,14 @@ export function Header({ logo, navItems, rightSlot, homeHref = "/", homeAriaLabe
           {cta ? (
             <Link
               href={cta.href}
-              className="hidden rounded-full bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 lg:inline-flex"
+              className="hidden rounded-full bg-foreground px-4 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring lg:inline-flex"
             >
               {cta.label}
             </Link>
           ) : null}
           <button
             type="button"
-            className="inline-flex items-center justify-center rounded-full p-2 text-slate-700 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-slate-200 dark:hover:bg-white/10 lg:hidden"
+            className="inline-flex items-center justify-center rounded-full p-2 text-muted-foreground transition hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring lg:hidden"
             onClick={() => setOpen((value) => !value)}
             aria-expanded={open}
             aria-controls="mobile-nav"
@@ -81,21 +81,21 @@ export function Header({ logo, navItems, rightSlot, homeHref = "/", homeAriaLabe
           </button>
         </div>
       </Container>
-      <div id="mobile-nav" hidden={!open} className="border-t border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900 lg:hidden">
+      <div id="mobile-nav" hidden={!open} className="border-t border-border bg-background lg:hidden">
         <Container>
           <ul className="flex flex-col gap-1 py-4 text-base font-medium">
             {navItems.map((item) => (
               <li key={item.href}>
                 <Link
                   href={item.href}
-                  className="block rounded-xl px-3 py-2 text-slate-700 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-slate-200 dark:hover:bg-white/10"
+                  className="block rounded-xl px-3 py-2 text-muted-foreground transition hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                   target={item.external ? "_blank" : undefined}
                   rel={item.external ? "noreferrer" : undefined}
                   onClick={() => setOpen(false)}
                 >
                   <span className="block text-base font-semibold">{item.label}</span>
                   {item.description ? (
-                    <span className="block text-sm text-slate-500 dark:text-slate-400">{item.description}</span>
+                    <span className="block text-sm text-muted-foreground">{item.description}</span>
                   ) : null}
                 </Link>
               </li>
@@ -104,7 +104,7 @@ export function Header({ logo, navItems, rightSlot, homeHref = "/", homeAriaLabe
               <li>
                 <Link
                   href={cta.href}
-                  className="mt-2 inline-flex w-full justify-center rounded-full bg-sky-600 px-4 py-2 text-center text-sm font-semibold text-white transition hover:bg-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500"
+                  className="mt-2 inline-flex w-full justify-center rounded-full bg-foreground px-4 py-2 text-center text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
                 >
                   {cta.label}
                 </Link>

--- a/packages/ui/src/components/client/ThemeToggle.tsx
+++ b/packages/ui/src/components/client/ThemeToggle.tsx
@@ -86,7 +86,7 @@ export function ThemeToggle({ label = "Toggle theme", className, ...props }: The
     <button
       type="button"
       className={clsx(
-        "inline-flex items-center justify-center rounded-full border border-slate-200 p-2 text-slate-600 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:border-slate-700 dark:text-slate-200 dark:hover:text-white",
+        "inline-flex items-center justify-center rounded-full border border-border p-2 text-muted-foreground transition hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
         className
       )}
       onClick={handleToggle}

--- a/packages/ui/src/components/client/ToastProvider.tsx
+++ b/packages/ui/src/components/client/ToastProvider.tsx
@@ -30,7 +30,7 @@ function toastClassNames(variant: ToastVariant) {
     case "error":
       return "border-rose-200 bg-rose-50 text-rose-900 dark:border-rose-500/40 dark:bg-rose-500/10 dark:text-rose-50";
     default:
-      return "border-slate-200 bg-white text-slate-900 dark:border-slate-700 dark:bg-slate-900/90 dark:text-slate-50";
+      return "border-border bg-card text-card-foreground";
   }
 }
 
@@ -68,7 +68,7 @@ export function ToastProvider({ children }: PropsWithChildren) {
             </div>
             {action ? <div className="shrink-0">{action}</div> : null}
             <Toast.Close
-              className="absolute right-3 top-3 text-slate-400 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-500 dark:text-slate-300 dark:hover:text-white"
+              className="absolute right-3 top-3 text-muted-foreground transition hover:text-foreground focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
               aria-label={closeLabel ?? "Dismiss notification"}
             >
               ×


### PR DESCRIPTION
## Summary
- remove hard-coded neutral color utilities from app and shared UI components
- rely on design tokens and Card helpers for surface, border, and text colors
- normalize admin forms and layout styling to use theme-aware tokens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da6853144c8324957207028b8436f7