### PR TITLE
feat: make customer logos inherit text color

### DIFF
--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
 import {
   Button,
@@ -9,6 +8,9 @@ import {
   CardHeader,
   CardTitle,
   Container,
+  CloudyardLogo,
+  ForgeLabsLogo,
+  NorthbeamLogo,
 } from "@airnub/ui";
 import { serverFetch } from "@airnub/seo";
 import { getTranslations } from "next-intl/server";
@@ -39,11 +41,15 @@ const highlightIds = [
   "platformAccelerators",
 ] as const;
 
-const customerLogos = [
-  { id: "forgeLabs", logo: "/logos/forge.svg" },
-  { id: "cloudyard", logo: "/logos/cloudyard.svg" },
-  { id: "northbeam", logo: "/logos/northbeam.svg" },
-] as const;
+const customerIds = ["forgeLabs", "cloudyard", "northbeam"] as const;
+
+type CustomerId = (typeof customerIds)[number];
+
+const customerLogos: Record<CustomerId, typeof CloudyardLogo> = {
+  forgeLabs: ForgeLabsLogo,
+  cloudyard: CloudyardLogo,
+  northbeam: NorthbeamLogo,
+};
 
 const speckitOutcomeIds = [
   "governedSpecLoop",
@@ -62,7 +68,7 @@ const serviceCardIds = [
 
 const airnubHomeContent = {
   highlights: highlightIds,
-  customers: customerLogos,
+  customers: customerIds,
 } as const;
 
 const airnubHomeContentUrl = `data:application/json,${encodeURIComponent(JSON.stringify(airnubHomeContent))}`;
@@ -95,9 +101,10 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
     description: t(`highlights.${key}.description`),
   }));
 
-  const customerItems = customers.map((customer) => ({
-    ...customer,
-    name: t(`customers.items.${customer.id}`),
+  const customerItems = customers.map((customerId) => ({
+    id: customerId,
+    name: t(`customers.items.${customerId}`),
+    Logo: customerLogos[customerId],
   }));
 
   const speckit = {
@@ -163,10 +170,11 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
             {t("customers.eyebrow")}
           </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-8">
-            {customerItems.map((customer) => (
-              <Card key={customer.id} aria-label={customer.name} className="h-16 w-40">
-                <CardContent className="flex h-full items-center justify-center p-4">
-                  <Image src={customer.logo} alt={customer.name} width={120} height={40} className="object-contain" />
+            {customerItems.map(({ id, name, Logo }) => (
+              <Card key={id} aria-label={name} className="group h-16 w-40 transition-colors">
+                <CardContent className="flex h-full items-center justify-center p-4 text-muted-foreground transition-colors group-hover:text-foreground">
+                  <Logo className="h-6 w-auto" aria-hidden="true" focusable="false" />
+                  <span className="sr-only">{name}</span>
                 </CardContent>
               </Card>
             ))}

--- a/apps/airnub/public/logos/cloudyard.svg
+++ b/apps/airnub/public/logos/cloudyard.svg
@@ -1,4 +1,14 @@
-<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg">
-  <rect width="120" height="40" rx="8" fill="#0ea5e9" opacity="0.1" />
-  <text x="60" y="24" font-family="sans-serif" font-size="16" text-anchor="middle" fill="#0369a1">Cloudyard</text>
+<svg width="120" height="40" viewBox="0 0 120 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text
+    x="60"
+    y="20"
+    dominant-baseline="middle"
+    text-anchor="middle"
+    font-size="16"
+    font-weight="600"
+    font-family="Inter, system-ui, sans-serif"
+    fill="currentColor"
+  >
+    Cloudyard
+  </text>
 </svg>

--- a/apps/airnub/public/logos/forge.svg
+++ b/apps/airnub/public/logos/forge.svg
@@ -1,4 +1,14 @@
-<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg">
-  <rect width="120" height="40" rx="8" fill="#0f172a" opacity="0.08" />
-  <text x="60" y="24" font-family="sans-serif" font-size="16" text-anchor="middle" fill="#0f172a">Forge Labs</text>
+<svg width="120" height="40" viewBox="0 0 120 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text
+    x="60"
+    y="20"
+    dominant-baseline="middle"
+    text-anchor="middle"
+    font-size="16"
+    font-weight="600"
+    font-family="Inter, system-ui, sans-serif"
+    fill="currentColor"
+  >
+    Forge Labs
+  </text>
 </svg>

--- a/apps/airnub/public/logos/northbeam.svg
+++ b/apps/airnub/public/logos/northbeam.svg
@@ -1,4 +1,14 @@
-<svg width="120" height="40" viewBox="0 0 120 40" xmlns="http://www.w3.org/2000/svg">
-  <rect width="120" height="40" rx="8" fill="#312e81" opacity="0.12" />
-  <text x="60" y="24" font-family="sans-serif" font-size="16" text-anchor="middle" fill="#1e1b4b">Northbeam</text>
+<svg width="120" height="40" viewBox="0 0 120 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text
+    x="60"
+    y="20"
+    dominant-baseline="middle"
+    text-anchor="middle"
+    font-size="16"
+    font-weight="600"
+    font-family="Inter, system-ui, sans-serif"
+    fill="currentColor"
+  >
+    Northbeam
+  </text>
 </svg>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,4 +10,5 @@ export * from "./components/client/ToastProvider";
 export * from "./components/card";
 export * from "../providers/theme";
 export * from "./icons/GithubIcon";
+export * from "./logos";
 export * from "./fonts";

--- a/packages/ui/src/logos/CloudyardLogo.tsx
+++ b/packages/ui/src/logos/CloudyardLogo.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+export function CloudyardLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 120 40"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fontSize="16"
+        fontWeight="600"
+        fontFamily="var(--font-sans, 'Inter', 'system-ui', sans-serif)"
+        fill="currentColor"
+      >
+        Cloudyard
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/logos/ForgeLabsLogo.tsx
+++ b/packages/ui/src/logos/ForgeLabsLogo.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+export function ForgeLabsLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 120 40"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fontSize="16"
+        fontWeight="600"
+        fontFamily="var(--font-sans, 'Inter', 'system-ui', sans-serif)"
+        fill="currentColor"
+      >
+        Forge Labs
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/logos/NorthbeamLogo.tsx
+++ b/packages/ui/src/logos/NorthbeamLogo.tsx
@@ -1,0 +1,26 @@
+import type { SVGProps } from "react";
+
+export function NorthbeamLogo(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 120 40"
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fontSize="16"
+        fontWeight="600"
+        fontFamily="var(--font-sans, 'Inter', 'system-ui', sans-serif)"
+        fill="currentColor"
+      >
+        Northbeam
+      </text>
+    </svg>
+  );
+}

--- a/packages/ui/src/logos/index.ts
+++ b/packages/ui/src/logos/index.ts
@@ -1,0 +1,3 @@
+export * from "./CloudyardLogo";
+export * from "./ForgeLabsLogo";
+export * from "./NorthbeamLogo";


### PR DESCRIPTION
## Summary
- convert customer logo SVGs to rely on currentColor so they inherit surrounding themes
- add reusable logo components to @airnub/ui and use them in the customer card grid
- restyle customer cards with Card primitives and semantic text utilities for hover states

## Testing
- pnpm --filter @airnub/airnub-app lint

------
https://chatgpt.com/codex/tasks/task_e_68da936d77ec8324896db974608d6ba3