### PR TITLE
refactor: isolate server-only brand exports

### DIFF
--- a/apps/airnub/app/api/og/route.tsx
+++ b/apps/airnub/app/api/og/route.tsx
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 
-import { ogTemplate } from "@airnub/brand";
+import { ogTemplate } from "@airnub/brand/server";
 
 export async function GET() {
   const template = await fs.readFile(ogTemplate);

--- a/apps/speckit/app/api/og/route.tsx
+++ b/apps/speckit/app/api/og/route.tsx
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 
-import { ogTemplate } from "@airnub/brand";
+import { ogTemplate } from "@airnub/brand/server";
 
 export async function GET() {
   const template = await fs.readFile(ogTemplate);

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -17,6 +17,11 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./server": {
+      "types": "./src/server.ts",
+      "import": "./src/server.ts",
+      "default": "./src/server.ts"
     }
   }
 }

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -1,10 +1,3 @@
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-export const ogTemplateUrl = new URL("../public/brand/og.png", import.meta.url);
-const packageDir = dirname(fileURLToPath(import.meta.url));
-export const ogTemplate = join(packageDir, "../public/brand/og.png");
-
 export * from "./AirnubWordmark";
 export * from "./SpeckitWordmark";
 export * from "./brand.config";

--- a/packages/brand/src/server.ts
+++ b/packages/brand/src/server.ts
@@ -1,0 +1,7 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ogTemplateUrl = new URL("../public/brand/og.png", import.meta.url);
+
+const packageDir = dirname(fileURLToPath(import.meta.url));
+export const ogTemplate = join(packageDir, "../public/brand/og.png");


### PR DESCRIPTION
## Summary
- move OG template resolution into a new server-only entry point for @airnub/brand
- keep the public index export client-safe and update package exports to surface the server module
- switch both app OG routes to consume the new server subpath

## Testing
- pnpm dev (terminated after verifying both Next.js apps started successfully)


------
https://chatgpt.com/codex/tasks/task_e_68daed0602ac8324947a22e0d1a4e132