### PR TITLE
Create shared brand metadata utility

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -11,7 +11,7 @@ import { assertLocale, locales, type Locale } from "../../i18n/routing";
 import { MaintenanceGate } from "./maintenance/MaintenanceGate";
 import { isMaintenanceModeEnabled } from "../../lib/runtime-flags";
 import { LocaleSwitcher } from "../../components/LocaleSwitcher";
-import { brand as airnubBrand } from "@airnub/brand";
+import { brand as airnubBrand, buildBrandMetadata } from "@airnub/brand";
 
 const jsonLd = buildAirnubOrganizationJsonLd();
 
@@ -39,46 +39,39 @@ export async function generateMetadata({
   const locale = assertLocale(localeParam);
   const t = await getTranslations({ locale, namespace: "layout.metadata" });
   const ogPath = airnubBrand.og ?? "/brand/og.png";
-  const ogUrl = new URL(ogPath, AIRNUB_BASE_URL);
-  const favicon = airnubBrand.favicon ?? airnubBrand.logos.mark ?? "/brand/favicon.svg";
+  const ogUrl = new URL(ogPath, AIRNUB_BASE_URL).toString();
 
-  return {
-    metadataBase: new URL(AIRNUB_BASE_URL),
-    title: {
-      default: t("titleDefault"),
-      template: t("titleTemplate"),
+  return buildBrandMetadata({
+    brand: airnubBrand,
+    baseUrl: AIRNUB_BASE_URL,
+    overrides: {
+      title: {
+        default: t("titleDefault"),
+        template: t("titleTemplate"),
+      },
+      description: t("description"),
+      openGraph: {
+        description: t("ogDescription"),
+        locale: localeToOg[locale],
+        images: [
+          {
+            url: ogUrl,
+            width: 1200,
+            height: 630,
+            alt: t("titleDefault"),
+          },
+        ],
+      },
+      twitter: {
+        description: t("twitterDescription"),
+        images: [ogUrl],
+      },
+      alternates: {
+        canonical: `/${locale}`,
+        languages: Object.fromEntries(locales.map((code) => [code, `/${code}`])),
+      },
     },
-    description: t("description"),
-    openGraph: {
-      title: airnubBrand.name,
-      description: t("ogDescription"),
-      url: AIRNUB_BASE_URL,
-      siteName: airnubBrand.name,
-      locale: localeToOg[locale],
-      type: "website",
-      images: [
-        {
-          url: ogUrl,
-          width: 1200,
-          height: 630,
-          alt: t("titleDefault"),
-        },
-      ],
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: airnubBrand.name,
-      description: t("twitterDescription"),
-      images: [ogUrl.toString()],
-    },
-    icons: {
-      icon: favicon,
-    },
-    alternates: {
-      canonical: `/${locale}`,
-      languages: Object.fromEntries(locales.map((code) => [code, `/${code}`])),
-    },
-  };
+  });
 }
 
 export default async function LocaleLayout({

--- a/apps/airnub/lib/jsonld.ts
+++ b/apps/airnub/lib/jsonld.ts
@@ -1,28 +1,27 @@
-import { brand as airnubBrand } from "@airnub/brand";
-import { itemListJsonLd, organizationJsonLd } from "@airnub/seo";
+import { brand as airnubBrand, buildBrandOrganizationJsonLd } from "@airnub/brand";
+import { itemListJsonLd } from "@airnub/seo";
 import { AIRNUB_BASE_URL } from "./routes";
 
 export function buildAirnubOrganizationJsonLd() {
-  const logoPath =
-    airnubBrand.logos.mark ?? airnubBrand.logos.light ?? airnubBrand.favicon ?? "/brand/logo.svg";
-  const logoUrl = new URL(logoPath, AIRNUB_BASE_URL).toString();
-  return organizationJsonLd({
-    name: "Airnub",
-    url: AIRNUB_BASE_URL,
-    logo: logoUrl,
-    sameAs: [
-      "https://github.com/airnub",
-      "https://www.linkedin.com/company/airnub",
-    ],
-    contactPoint: [
-      {
-        telephone: "+1-415-555-0163",
-        contactType: "sales",
-        email: "hello@airnub.io",
-        areaServed: "Global",
-        availableLanguage: ["English"],
-      },
-    ],
+  const sameAs = [airnubBrand.social.github, airnubBrand.social.linkedin].filter(
+    (url): url is string => Boolean(url)
+  );
+
+  return buildBrandOrganizationJsonLd({
+    brand: airnubBrand,
+    baseUrl: AIRNUB_BASE_URL,
+    overrides: {
+      sameAs,
+      contactPoint: [
+        {
+          telephone: "+1-415-555-0163",
+          contactType: "sales",
+          email: "hello@airnub.io",
+          areaServed: "Global",
+          availableLanguage: ["English"],
+        },
+      ],
+    },
   });
 }
 

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -24,6 +24,7 @@ import { getCurrentLanguage } from "../lib/language";
 import { getSpeckitMessages } from "../i18n/messages";
 import { supportedLanguages } from "../i18n/config";
 import speckitBrand from "../brand.config";
+import { buildBrandMetadata } from "@airnub/brand";
 
 const jsonLd = buildSpeckitSoftwareJsonLd();
 
@@ -32,45 +33,38 @@ export async function generateMetadata(): Promise<Metadata> {
   const layoutMessages = getSpeckitMessages(language).layout;
   const metadataMessages = layoutMessages.metadata;
   const ogPath = speckitBrand.og ?? "/brand/og.png";
-  const ogUrl = new URL(ogPath, SPECKIT_BASE_URL);
-  const favicon = speckitBrand.favicon ?? speckitBrand.logos.mark ?? "/brand/favicon.svg";
+  const ogUrl = new URL(ogPath, SPECKIT_BASE_URL).toString();
 
-  return {
-    metadataBase: new URL(SPECKIT_BASE_URL),
-    title: {
-      default: metadataMessages.titleDefault,
-      template: metadataMessages.titleTemplate,
+  return buildBrandMetadata({
+    brand: speckitBrand,
+    baseUrl: SPECKIT_BASE_URL,
+    overrides: {
+      title: {
+        default: metadataMessages.titleDefault,
+        template: metadataMessages.titleTemplate,
+      },
+      description: metadataMessages.description,
+      openGraph: {
+        description: metadataMessages.ogDescription,
+        locale: metadataMessages.openGraphLocale,
+        images: [
+          {
+            url: ogUrl,
+            width: 1200,
+            height: 630,
+            alt: metadataMessages.ogImageAlt,
+          },
+        ],
+      },
+      twitter: {
+        description: metadataMessages.twitterDescription,
+        images: [ogUrl],
+      },
+      alternates: {
+        canonical: "/",
+      },
     },
-    description: metadataMessages.description,
-    openGraph: {
-      title: speckitBrand.name,
-      description: metadataMessages.ogDescription,
-      url: SPECKIT_BASE_URL,
-      siteName: speckitBrand.name,
-      locale: metadataMessages.openGraphLocale,
-      type: "website",
-      images: [
-        {
-          url: ogUrl,
-          width: 1200,
-          height: 630,
-          alt: metadataMessages.ogImageAlt,
-        },
-      ],
-    },
-    twitter: {
-      card: "summary_large_image",
-      title: speckitBrand.name,
-      description: metadataMessages.twitterDescription,
-      images: [ogUrl.toString()],
-    },
-    icons: {
-      icon: favicon,
-    },
-    alternates: {
-      canonical: "/",
-    },
-  };
+  });
 }
 
 export default async function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/speckit/lib/jsonld.ts
+++ b/apps/speckit/lib/jsonld.ts
@@ -1,14 +1,22 @@
-import { softwareApplicationJsonLd } from "@airnub/seo";
+import { buildBrandSoftwareApplicationJsonLd } from "@airnub/brand";
 import { SPECKIT_BASE_URL } from "./routes";
+import speckitBrand from "../brand.config";
 
 export function buildSpeckitSoftwareJsonLd() {
-  return softwareApplicationJsonLd({
-    name: "Speckit",
-    url: SPECKIT_BASE_URL,
+  const sameAs = [
+    speckitBrand.social.github,
+    "https://airnub.io",
+  ].filter((url): url is string => Boolean(url));
+
+  return buildBrandSoftwareApplicationJsonLd({
+    brand: speckitBrand,
+    baseUrl: SPECKIT_BASE_URL,
     applicationCategory: "DevSecOps Application",
-    description:
-      "End vibe-coding. Ship secure, auditable releases with governed workflows and continuous evidence.",
-    softwareHelp: "https://docs.speckit.dev",
-    sameAs: ["https://github.com/airnub/speckit", "https://airnub.io"],
+    overrides: {
+      description:
+        "End vibe-coding. Ship secure, auditable releases with governed workflows and continuous evidence.",
+      softwareHelp: "https://docs.speckit.dev",
+      sameAs,
+    },
   });
 }

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -8,3 +8,4 @@ export const ogTemplate = join(packageDir, "../public/brand/og.png");
 export * from "./AirnubWordmark";
 export * from "./SpeckitWordmark";
 export * from "./brand.config";
+export * from "./metadata";

--- a/packages/brand/src/metadata.ts
+++ b/packages/brand/src/metadata.ts
@@ -1,0 +1,186 @@
+import type { Metadata } from "next";
+import { organizationJsonLd, softwareApplicationJsonLd, type JsonLd } from "@airnub/seo";
+import type { BrandConfig } from "./brand.config";
+
+const DEFAULT_OG_IMAGE_PATH = "/brand/og.png";
+const DEFAULT_ICON_PATH = "/brand/favicon.svg";
+
+function resolveOgImagePath(brand: BrandConfig): string {
+  return (
+    brand.og ??
+    brand.logos.mark ??
+    brand.logos.light ??
+    brand.favicon ??
+    DEFAULT_OG_IMAGE_PATH
+  );
+}
+
+function resolveIconPath(brand: BrandConfig): string {
+  return brand.favicon ?? brand.logos.mark ?? DEFAULT_ICON_PATH;
+}
+
+function resolveLogoPath(brand: BrandConfig): string {
+  return brand.logos.mark ?? brand.logos.light ?? resolveIconPath(brand);
+}
+
+function toAbsoluteUrl(baseUrl: string, value?: string): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    return new URL(value, baseUrl).toString();
+  } catch {
+    return value;
+  }
+}
+
+export function getBrandSocialUrls(brand: BrandConfig): string[] {
+  const urls = Object.values(brand.social ?? {}).filter(
+    (value): value is string => Boolean(value?.length)
+  );
+  return Array.from(new Set(urls));
+}
+
+export interface BuildBrandMetadataOptions {
+  brand: BrandConfig;
+  baseUrl: string;
+  overrides?: Partial<Metadata>;
+}
+
+export function buildBrandMetadata({
+  brand,
+  baseUrl,
+  overrides,
+}: BuildBrandMetadataOptions): Metadata {
+  const ogImageUrl = toAbsoluteUrl(baseUrl, resolveOgImagePath(brand));
+  const iconPath = resolveIconPath(brand);
+  const metadataBase = overrides?.metadataBase ?? new URL(baseUrl);
+
+  const defaultOpenGraph: NonNullable<Metadata["openGraph"]> = {
+    title: brand.name,
+    description: brand.description,
+    url: baseUrl,
+    siteName: brand.name,
+    type: "website",
+    ...(ogImageUrl
+      ? {
+          images: [
+            {
+              url: ogImageUrl,
+              width: 1200,
+              height: 630,
+              alt: brand.name,
+            },
+          ],
+        }
+      : {}),
+  };
+
+  const defaultTwitter: NonNullable<Metadata["twitter"]> = {
+    card: "summary_large_image",
+    title: brand.name,
+    description: brand.description,
+    ...(ogImageUrl ? { images: [ogImageUrl] } : {}),
+  };
+
+  const {
+    openGraph: openGraphOverrides,
+    twitter: twitterOverrides,
+    icons: iconOverrides,
+    metadataBase: _metadataBaseOverride,
+    title: titleOverride,
+    description: descriptionOverride,
+    ...restOverrides
+  } = overrides ?? {};
+
+  return {
+    metadataBase,
+    title: titleOverride ?? brand.name,
+    description: descriptionOverride ?? brand.description,
+    openGraph: {
+      ...defaultOpenGraph,
+      ...openGraphOverrides,
+      ...(openGraphOverrides?.images
+        ? { images: openGraphOverrides.images }
+        : defaultOpenGraph.images
+          ? { images: defaultOpenGraph.images }
+          : {}),
+    },
+    twitter: {
+      ...defaultTwitter,
+      ...twitterOverrides,
+      ...(twitterOverrides?.images
+        ? { images: twitterOverrides.images }
+        : defaultTwitter.images
+          ? { images: defaultTwitter.images }
+          : {}),
+    },
+    icons: iconOverrides ?? { icon: iconPath },
+    ...restOverrides,
+  } satisfies Metadata;
+}
+
+type OrganizationJsonLdOptions = Parameters<typeof organizationJsonLd>[0];
+
+export interface BuildBrandOrganizationJsonLdOptions {
+  brand: BrandConfig;
+  baseUrl: string;
+  overrides?: {
+    name?: string;
+    url?: string;
+    logo?: string;
+    sameAs?: string[];
+    contactPoint?: NonNullable<OrganizationJsonLdOptions["contactPoint"]>;
+  };
+}
+
+export function buildBrandOrganizationJsonLd({
+  brand,
+  baseUrl,
+  overrides,
+}: BuildBrandOrganizationJsonLdOptions): JsonLd {
+  const logo = toAbsoluteUrl(baseUrl, overrides?.logo ?? resolveLogoPath(brand));
+  const sameAs = overrides?.sameAs ?? getBrandSocialUrls(brand);
+
+  return organizationJsonLd({
+    name: overrides?.name ?? brand.name,
+    url: overrides?.url ?? baseUrl,
+    ...(logo ? { logo } : {}),
+    ...(sameAs.length ? { sameAs } : {}),
+    ...(overrides?.contactPoint ? { contactPoint: overrides.contactPoint } : {}),
+  });
+}
+
+type SoftwareApplicationJsonLdOptions = Parameters<typeof softwareApplicationJsonLd>[0];
+
+export interface BuildBrandSoftwareApplicationJsonLdOptions {
+  brand: BrandConfig;
+  baseUrl: string;
+  applicationCategory: SoftwareApplicationJsonLdOptions["applicationCategory"];
+  overrides?: Partial<Omit<SoftwareApplicationJsonLdOptions, "name" | "url" | "applicationCategory" >>;
+}
+
+export function buildBrandSoftwareApplicationJsonLd({
+  brand,
+  baseUrl,
+  applicationCategory,
+  overrides,
+}: BuildBrandSoftwareApplicationJsonLdOptions): JsonLd {
+  const ogImage = overrides?.image ?? resolveOgImagePath(brand);
+  const image = toAbsoluteUrl(baseUrl, ogImage);
+  const sameAs = overrides?.sameAs ?? getBrandSocialUrls(brand);
+
+  return softwareApplicationJsonLd({
+    name: brand.name,
+    url: baseUrl,
+    applicationCategory,
+    ...(overrides?.operatingSystem ? { operatingSystem: overrides.operatingSystem } : {}),
+    description: overrides?.description ?? brand.description,
+    ...(image ? { image } : {}),
+    ...(overrides?.offers ? { offers: overrides.offers } : {}),
+    ...(overrides?.aggregateRating ? { aggregateRating: overrides.aggregateRating } : {}),
+    ...(overrides?.softwareHelp ? { softwareHelp: overrides.softwareHelp } : {}),
+    ...(sameAs.length ? { sameAs } : {}),
+  });
+}


### PR DESCRIPTION
## Summary
- add shared metadata and JSON-LD builders in `@airnub/brand`
- use the helper to configure base metadata in the Airnub and Speckit layouts
- refactor JSON-LD modules to wrap the shared helper where appropriate

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dad7885e0883248ae94471873dc6a8