### PR TITLE
Add ESLint restriction for app header/footer imports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,5 +13,26 @@ module.exports = {
         message: "Use semantic tokens instead of Tailwind dark: utilities.",
       },
     ],
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            name: "@/components/header",
+            message: "Use the shared @airnub/ui exports.",
+          },
+          {
+            name: "@/components/footer",
+            message: "Use the shared @airnub/ui exports.",
+          },
+        ],
+        patterns: [
+          {
+            group: ["@/components/header/*", "@/components/footer/*"],
+            message: "Use the shared @airnub/ui exports.",
+          },
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
## Summary
- add a no-restricted-imports rule to steer header/footer imports toward @airnub/ui

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dad3b788208324b0ca801684cbfc56