### PR TITLE
feat: add shared tailwind preset

### DIFF
--- a/apps/airnub/tailwind.config.ts
+++ b/apps/airnub/tailwind.config.ts
@@ -1,7 +1,11 @@
 import type { Config } from "tailwindcss";
-import preset from "@airnub/tailwind-config/tailwind.config";
+import preset from "@airnub/ui/tailwind-preset";
 
 export default {
+  content: [
+    "./app/**/*.{ts,tsx,mdx}",
+    "./components/**/*.{ts,tsx,mdx}",
+    "../../packages/ui/**/*.{ts,tsx}",
+  ],
   presets: [preset],
 } satisfies Config;
-

--- a/apps/speckit/tailwind.config.ts
+++ b/apps/speckit/tailwind.config.ts
@@ -1,7 +1,11 @@
 import type { Config } from "tailwindcss";
-import preset from "@airnub/tailwind-config/tailwind.config";
+import preset from "@airnub/ui/tailwind-preset";
 
 export default {
+  content: [
+    "./app/**/*.{ts,tsx,mdx}",
+    "./components/**/*.{ts,tsx,mdx}",
+    "../../packages/ui/**/*.{ts,tsx}",
+  ],
   presets: [preset],
-} satisfies Partial<Config>;
-
+} satisfies Config;

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -1,29 +1,3 @@
-import type { Config } from "tailwindcss";
-import tailwindTypography from "@tailwindcss/typography";
+import preset from "@airnub/ui/tailwind-preset";
 
-export default {
-  darkMode: "class",
-  content: [
-    "../../packages/ui/**/*.{ts,tsx}",
-    "../../apps/**/*.{ts,tsx}",
-  ],
-  theme: {
-    container: { center: true, padding: "2rem" },
-    extend: {
-      colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
-        card: "hsl(var(--card))",
-        "card-foreground": "hsl(var(--card-foreground))",
-        muted: "hsl(var(--muted))",
-        "muted-foreground": "hsl(var(--muted-foreground))",
-      },
-      borderRadius: { xl: "1rem", "2xl": "1.25rem" },
-      boxShadow: { card: "0 1px 2px rgba(0,0,0,.05)" },
-    },
-  },
-  plugins: [tailwindTypography],
-} satisfies Config;
+export default preset;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,7 +12,8 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toast": "^1.2.4",
     "clsx": "^2.1.1",
-    "next-themes": "^0.4.4"
+    "next-themes": "^0.4.4",
+    "tailwindcss-animate": "^1.0.7"
   },
   "peerDependencies": {
     "next": ">=15.0.0",
@@ -26,6 +27,11 @@
       "import": "./src/index.ts",
       "default": "./src/index.ts"
     },
-    "./styles.css": "./styles.css"
+    "./styles.css": "./styles.css",
+    "./tailwind-preset": {
+      "types": "./tailwind-preset.ts",
+      "import": "./tailwind-preset.ts",
+      "default": "./tailwind-preset.ts"
+    }
   }
 }

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -4,28 +4,47 @@
 
 :root {
   --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
+  --foreground: 240 10% 3.9%;
   --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
-  --muted: 210 40% 96%;
-  --muted-foreground: 215 16% 35%;
-  --border: 214 32% 91%;
-  --input: 214 32% 91%;
+  --card-foreground: 240 10% 3.9%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
   --ring: 222.2 84% 4.9%;
+  --radius: 0.75rem;
 }
 
 .dark {
-  --background: 222.2 47% 11%;
-  --foreground: 210 40% 98%;
-  --card: 222.2 47% 13%;
-  --card-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20% 70%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --ring: 212 100% 50%;
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 85.7% 97.3%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 210 40% 98%;
+  --radius: 0.75rem;
 }
 
-html, body {
+html,
+body {
   @apply bg-background text-foreground antialiased;
 }

--- a/packages/ui/tailwind-preset.ts
+++ b/packages/ui/tailwind-preset.ts
@@ -1,0 +1,55 @@
+import type { Config } from "tailwindcss";
+import tailwindTypography from "@tailwindcss/typography";
+import tailwindAnimate from "tailwindcss-animate";
+
+const config = {
+  darkMode: "class",
+  theme: {
+    container: { center: true, padding: "2rem" },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+        xl: "calc(var(--radius) + 4px)",
+      },
+      boxShadow: {
+        card: "0 1px 2px rgba(0,0,0,.05)",
+      },
+    },
+  },
+  plugins: [tailwindTypography, tailwindAnimate],
+} satisfies Config;
+
+export default config;


### PR DESCRIPTION
## Summary
- add a Tailwind preset in `@airnub/ui` with expanded design tokens and the animate plugin
- update both apps to consume the shared preset and point their content globs at local sources
- expose the preset entry point from the UI package and sync design tokens in `styles.css`

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da7c31015c8324bdc93913dbc52b51