### PR TITLE
feat: centralize tailwind content globs and brand tokens

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -1,4 +1,3 @@
-import "@airnub/ui/styles.css";
 import "../globals.css";
 import { BrandProvider, FooterAirnub, HeaderAirnub, ThemeProvider, ToastProvider, type FooterColumn } from "@airnub/ui";
 import type { Metadata } from "next";

--- a/apps/airnub/app/globals.css
+++ b/apps/airnub/app/globals.css
@@ -1,3 +1,6 @@
+@import "@airnub/ui/styles/tokens.css";
+@import "@airnub/ui/styles.css";
+
 html {
   scroll-behavior: smooth;
 }

--- a/apps/airnub/tailwind.config.ts
+++ b/apps/airnub/tailwind.config.ts
@@ -2,10 +2,5 @@ import type { Config } from "tailwindcss";
 import preset from "@airnub/ui/tailwind-preset";
 
 export default {
-  content: [
-    "./app/**/*.{ts,tsx,mdx}",
-    "./components/**/*.{ts,tsx,mdx}",
-    "../../packages/ui/**/*.{ts,tsx}",
-  ],
   presets: [preset],
 } satisfies Config;

--- a/apps/speckit/app/globals.css
+++ b/apps/speckit/app/globals.css
@@ -1,3 +1,6 @@
+@import "@airnub/ui/styles/tokens.css";
+@import "@airnub/ui/styles.css";
+
 html {
   scroll-behavior: smooth;
 }

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { clsx } from "clsx";
-import "@airnub/ui/styles.css";
 import "./globals.css";
 import {
   BrandProvider,

--- a/apps/speckit/tailwind.config.ts
+++ b/apps/speckit/tailwind.config.ts
@@ -2,10 +2,5 @@ import type { Config } from "tailwindcss";
 import preset from "@airnub/ui/tailwind-preset";
 
 export default {
-  content: [
-    "./app/**/*.{ts,tsx,mdx}",
-    "./components/**/*.{ts,tsx,mdx}",
-    "../../packages/ui/**/*.{ts,tsx}",
-  ],
   presets: [preset],
 } satisfies Config;

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
       "default": "./src/index.ts"
     },
     "./styles.css": "./styles.css",
+    "./styles/tokens.css": "./styles/tokens.css",
     "./tailwind-preset": {
       "types": "./tailwind-preset.ts",
       "import": "./tailwind-preset.ts",

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -3,20 +3,20 @@
 @tailwind utilities;
 
 :root {
-  --background: 0 0% 100%;
-  --foreground: 240 10% 3.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 240 10% 3.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 240 10% 3.9%;
+  --background: var(--brand-background);
+  --foreground: var(--brand-foreground);
+  --card: var(--brand-background);
+  --card-foreground: var(--brand-foreground);
+  --popover: var(--brand-background);
+  --popover-foreground: var(--brand-foreground);
   --muted: 240 4.8% 95.9%;
   --muted-foreground: 240 3.8% 46.1%;
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
+  --primary: var(--brand-primary);
+  --primary-foreground: var(--brand-primary-foreground);
   --secondary: 240 4.8% 95.9%;
   --secondary-foreground: 240 5.9% 10%;
-  --accent: 240 4.8% 95.9%;
-  --accent-foreground: 240 5.9% 10%;
+  --accent: var(--brand-accent);
+  --accent-foreground: var(--brand-accent-foreground);
   --destructive: 0 84.2% 60.2%;
   --destructive-foreground: 0 0% 98%;
   --success: 142 76% 36%;
@@ -28,20 +28,20 @@
 }
 
 .dark {
-  --background: 240 10% 3.9%;
-  --foreground: 0 0% 98%;
-  --card: 240 10% 3.9%;
-  --card-foreground: 0 0% 98%;
-  --popover: 240 10% 3.9%;
-  --popover-foreground: 0 0% 98%;
+  --background: var(--brand-background);
+  --foreground: var(--brand-foreground);
+  --card: var(--brand-background);
+  --card-foreground: var(--brand-foreground);
+  --popover: var(--brand-background);
+  --popover-foreground: var(--brand-foreground);
   --muted: 240 3.7% 15.9%;
   --muted-foreground: 240 5% 64.9%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
+  --primary: var(--brand-primary);
+  --primary-foreground: var(--brand-primary-foreground);
   --secondary: 240 3.7% 15.9%;
   --secondary-foreground: 0 0% 98%;
-  --accent: 240 3.7% 15.9%;
-  --accent-foreground: 0 0% 98%;
+  --accent: var(--brand-accent);
+  --accent-foreground: var(--brand-accent-foreground);
   --destructive: 0 62.8% 30.6%;
   --destructive-foreground: 0 85.7% 97.3%;
   --success: 142 76% 52%;

--- a/packages/ui/styles/tokens.css
+++ b/packages/ui/styles/tokens.css
@@ -1,0 +1,17 @@
+:root {
+  --brand-background: 0 0% 100%;
+  --brand-foreground: 240 10% 3.9%;
+  --brand-primary: 222.2 47.4% 11.2%;
+  --brand-primary-foreground: 210 40% 98%;
+  --brand-accent: 240 4.8% 95.9%;
+  --brand-accent-foreground: 240 5.9% 10%;
+}
+
+.dark {
+  --brand-background: 240 10% 3.9%;
+  --brand-foreground: 0 0% 98%;
+  --brand-primary: 210 40% 98%;
+  --brand-primary-foreground: 222.2 47.4% 11.2%;
+  --brand-accent: 240 3.7% 15.9%;
+  --brand-accent-foreground: 0 0% 98%;
+}

--- a/packages/ui/tailwind-preset.ts
+++ b/packages/ui/tailwind-preset.ts
@@ -3,7 +3,13 @@ import tailwindTypography from "@tailwindcss/typography";
 import tailwindAnimate from "tailwindcss-animate";
 
 const preset = {
-  darkMode: "class",
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx,js,jsx,md,mdx}",
+    "./components/**/*.{ts,tsx,js,jsx,md,mdx}",
+    "./src/**/*.{ts,tsx,js,jsx,md,mdx}",
+    "../../packages/**/*.{ts,tsx,js,jsx,md,mdx}",
+  ],
   theme: {
     container: { center: true, padding: "2rem" },
     extend: {
@@ -11,8 +17,8 @@ const preset = {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        background: "hsl(var(--brand-background))",
+        foreground: "hsl(var(--brand-foreground))",
         card: {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
@@ -26,16 +32,16 @@ const preset = {
           foreground: "hsl(var(--muted-foreground))",
         },
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: "hsl(var(--brand-primary))",
+          foreground: "hsl(var(--brand-primary-foreground))",
         },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
         },
         accent: {
-          DEFAULT: "hsl(var(--accent))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: "hsl(var(--brand-accent))",
+          foreground: "hsl(var(--brand-accent-foreground))",
         },
         destructive: {
           DEFAULT: "hsl(var(--destructive))",


### PR DESCRIPTION
## Summary
- add shared content globs and brand color variables to the shared Tailwind preset
- provide a tokens.css stylesheet for light and dark brand colors and consume it from each app
- simplify both app Tailwind configs to rely on the preset content globs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dad16096f48324b8057222759442ed