### PR TITLE
feat: support environment-based brand overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ This command will:
 - Copy `.brand/public/brand/` into `packages/brand/public/brand/` and both apps' `public/brand/` folders so `/brand/*` requests resolve everywhere.
 - Regenerate `packages/brand/runtime/brand.config.json` and `packages/brand/runtime/tokens.css` so runtime code and CSS can safely consume the shared brand tokens without bundling TypeScript.
 
-If you need to tweak metadata (name, colors, social links, etc.), update [`packages/brand/src/brand.config.ts`](packages/brand/src/brand.config.ts) and re-run `pnpm brand:sync` so the runtime outputs stay fresh.
+If you need to tweak metadata (name, colors, social links, etc.), you can either edit [`packages/brand/src/brand.config.ts`](packages/brand/src/brand.config.ts) directly or provide environment overrides before running the sync script. Supported variables include:
+
+- `BRAND_NAME`, `BRAND_DOMAIN`, `BRAND_DESCRIPTION`
+- `BRAND_COLOR_PRIMARY`, `BRAND_COLOR_SECONDARY`, `BRAND_COLOR_ACCENT`, `BRAND_COLOR_BACKGROUND`, `BRAND_COLOR_FOREGROUND`
+- `BRAND_LOGO_LIGHT`, `BRAND_LOGO_DARK`, `BRAND_LOGO_MARK`
+- `BRAND_FAVICON`, `BRAND_OG`
+- `BRAND_SOCIAL_*` (e.g., `BRAND_SOCIAL_GITHUB`, `BRAND_SOCIAL_LINKEDIN`, `BRAND_SOCIAL_PRODUCT_HUNT`)
+
+After updating any of these values, re-run `pnpm brand:sync` so the runtime outputs stay fresh.
 
 ## Additional documentation
 

--- a/scripts/brand-sync.ts
+++ b/scripts/brand-sync.ts
@@ -3,7 +3,9 @@ import { constants } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { brand } from "../packages/brand/src/brand.config";
+import { resolveBrandConfig } from "@airnub/brand";
+
+const brand = resolveBrandConfig();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");


### PR DESCRIPTION
## Summary
- add a resolver to merge environment variables into the shared brand config
- export the resolved config for consumers and update the brand sync script to use it
- document the supported environment overrides for brand metadata

## Testing
- pnpm brand:sync

------
https://chatgpt.com/codex/tasks/task_e_68daf9584fa88324bbf825b9395d33d6