### PR TITLE
refactor: align card primitives across apps

### DIFF
--- a/apps/airnub/app/[locale]/company/page.tsx
+++ b/apps/airnub/app/[locale]/company/page.tsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
-import { Container } from "@airnub/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+} from "@airnub/ui";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { LocaleLink } from "../../../components/LocaleLink";
@@ -76,69 +83,80 @@ export default async function CompanyPage({
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {values.map((value) => (
-            <div
-              key={value.id}
-              className="rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40"
-            >
-              <h2 className="text-xl font-semibold text-foreground">{value.name}</h2>
-              <p className="mt-3 text-sm text-muted-foreground">{value.description}</p>
-            </div>
+            <Card key={value.id} className="bg-card/60 shadow-lg shadow-slate-950/40">
+              <CardHeader>
+                <CardTitle className="text-xl">{value.name}</CardTitle>
+                <CardDescription>{value.description}</CardDescription>
+              </CardHeader>
+            </Card>
           ))}
         </Container>
       </section>
 
       <section id="careers">
-        <Container className="rounded-3xl border border-border bg-card/70 p-10 text-foreground shadow-lg shadow-slate-950/40">
-          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
-            <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-foreground">{careers.title}</h2>
-              <p className="mt-4 text-sm text-muted-foreground">{careers.description}</p>
-            </div>
-            <div>
-              <Link
-                href={careers.ctaHref}
-                className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-              >
-                {careers.ctaLabel}
-              </Link>
-            </div>
-          </div>
+        <Container>
+          <Card className="bg-card/70 text-foreground shadow-lg shadow-slate-950/40">
+            <CardContent className="grid gap-8 pt-5 lg:grid-cols-2 lg:items-center">
+              <CardHeader className="p-0">
+                <CardTitle className="text-3xl tracking-tight">{careers.title}</CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  {careers.description}
+                </CardDescription>
+              </CardHeader>
+              <div>
+                <Link
+                  href={careers.ctaHref}
+                  className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  {careers.ctaLabel}
+                </Link>
+              </div>
+            </CardContent>
+          </Card>
         </Container>
       </section>
 
       <section id="press">
         <Container className="grid gap-6 md:grid-cols-2">
           {press.cards.map((card) => (
-            <div key={card.id} className="rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40">
-              <h2 className="text-xl font-semibold text-foreground">{card.title}</h2>
-              <p className="mt-3 text-sm text-muted-foreground">{card.description}</p>
-              <Link
-                href={card.ctaHref}
-                className="mt-4 inline-flex text-sm font-semibold text-sky-400"
-                target={card.external ? "_blank" : undefined}
-                rel={card.external ? "noreferrer" : undefined}
-              >
-                {card.ctaLabel} →
-              </Link>
-            </div>
+            <Card key={card.id} className="bg-card/60 shadow-lg shadow-slate-950/40">
+              <CardHeader>
+                <CardTitle className="text-xl">{card.title}</CardTitle>
+                <CardDescription>{card.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <Link
+                  href={card.ctaHref}
+                  className="inline-flex text-sm font-semibold text-sky-400"
+                  target={card.external ? "_blank" : undefined}
+                  rel={card.external ? "noreferrer" : undefined}
+                >
+                  {card.ctaLabel} →
+                </Link>
+              </CardContent>
+            </Card>
           ))}
         </Container>
       </section>
 
       <section id="legal">
-        <Container className="rounded-3xl border border-border bg-card/60 p-10 shadow-lg shadow-slate-950/40">
-          <h2 className="text-2xl font-semibold text-foreground">{legal.title}</h2>
-          <div className="mt-6 grid gap-6 md:grid-cols-2">
-            {legal.items.map((item) => (
-              <div key={item.id}>
-                <h3 className="text-lg font-semibold text-foreground">{item.title}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{item.description}</p>
-                <LocaleLink href={item.ctaHref} className="mt-3 inline-flex text-sm font-semibold text-sky-400">
-                  {item.ctaLabel} →
-                </LocaleLink>
-              </div>
-            ))}
-          </div>
+        <Container>
+          <Card className="bg-card/60 shadow-lg shadow-slate-950/40">
+            <CardHeader>
+              <CardTitle className="text-2xl">{legal.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="grid gap-6 pt-0 md:grid-cols-2">
+              {legal.items.map((item) => (
+                <div key={item.id} className="space-y-3">
+                  <CardTitle className="text-lg">{item.title}</CardTitle>
+                  <CardDescription>{item.description}</CardDescription>
+                  <LocaleLink href={item.ctaHref} className="inline-flex text-sm font-semibold text-sky-400">
+                    {item.ctaLabel} →
+                  </LocaleLink>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
         </Container>
       </section>
     </div>

--- a/apps/airnub/app/[locale]/contact/page.tsx
+++ b/apps/airnub/app/[locale]/contact/page.tsx
@@ -43,13 +43,13 @@ function ContactShortcuts({
 }: ContactShortcutsProps) {
   return (
     <div className="space-y-6">
-      <Card className="rounded-3xl bg-card/80 shadow-lg shadow-slate-900/5 backdrop-blur">
-        <CardHeader className="p-6">
+      <Card className="bg-card/80 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <CardHeader>
           <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             {emailTitle}
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-2 p-6 pt-0 text-sm text-muted-foreground">
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
           <p>
             {emailSales}: <a className="text-sky-600 underline-offset-4 hover:underline dark:text-sky-400" href="mailto:hello@airnub.io">hello@airnub.io</a>
           </p>
@@ -58,13 +58,13 @@ function ContactShortcuts({
           </p>
         </CardContent>
       </Card>
-      <Card className="rounded-3xl bg-card/80 shadow-lg shadow-slate-900/5 backdrop-blur">
-        <CardHeader className="p-6">
+      <Card className="bg-card/80 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <CardHeader>
           <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             {officeTitle}
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-3 p-6 pt-0 text-sm text-muted-foreground">
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
           <p>{officeDescription}</p>
           <a
             href="https://cal.com/airnub/office-hours"
@@ -118,14 +118,14 @@ export default async function ContactPage({ params }: { params: Promise<{ locale
 
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
-          <Card className="rounded-3xl bg-card/80 shadow-lg shadow-slate-900/5 backdrop-blur">
-            <CardHeader className="p-10">
+          <Card className="bg-card/80 shadow-lg shadow-slate-900/5 backdrop-blur">
+            <CardHeader className="gap-4">
               <CardTitle className="text-xl text-foreground">{t("form.title")}</CardTitle>
               <CardDescription className="text-sm text-muted-foreground">
                 {t("form.description")}
               </CardDescription>
             </CardHeader>
-            <CardContent className="p-10 pt-0">
+            <CardContent>
               <ContactForm
                 action={submitLead}
                 initialState={initialLeadFormState}

--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -148,7 +148,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
         <Container className="grid gap-10 lg:grid-cols-3">
           {highlightItems.map((item) => (
             <Card key={item.id}>
-              <CardHeader className="p-8">
+              <CardHeader>
                 <CardTitle className="text-xl">{item.title}</CardTitle>
                 <CardDescription>{item.description}</CardDescription>
               </CardHeader>
@@ -165,7 +165,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           <div className="mt-8 flex flex-wrap items-center justify-center gap-8">
             {customerItems.map((customer) => (
               <Card key={customer.id} aria-label={customer.name} className="h-16 w-40">
-                <CardContent className="flex h-full items-center justify-center p-4">
+                <CardContent className="flex h-full items-center justify-center pt-5">
                   <Image src={customer.logo} alt={customer.name} width={120} height={40} className="object-contain" />
                 </CardContent>
               </Card>
@@ -177,15 +177,17 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
       <section>
         <Container>
           <Card>
-            <CardContent className="grid gap-12 p-10 sm:p-12 lg:grid-cols-2 lg:items-center">
-              <div>
-                <CardTitle className="text-3xl tracking-tight text-card-foreground sm:text-4xl">
-                  {speckit.title}
-                </CardTitle>
-                <CardDescription className="mt-4 text-base text-muted-foreground">
-                  {speckit.description}
-                </CardDescription>
-                <div className="mt-6 flex flex-wrap gap-4">
+            <CardContent className="grid gap-12 pt-5 lg:grid-cols-2 lg:items-start">
+              <div className="space-y-6">
+                <CardHeader className="gap-4 p-0">
+                  <CardTitle className="text-3xl tracking-tight text-card-foreground sm:text-4xl">
+                    {speckit.title}
+                  </CardTitle>
+                  <CardDescription className="text-base text-muted-foreground">
+                    {speckit.description}
+                  </CardDescription>
+                </CardHeader>
+                <div className="flex flex-wrap gap-4">
                   <Button asChild>
                     <Link href="https://speckit.airnub.io" target="_blank" rel="noreferrer">
                       {speckit.primaryCta}
@@ -197,10 +199,10 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
                 </div>
               </div>
               <Card>
-                <CardHeader className="p-8">
+                <CardHeader>
                   <CardTitle className="text-lg">{speckit.outcomesTitle}</CardTitle>
                 </CardHeader>
-                <CardContent className="p-8 pt-0">
+                <CardContent>
                   <ul className="space-y-3 text-sm text-muted-foreground">
                     {speckit.outcomes.map((outcome, index) => {
                       const accentClass = outcomeAccentClasses[

--- a/apps/airnub/app/[locale]/products/page.tsx
+++ b/apps/airnub/app/[locale]/products/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { Button, Container } from "@airnub/ui";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Container } from "@airnub/ui";
 import { getTranslations } from "next-intl/server";
 import { PageHero } from "../../../components/PageHero";
 import { JsonLd } from "../../../components/JsonLd";
@@ -82,22 +82,22 @@ export default async function ProductsPage({
               : {};
 
             return (
-              <article
+              <Card
                 key={offering.id}
-                className="flex h-full flex-col justify-between rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40"
+                className="flex h-full flex-col justify-between bg-card/60 shadow-lg shadow-slate-950/40"
               >
-                <div>
+                <CardHeader className="gap-4">
                   <div className="flex items-center gap-3">
-                    <h2 className="text-2xl font-semibold text-foreground">{offering.name}</h2>
+                    <CardTitle className="text-2xl">{offering.name}</CardTitle>
                     {offering.badge ? (
                       <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-sky-300">
                         {offering.badge}
                       </span>
                     ) : null}
                   </div>
-                  <p className="mt-3 text-sm text-muted-foreground">{offering.description}</p>
-                </div>
-                <div className="mt-8">
+                  <CardDescription>{offering.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="mt-auto">
                   <LinkComponent
                     href={offering.href}
                     className="text-sm font-semibold text-sky-400 transition hover:text-sky-300"
@@ -105,8 +105,8 @@ export default async function ProductsPage({
                   >
                     {offeringCta} →
                   </LinkComponent>
-                </div>
-              </article>
+                </CardContent>
+              </Card>
             );
           })}
         </Container>
@@ -115,26 +115,26 @@ export default async function ProductsPage({
       <section>
         <Container className="grid gap-8 lg:grid-cols-2">
           {insights.map((insight) => (
-            <div key={insight.id} className="rounded-3xl border border-border bg-card/70 p-8 shadow-lg shadow-slate-950/40">
-              <h3 className="text-xl font-semibold text-foreground">{insight.title}</h3>
-              {insight.description ? (
-                <p className="mt-3 text-sm text-muted-foreground">{insight.description}</p>
-              ) : null}
-              {insight.bullets ? (
-                <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-                  {insight.bullets.map((bullet) => (
-                    <li key={bullet}>→ {bullet}</li>
-                  ))}
-                </ul>
-              ) : null}
-              {insight.paragraphs ? (
-                <div className="mt-3 space-y-3 text-sm text-muted-foreground">
-                  {insight.paragraphs.map((paragraph) => (
-                    <p key={paragraph}>{paragraph}</p>
-                  ))}
-                </div>
-              ) : null}
-            </div>
+            <Card key={insight.id} className="bg-card/70 shadow-lg shadow-slate-950/40">
+              <CardHeader className="gap-3">
+                <CardTitle className="text-xl">{insight.title}</CardTitle>
+                {insight.description ? <CardDescription>{insight.description}</CardDescription> : null}
+              </CardHeader>
+              {(insight.bullets || insight.paragraphs) && (
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  {insight.bullets ? (
+                    <ul className="space-y-2">
+                      {insight.bullets.map((bullet) => (
+                        <li key={bullet}>→ {bullet}</li>
+                      ))}
+                    </ul>
+                  ) : null}
+                  {insight.paragraphs
+                    ? insight.paragraphs.map((paragraph) => <p key={paragraph}>{paragraph}</p>)
+                    : null}
+                </CardContent>
+              )}
+            </Card>
           ))}
         </Container>
       </section>

--- a/apps/airnub/app/[locale]/resources/page.tsx
+++ b/apps/airnub/app/[locale]/resources/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Container } from "@airnub/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+} from "@airnub/ui";
 import { getTranslations } from "next-intl/server";
 import { LocaleLink } from "../../../components/LocaleLink";
 import { PageHero } from "../../../components/PageHero";
@@ -67,14 +74,16 @@ export default async function ResourcesPage({
           <h2 className="text-xl font-semibold text-foreground">{resources("guidesHeading")}</h2>
           <div className="mt-6 grid gap-6 md:grid-cols-3">
             {guides.map((guide) => (
-              <Link
-                key={guide.id}
-                href={guide.href}
-                className="group rounded-3xl border border-border bg-card/60 p-6 shadow-lg shadow-slate-950/40 transition hover:-translate-y-1 hover:border-ring/40"
-              >
-                <p className="text-sm font-semibold text-sky-400 group-hover:text-sky-300">{guideLabel}</p>
-                <h3 className="mt-2 text-lg font-semibold text-foreground">{guide.title}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{guide.description}</p>
+              <Link key={guide.id} href={guide.href} className="group block">
+                <Card className="bg-card/60 transition hover:-translate-y-1 hover:border-ring/40 hover:shadow-xl shadow-lg shadow-slate-950/40">
+                  <CardHeader className="gap-3">
+                    <p className="text-sm font-semibold text-sky-400 transition group-hover:text-sky-300">
+                      {guideLabel}
+                    </p>
+                    <CardTitle className="text-lg">{guide.title}</CardTitle>
+                    <CardDescription>{guide.description}</CardDescription>
+                  </CardHeader>
+                </Card>
               </Link>
             ))}
           </div>
@@ -86,14 +95,18 @@ export default async function ResourcesPage({
           <h2 className="text-xl font-semibold text-foreground">{resources("updatesHeading")}</h2>
           <div className="mt-6 space-y-4">
             {updates.map((update) => (
-              <Link
-                key={update.id}
-                href={update.href}
-                className="flex flex-col rounded-3xl border border-border bg-card/60 p-6 shadow-lg shadow-slate-950/40 transition hover:border-ring/40"
-              >
-                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{update.date}</span>
-                <h3 className="mt-2 text-lg font-semibold text-foreground">{update.title}</h3>
-                <span className="mt-2 text-sm font-semibold text-sky-400">{updateCta} →</span>
+              <Link key={update.id} href={update.href} className="block">
+                <Card className="bg-card/60 transition hover:border-ring/40 hover:shadow-xl shadow-lg shadow-slate-950/40">
+                  <CardHeader className="gap-2">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {update.date}
+                    </span>
+                    <CardTitle className="text-lg">{update.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <span className="text-sm font-semibold text-sky-400">{updateCta} →</span>
+                  </CardContent>
+                </Card>
               </Link>
             ))}
           </div>
@@ -101,21 +114,23 @@ export default async function ResourcesPage({
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-border bg-card/70 p-10 shadow-lg shadow-slate-950/40">
-          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
-            <div>
-              <h2 className="text-2xl font-semibold text-foreground">{officeHours.title}</h2>
-              <p className="mt-3 text-sm text-muted-foreground">{officeHours.description}</p>
-            </div>
-            <div>
-              <LocaleLink
-                href={officeHours.ctaHref}
-                className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-              >
-                {officeHours.ctaLabel}
-              </LocaleLink>
-            </div>
-          </div>
+        <Container>
+          <Card className="bg-card/70 shadow-lg shadow-slate-950/40">
+            <CardContent className="grid gap-8 pt-5 lg:grid-cols-2 lg:items-center">
+              <CardHeader className="p-0">
+                <CardTitle className="text-2xl">{officeHours.title}</CardTitle>
+                <CardDescription>{officeHours.description}</CardDescription>
+              </CardHeader>
+              <div>
+                <LocaleLink
+                  href={officeHours.ctaHref}
+                  className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  {officeHours.ctaLabel}
+                </LocaleLink>
+              </div>
+            </CardContent>
+          </Card>
         </Container>
       </section>
     </div>

--- a/apps/airnub/app/[locale]/services/page.tsx
+++ b/apps/airnub/app/[locale]/services/page.tsx
@@ -1,5 +1,13 @@
 import type { Metadata } from "next";
-import { Button, Container } from "@airnub/ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+} from "@airnub/ui";
 import { getTranslations } from "next-intl/server";
 import { LocaleLink } from "../../../components/LocaleLink";
 import { PageHero } from "../../../components/PageHero";
@@ -66,41 +74,47 @@ export default async function ServicesPage({
       <section>
         <Container className="space-y-10">
           {engagements.map((engagement) => (
-            <article
+            <Card
               key={engagement.id}
               id={engagement.id}
-              className="rounded-3xl border border-border bg-card/60 p-10 shadow-lg shadow-slate-950/40"
+              className="bg-card/60 shadow-lg shadow-slate-950/40"
             >
-              <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-                <div className="lg:max-w-2xl">
-                  <h2 className="text-2xl font-semibold text-foreground">{engagement.title}</h2>
-                  <p className="mt-3 text-sm text-muted-foreground">{engagement.description}</p>
-                </div>
-                <div className="lg:min-w-[16rem]">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{deliverablesLabel}</p>
-                  <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+              <CardContent className="flex flex-col gap-6 pt-5 lg:flex-row lg:items-start lg:justify-between">
+                <CardHeader className="p-0 lg:max-w-2xl">
+                  <CardTitle className="text-2xl">{engagement.title}</CardTitle>
+                  <CardDescription>{engagement.description}</CardDescription>
+                </CardHeader>
+                <div className="space-y-3 text-sm text-muted-foreground lg:min-w-[16rem]">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    {deliverablesLabel}
+                  </p>
+                  <ul className="space-y-2">
                     {engagement.deliverables.map((item) => (
                       <li key={item}>→ {item}</li>
                     ))}
                   </ul>
                 </div>
-              </div>
-            </article>
+              </CardContent>
+            </Card>
           ))}
         </Container>
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-border bg-card/80 p-10 text-foreground shadow-xl shadow-slate-950/40">
-          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
-            <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-foreground">{outcomes.title}</h2>
-              <p className="mt-4 text-sm text-muted-foreground">{outcomes.description}</p>
-            </div>
-            <div className="rounded-2xl border border-border/10 bg-card/5 p-6 text-sm text-foreground">
-              <p>{outcomes.note}</p>
-            </div>
-          </div>
+        <Container>
+          <Card className="bg-card/80 text-foreground shadow-xl shadow-slate-950/40">
+            <CardContent className="grid gap-8 pt-5 lg:grid-cols-2 lg:items-center">
+              <CardHeader className="p-0">
+                <CardTitle className="text-3xl tracking-tight">{outcomes.title}</CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  {outcomes.description}
+                </CardDescription>
+              </CardHeader>
+              <div className="rounded-2xl border border-border/10 bg-card/5 p-6 text-sm text-foreground">
+                <p>{outcomes.note}</p>
+              </div>
+            </CardContent>
+          </Card>
         </Container>
       </section>
     </div>

--- a/apps/airnub/app/[locale]/solutions/page.tsx
+++ b/apps/airnub/app/[locale]/solutions/page.tsx
@@ -1,5 +1,12 @@
 import type { Metadata } from "next";
-import { Container } from "@airnub/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+} from "@airnub/ui";
 import { getTranslations } from "next-intl/server";
 import { PageHero } from "../../../components/PageHero";
 import { assertLocale } from "../../../i18n/routing";
@@ -55,38 +62,43 @@ export default async function SolutionsPage({
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {sectors.map((sector) => (
-            <div
-              key={sector.id}
-              className="rounded-3xl border border-border bg-card/60 p-8 shadow-lg shadow-slate-950/40"
-            >
-              <h2 className="text-xl font-semibold text-foreground">{sector.name}</h2>
-              <p className="mt-3 text-sm text-muted-foreground">{sector.summary}</p>
-              <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-                {sector.bullets.map((bullet) => (
-                  <li key={bullet}>→ {bullet}</li>
-                ))}
-              </ul>
-            </div>
+            <Card key={sector.id} className="bg-card/60 shadow-lg shadow-slate-950/40">
+              <CardHeader>
+                <CardTitle className="text-xl">{sector.name}</CardTitle>
+                <CardDescription>{sector.summary}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-muted-foreground">
+                <ul className="space-y-2">
+                  {sector.bullets.map((bullet) => (
+                    <li key={bullet}>→ {bullet}</li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
           ))}
         </Container>
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-border bg-gradient-to-br from-muted via-background to-muted p-10 text-foreground shadow-xl shadow-slate-950/40">
-          <div className="grid gap-10 lg:grid-cols-2 lg:items-center">
-            <div>
-              <h2 className="text-3xl font-semibold tracking-tight text-foreground">{partner.title}</h2>
-              <p className="mt-4 text-sm text-muted-foreground">{partner.description}</p>
-            </div>
-            <div className="rounded-2xl border border-border/10 bg-card/5 p-6 text-sm text-muted-foreground">
-              <p className="font-semibold text-foreground">{partner.expectationsTitle}</p>
-              <ul className="mt-3 space-y-2">
-                {partner.expectations.map((item) => (
-                  <li key={item}>→ {item}</li>
-                ))}
-              </ul>
-            </div>
-          </div>
+        <Container>
+          <Card className="bg-gradient-to-br from-muted via-background to-muted text-foreground shadow-xl shadow-slate-950/40">
+            <CardContent className="grid gap-10 lg:grid-cols-2 lg:items-center">
+              <CardHeader className="p-0">
+                <CardTitle className="text-3xl tracking-tight">{partner.title}</CardTitle>
+                <CardDescription className="text-sm text-muted-foreground">
+                  {partner.description}
+                </CardDescription>
+              </CardHeader>
+              <div className="rounded-2xl border border-border/10 bg-card/5 p-6 text-sm text-muted-foreground">
+                <p className="font-semibold text-foreground">{partner.expectationsTitle}</p>
+                <ul className="mt-3 space-y-2">
+                  {partner.expectations.map((item) => (
+                    <li key={item}>→ {item}</li>
+                  ))}
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
         </Container>
       </section>
     </div>

--- a/apps/airnub/app/[locale]/trust/page.tsx
+++ b/apps/airnub/app/[locale]/trust/page.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Container } from "@airnub/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+} from "@airnub/ui";
 import { getTranslations } from "next-intl/server";
 import { LocaleLink } from "../../../components/LocaleLink";
 import { PageHero } from "../../../components/PageHero";
@@ -58,37 +65,39 @@ export default async function TrustPage({
       <section>
         <Container className="grid gap-8 lg:grid-cols-3">
           {highlights.map((item) => (
-            <Link
-              key={item.id}
-              href={item.href}
-              className="rounded-3xl border border-border bg-card/60 p-8 text-left shadow-lg shadow-slate-950/40 transition hover:border-ring/40"
-              target="_blank"
-              rel="noreferrer"
-            >
-              <h2 className="text-xl font-semibold text-foreground">{item.title}</h2>
-              <p className="mt-3 text-sm text-muted-foreground">{item.description}</p>
-              <span className="mt-4 inline-flex text-sm font-semibold text-sky-400">{highlightCta} →</span>
+            <Link key={item.id} href={item.href} className="block" target="_blank" rel="noreferrer">
+              <Card className="bg-card/60 text-left transition hover:border-ring/40 hover:shadow-xl shadow-lg shadow-slate-950/40">
+                <CardHeader>
+                  <CardTitle className="text-xl">{item.title}</CardTitle>
+                  <CardDescription>{item.description}</CardDescription>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <span className="inline-flex text-sm font-semibold text-sky-400">{highlightCta} →</span>
+                </CardContent>
+              </Card>
             </Link>
           ))}
         </Container>
       </section>
 
       <section>
-        <Container className="rounded-3xl border border-border bg-card/70 p-10 shadow-lg shadow-slate-950/40">
-          <div className="grid gap-8 lg:grid-cols-2 lg:items-center">
-            <div>
-              <h2 className="text-2xl font-semibold text-foreground">{request.title}</h2>
-              <p className="mt-3 text-sm text-muted-foreground">{request.description}</p>
-            </div>
-            <div>
-              <LocaleLink
-                href={request.ctaHref}
-                className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
-              >
-                {request.ctaLabel}
-              </LocaleLink>
-            </div>
-          </div>
+        <Container>
+          <Card className="bg-card/70 shadow-lg shadow-slate-950/40">
+            <CardContent className="grid gap-8 pt-5 lg:grid-cols-2 lg:items-center">
+              <CardHeader className="p-0">
+                <CardTitle className="text-2xl">{request.title}</CardTitle>
+                <CardDescription>{request.description}</CardDescription>
+              </CardHeader>
+              <div>
+                <LocaleLink
+                  href={request.ctaHref}
+                  className="inline-flex items-center rounded-full bg-foreground px-5 py-2 text-sm font-semibold text-background transition hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                >
+                  {request.ctaLabel}
+                </LocaleLink>
+              </div>
+            </CardContent>
+          </Card>
         </Container>
       </section>
     </div>

--- a/apps/speckit/app/contact/page.tsx
+++ b/apps/speckit/app/contact/page.tsx
@@ -24,23 +24,23 @@ function ContactShortcuts({ shortcuts }: ContactShortcutsProps) {
   return (
     <div className="space-y-6">
       <Card>
-        <CardHeader className="p-6">
+        <CardHeader>
           <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             {shortcuts.emailHeading}
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-2 p-6 pt-0 text-sm text-muted-foreground">
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
           <p>{shortcuts.productQuestions}</p>
           <p>{shortcuts.security}</p>
         </CardContent>
       </Card>
       <Card>
-        <CardHeader className="p-6">
+        <CardHeader>
           <CardTitle className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
             {shortcuts.docsHeading}
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-3 p-6 pt-0 text-sm text-muted-foreground">
+        <CardContent className="space-y-3 text-sm text-muted-foreground">
           <p>{shortcuts.docsDescription}</p>
           <Button
             asChild
@@ -72,11 +72,11 @@ export default async function ContactPage() {
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,1fr]">
           <Card>
-            <CardHeader className="p-10">
+            <CardHeader className="gap-4">
               <CardTitle className="text-xl text-foreground">{contact.form.title}</CardTitle>
               <CardDescription className="text-sm text-muted-foreground">{contact.form.description}</CardDescription>
             </CardHeader>
-            <CardContent className="p-10 pt-0">
+            <CardContent>
               <form action={submitLead} className="space-y-6">
                 <div className="grid gap-6 md:grid-cols-2">
                   <div>

--- a/apps/speckit/app/how-it-works/page.tsx
+++ b/apps/speckit/app/how-it-works/page.tsx
@@ -31,7 +31,7 @@ export default async function HowItWorksPage() {
         <Container className="grid gap-8 lg:grid-cols-3">
           {messages.stages.map((stage, index) => (
             <Card key={stage.name}>
-              <CardHeader className="p-8">
+              <CardHeader className="gap-3">
                 <span className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
                   {messages.stageLabel.replace(/\{[^}]+\}/g, String(index + 1))}
                 </span>
@@ -46,7 +46,7 @@ export default async function HowItWorksPage() {
       <section>
         <Container>
           <Card>
-            <CardContent className="grid gap-8 p-10 lg:grid-cols-3">
+            <CardContent className="grid gap-8 pt-5 lg:grid-cols-3">
               {messages.audiences.map((audience) => (
                 <Card key={audience.role} className="bg-muted shadow-none">
                   <CardHeader>
@@ -63,13 +63,13 @@ export default async function HowItWorksPage() {
       <section>
         <Container>
           <Card className="bg-gradient-to-br from-muted via-background to-muted">
-            <CardHeader className="p-10">
+            <CardHeader className="gap-4">
               <CardTitle className="text-3xl text-foreground">{messages.tooling.title}</CardTitle>
               <CardDescription className="text-sm text-muted-foreground">
                 {messages.tooling.description}
               </CardDescription>
             </CardHeader>
-            <CardContent className="p-10 pt-0">
+            <CardContent>
               <ul className="grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
                 {messages.tooling.items.map((item) => (
                   <li key={item}>→ {item}</li>

--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -61,7 +61,7 @@ export default async function SpeckitHome() {
         <Container className="grid gap-8 lg:grid-cols-3">
           {home.features.map((feature) => (
             <Card key={feature.title} className="h-full">
-              <CardHeader className="h-full p-8">
+              <CardHeader className="h-full">
                 <CardTitle className="text-xl">{feature.title}</CardTitle>
                 <CardDescription>{feature.description}</CardDescription>
               </CardHeader>
@@ -91,16 +91,16 @@ export default async function SpeckitHome() {
               className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.15),_transparent_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.25),_transparent_55%)]"
               aria-hidden="true"
             />
-            <CardContent className="relative space-y-6 text-sm text-muted-foreground">
+            <CardContent className="relative space-y-6 pt-5 text-sm text-muted-foreground">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-wide text-indigo-600 dark:text-indigo-300">
                   {home.guardrails.cardTitle}
                 </p>
                 <Card className="mt-3 border-none bg-muted shadow-none">
-                  <CardHeader className="p-4">
+                  <CardHeader className="gap-3">
                     <CardTitle className="text-base">{home.guardrails.specTitle}</CardTitle>
                   </CardHeader>
-                  <CardContent className="p-4 pt-0 text-xs text-muted-foreground">
+                  <CardContent className="text-xs text-muted-foreground">
                     <ul className="space-y-2">
                       {home.guardrails.checklist.map((item) => (
                         <li key={item}>{item}</li>
@@ -116,7 +116,7 @@ export default async function SpeckitHome() {
                 <div className="mt-3 space-y-2 text-xs text-muted-foreground">
                   {home.guardrails.evidence.map((item) => (
                     <Card key={item.label} className="shadow-none">
-                      <CardContent className="flex items-center justify-between px-3 py-2">
+                      <CardContent className="flex items-center justify-between pt-5">
                         <span>{item.label}</span>
                         <span className="text-indigo-600 dark:text-indigo-300">{item.status}</span>
                       </CardContent>
@@ -132,13 +132,15 @@ export default async function SpeckitHome() {
       <section>
         <Container>
           <Card>
-            <CardContent className="grid gap-10 p-10 lg:grid-cols-[2fr,3fr] lg:items-center">
-              <div>
-                <CardTitle className="text-3xl text-foreground">{home.alignment.title}</CardTitle>
-                <CardDescription className="mt-4 text-base text-muted-foreground">
-                  {home.alignment.description}
-                </CardDescription>
-                <div className="mt-6 flex flex-wrap gap-4">
+            <CardContent className="grid gap-10 pt-5 lg:grid-cols-[2fr,3fr] lg:items-center">
+              <div className="space-y-6">
+                <CardHeader className="p-0">
+                  <CardTitle className="text-3xl text-foreground">{home.alignment.title}</CardTitle>
+                  <CardDescription className="text-base text-muted-foreground">
+                    {home.alignment.description}
+                  </CardDescription>
+                </CardHeader>
+                <div className="flex flex-wrap gap-4">
                   <Button variant="ghost" asChild>
                     <Link href={home.alignment.actions.primaryHref}>{home.alignment.actions.primaryLabel}</Link>
                   </Button>
@@ -170,7 +172,7 @@ export default async function SpeckitHome() {
           <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-muted-foreground">
             {home.integrations.items.map((logo) => (
               <Card key={logo} className="h-16 w-36 shadow-none">
-                <CardContent className="flex h-full items-center justify-center text-sm font-semibold text-foreground">
+                <CardContent className="flex h-full items-center justify-center pt-5 text-sm font-semibold text-foreground">
                   {logo}
                 </CardContent>
               </Card>

--- a/apps/speckit/app/pricing/page.tsx
+++ b/apps/speckit/app/pricing/page.tsx
@@ -39,12 +39,12 @@ export default async function PricingPage() {
         <Container className="grid gap-8 lg:grid-cols-3">
           {pricing.tiers.map((tier) => (
             <Card key={tier.name} className="flex h-full flex-col">
-              <CardHeader className="p-8 pb-0">
+              <CardHeader className="gap-3">
                 <CardTitle className="text-2xl">{tier.name}</CardTitle>
                 <p className="text-lg font-semibold text-indigo-600 dark:text-indigo-300">{tier.price}</p>
                 <CardDescription>{tier.description}</CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-1 flex-col justify-between gap-6 p-8 pt-4 text-sm text-muted-foreground">
+              <CardContent className="flex flex-1 flex-col justify-between gap-6 text-sm text-muted-foreground">
                 <ul className="space-y-2">
                   {tier.highlights.map((highlight) => (
                     <li key={highlight}>→ {highlight}</li>

--- a/apps/speckit/app/product/page.tsx
+++ b/apps/speckit/app/product/page.tsx
@@ -47,7 +47,7 @@ export default async function ProductPage() {
         <Container className="grid gap-8 lg:grid-cols-3">
           {product.pillars.map((pillar) => (
             <Card key={pillar.title} className="h-full">
-              <CardHeader className="h-full p-8">
+              <CardHeader className="h-full">
                 <CardTitle className="text-2xl">{pillar.title}</CardTitle>
                 <CardDescription>{pillar.description}</CardDescription>
               </CardHeader>
@@ -59,10 +59,10 @@ export default async function ProductPage() {
       <section>
         <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-start">
           <Card>
-            <CardHeader className="p-8">
+            <CardHeader>
               <CardTitle className="text-2xl">{product.timeline.title}</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-6 p-8 pt-0 text-sm text-muted-foreground">
+            <CardContent className="space-y-6 text-sm text-muted-foreground">
               {product.timeline.steps.map((step, index) => (
                 <div key={step.name}>
                   <div className="font-semibold text-foreground">{`${index + 1}. ${step.name}`}</div>
@@ -73,11 +73,11 @@ export default async function ProductPage() {
           </Card>
           <div className="space-y-8">
             <Card>
-              <CardHeader className="p-8">
+              <CardHeader>
                 <CardTitle className="text-xl">{product.integrationsCard.title}</CardTitle>
                 <CardDescription>{product.integrationsCard.description}</CardDescription>
               </CardHeader>
-              <CardContent className="flex flex-wrap gap-3 p-8 pt-0 text-xs text-muted-foreground">
+              <CardContent className="flex flex-wrap gap-3 text-xs text-muted-foreground">
                 {product.integrationsCard.items.map((integration) => (
                   <Card key={integration} className="rounded-full shadow-none">
                     <CardContent className="px-4 py-2 text-xs text-muted-foreground">
@@ -88,10 +88,10 @@ export default async function ProductPage() {
               </CardContent>
             </Card>
             <Card>
-              <CardHeader className="p-8">
+              <CardHeader>
                 <CardTitle className="text-xl">{product.supabaseCard.title}</CardTitle>
               </CardHeader>
-              <CardContent className="space-y-3 p-8 pt-0 text-sm text-muted-foreground">
+              <CardContent className="space-y-3 text-sm text-muted-foreground">
                 {product.supabaseCard.paragraphs.map((paragraph) => (
                   <p key={paragraph}>{paragraph}</p>
                 ))}

--- a/apps/speckit/app/solutions/ciso/page.tsx
+++ b/apps/speckit/app/solutions/ciso/page.tsx
@@ -30,10 +30,10 @@ export default async function CisoSolutionsPage() {
       <section>
         <Container>
           <Card className="bg-card/10">
-            <CardHeader className="p-10">
+            <CardHeader>
               <CardTitle className="text-2xl">{messages.outcomesTitle}</CardTitle>
             </CardHeader>
-            <CardContent className="p-10 pt-0 text-sm text-muted-foreground">
+            <CardContent className="text-sm text-muted-foreground">
               <ul className="space-y-3">
                 {messages.outcomes.map((outcome) => (
                   <li key={outcome}>→ {outcome}</li>
@@ -47,10 +47,10 @@ export default async function CisoSolutionsPage() {
       <section>
         <Container>
           <Card className="bg-gradient-to-br from-muted via-background to-muted">
-            <CardHeader className="p-10">
+            <CardHeader>
               <CardTitle className="text-2xl">{messages.deliverables.title}</CardTitle>
             </CardHeader>
-            <CardContent className="grid gap-6 p-10 pt-0 text-sm text-muted-foreground md:grid-cols-2">
+            <CardContent className="grid gap-6 text-sm text-muted-foreground md:grid-cols-2">
               {messages.deliverables.cards.map((card) => (
                 <Card key={card.title} className="bg-card/5 shadow-none">
                   <CardHeader>

--- a/apps/speckit/app/solutions/devsecops/page.tsx
+++ b/apps/speckit/app/solutions/devsecops/page.tsx
@@ -30,10 +30,10 @@ export default async function DevSecOpsSolutionsPage() {
       <section>
         <Container>
           <Card className="bg-card/10">
-            <CardHeader className="p-10">
+            <CardHeader>
               <CardTitle className="text-2xl">{messages.benefitsTitle}</CardTitle>
             </CardHeader>
-            <CardContent className="p-10 pt-0 text-sm text-muted-foreground">
+            <CardContent className="text-sm text-muted-foreground">
               <ul className="space-y-3">
                 {messages.benefits.map((benefit) => (
                   <li key={benefit}>→ {benefit}</li>
@@ -47,10 +47,10 @@ export default async function DevSecOpsSolutionsPage() {
       <section>
         <Container>
           <Card className="bg-gradient-to-br from-muted via-background to-muted">
-            <CardHeader className="p-10">
+            <CardHeader>
               <CardTitle className="text-2xl">{messages.capabilities.title}</CardTitle>
             </CardHeader>
-            <CardContent className="grid gap-6 p-10 pt-0 text-sm text-muted-foreground md:grid-cols-2">
+            <CardContent className="grid gap-6 text-sm text-muted-foreground md:grid-cols-2">
               {messages.capabilities.cards.map((card) => (
                 <Card key={card.title} className="bg-card/5 shadow-none">
                   <CardHeader>

--- a/apps/speckit/app/solutions/page.tsx
+++ b/apps/speckit/app/solutions/page.tsx
@@ -33,11 +33,11 @@ export default async function SolutionsOverviewPage() {
           {solutions.personas.map((persona) => (
             <Link key={persona.title} href={persona.href} className="group block text-left">
               <Card className="h-full transition hover:border-ring">
-                <CardHeader className="p-6">
+                <CardHeader>
                   <CardTitle className="text-2xl">{persona.title}</CardTitle>
                   <CardDescription>{persona.description}</CardDescription>
                 </CardHeader>
-                <CardContent className="p-6 pt-0">
+                <CardContent>
                   <span className="inline-flex text-sm font-semibold text-indigo-600 transition group-hover:text-indigo-700 dark:text-indigo-300 dark:group-hover:text-indigo-200">
                     {persona.ctaLabel}
                   </span>

--- a/apps/speckit/app/template/page.tsx
+++ b/apps/speckit/app/template/page.tsx
@@ -45,7 +45,7 @@ export default async function TemplatePage() {
         <Container className="grid gap-6 md:grid-cols-2">
           {template.steps.map((step) => (
             <Card key={step.title}>
-              <CardHeader className="p-8">
+              <CardHeader>
                 <CardTitle className="text-xl">{step.title}</CardTitle>
                 <CardDescription>{step.description}</CardDescription>
               </CardHeader>


### PR DESCRIPTION
## Summary
- refactor Airnub marketing pages to compose the shared Card primitives for highlights, callouts, and support content
- update Speckit product, pricing, and marketing pages to reuse the new Card subcomponents for consistent typography and spacing

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68da935acf648324add5cac36eada3de