### PR TITLE
fix: stabilize branding build pipeline

### DIFF
--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -3,7 +3,7 @@ import { BrandProvider, FooterAirnub, HeaderAirnub, ThemeProvider, ToastProvider
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getTranslations, setRequestLocale } from "next-intl/server";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import { buildAirnubOrganizationJsonLd } from "../../lib/jsonld";
 import { AIRNUB_BASE_URL } from "../../lib/routes";
 import { localeHref } from "../../lib/locale";
@@ -182,7 +182,11 @@ export default async function LocaleLayout({
                   homeAriaLabel={`${airnubBrand.name} home`}
                   githubLabel={common("githubLabel")}
                   themeToggleLabel={common("theme.toggle")}
-                  additionalRightSlot={<LocaleSwitcher />}
+                  additionalRightSlot={
+                    <Suspense fallback={null}>
+                      <LocaleSwitcher />
+                    </Suspense>
+                  }
                 />
                 <main id="content" className="flex-1">
                   <MaintenanceGate

--- a/apps/airnub/app/[locale]/trust/route.ts
+++ b/apps/airnub/app/[locale]/trust/route.ts
@@ -1,7 +1,0 @@
-import { redirect } from "next/navigation";
-
-export const dynamic = "force-static";
-
-export function GET() {
-  redirect("https://trust.airnub.io");
-}

--- a/apps/airnub/app/admin/(protected)/leads/page.tsx
+++ b/apps/airnub/app/admin/(protected)/leads/page.tsx
@@ -47,7 +47,7 @@ export default async function LeadsPage() {
     serviceClient
       .from("contact_leads")
       .select(
-        "id,created_at,full_name,email,company,message,source,consent,lead_actions(id,status,assignee,note,created_at,created_by)"
+        "id,created_at,full_name,email,company,message,source,consent,user_agent,ip_hash,lead_actions(id,lead_id,status,assignee,note,created_at,created_by)"
       )
       .order("created_at", { ascending: false })
       .limit(100),

--- a/apps/airnub/app/admin/(public)/sign-in/SignInForm.tsx
+++ b/apps/airnub/app/admin/(public)/sign-in/SignInForm.tsx
@@ -5,7 +5,7 @@ import { Button } from "@airnub/ui";
 import type { SignInFormState } from "./actions";
 
 type Props = {
-  action: (state: SignInFormState | undefined, formData: FormData) => Promise<SignInFormState | void>;
+  action: (state: SignInFormState | undefined, formData: FormData) => Promise<SignInFormState>;
 };
 
 const initialState: SignInFormState = {};

--- a/apps/airnub/app/admin/(public)/sign-in/actions.ts
+++ b/apps/airnub/app/admin/(public)/sign-in/actions.ts
@@ -9,7 +9,10 @@ export type SignInFormState = {
 
 const GENERIC_ERROR = "Unable to sign in with those credentials. Confirm the admin email and password in Supabase.";
 
-export async function signInAction(_prevState: SignInFormState | undefined, formData: FormData): Promise<SignInFormState | void> {
+export async function signInAction(
+  _prevState: SignInFormState | undefined,
+  formData: FormData
+): Promise<SignInFormState> {
   const email = formData.get("email");
   const password = formData.get("password");
 
@@ -30,4 +33,6 @@ export async function signInAction(_prevState: SignInFormState | undefined, form
   }
 
   redirect("/admin/leads");
+
+  return {};
 }

--- a/apps/airnub/i18n/request.ts
+++ b/apps/airnub/i18n/request.ts
@@ -1,3 +1,4 @@
+import type { AbstractIntlMessages } from "next-intl";
 import { getRequestConfig } from "next-intl/server";
 import { defaultLocale, locales, type Locale } from "./routing";
 
@@ -27,6 +28,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
 
   return {
     locale: normalizedLocale,
-    messages,
+    messages: messages as unknown as AbstractIntlMessages,
   };
 });

--- a/apps/airnub/lib/supabase-auth.ts
+++ b/apps/airnub/lib/supabase-auth.ts
@@ -4,6 +4,7 @@ import { cookies as getCookies } from "next/headers";
 
 type Cookie = { name: string; value: string };
 type CookieWithOptions = { name: string; value: string; options: Partial<CookieOptions> };
+type CookieStore = Awaited<ReturnType<typeof getCookies>>;
 
 function ensureEnv(name: string) {
   const value = process.env[name];
@@ -17,15 +18,17 @@ export function createServerActionSupabase() {
   const supabaseUrl = ensureEnv("NEXT_PUBLIC_SUPABASE_URL");
   const supabaseAnonKey = ensureEnv("NEXT_PUBLIC_SUPABASE_ANON_KEY");
 
-  const cookieStore = getCookies();
+  const cookieStorePromise = Promise.resolve(getCookies() as Promise<CookieStore> | CookieStore);
 
   return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
-      getAll() {
-        return cookieStore.getAll().map(({ name, value }) => ({ name, value })) as Cookie[];
+      async getAll() {
+        const store = await cookieStorePromise;
+        const all = store.getAll();
+        return all.map(({ name, value }) => ({ name, value })) as Cookie[];
       },
-      setAll(cookies) {
-        const store = getCookies();
+      async setAll(cookies) {
+        const store = await Promise.resolve(getCookies() as Promise<CookieStore> | CookieStore);
         for (const cookie of cookies as CookieWithOptions[]) {
           store.set(cookie.name, cookie.value, cookie.options);
         }

--- a/apps/airnub/package.json
+++ b/apps/airnub/package.json
@@ -19,6 +19,7 @@
     "@airnub/db": "workspace:*",
     "@airnub/seo": "workspace:*",
     "@airnub/ui": "workspace:*",
+    "@supabase/ssr": "^0.7.0",
     "@vercel/og": "^0.8.5",
     "clsx": "^2.1.1",
     "next-intl": "^3.17.3",

--- a/apps/airnub/tailwind.config.ts
+++ b/apps/airnub/tailwind.config.ts
@@ -1,6 +1,9 @@
 import type { Config } from "tailwindcss";
 import preset from "@airnub/ui/tailwind-preset";
 
+const contentGlobs = Array.isArray(preset.content) ? [...preset.content] : [];
+
 export default {
+  content: contentGlobs,
   presets: [preset],
 } satisfies Config;

--- a/apps/speckit/tailwind.config.ts
+++ b/apps/speckit/tailwind.config.ts
@@ -1,6 +1,9 @@
 import type { Config } from "tailwindcss";
 import preset from "@airnub/ui/tailwind-preset";
 
+const contentGlobs = Array.isArray(preset.content) ? [...preset.content] : [];
+
 export default {
+  content: contentGlobs,
   presets: [preset],
 } satisfies Config;

--- a/docs/src/components/HomepageFeatures/index.tsx
+++ b/docs/src/components/HomepageFeatures/index.tsx
@@ -1,4 +1,4 @@
-import type {ReactNode} from 'react';
+import type {ComponentType, ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import Heading from '@theme/Heading';
@@ -8,7 +8,7 @@ type FeatureIconProps = {className?: string};
 
 type FeatureItem = {
   title: string;
-  Icon: (props: FeatureIconProps) => JSX.Element;
+  Icon: ComponentType<FeatureIconProps>;
   description: ReactNode;
 };
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,7 @@
   "types": "src/index.ts",
   "dependencies": {
     "@airnub/brand": "workspace:*",
+    "@tailwindcss/typography": "^0.5.19",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-toast": "^1.2.4",
     "clsx": "^2.1.1",

--- a/packages/ui/src/fonts.ts
+++ b/packages/ui/src/fonts.ts
@@ -1,16 +1,5 @@
-import { IBM_Plex_Mono, Inter } from "next/font/google";
+export const fontSans = { variable: "font-sans-variable" } as const;
 
-export const fontSans = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-sans",
-});
-
-export const fontMono = IBM_Plex_Mono({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
-  display: "swap",
-  variable: "--font-mono",
-});
+export const fontMono = { variable: "font-mono-variable" } as const;
 
 export const fontVariables = `${fontSans.variable} ${fontMono.variable}`;

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -25,6 +25,8 @@
   --input: 214.3 31.8% 91.4%;
   --ring: 222.2 84% 4.9%;
   --radius: 0.75rem;
+  --font-sans: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 
 .dark {
@@ -50,6 +52,16 @@
   --input: 240 3.7% 15.9%;
   --ring: 210 40% 98%;
   --radius: 0.75rem;
+  --font-sans: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.font-sans-variable {
+  --font-sans: 'Inter', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.font-mono-variable {
+  --font-mono: 'IBM Plex Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
 }
 
 html,

--- a/packages/ui/tailwind-preset.ts
+++ b/packages/ui/tailwind-preset.ts
@@ -1,18 +1,21 @@
-import { join } from "path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Config } from "tailwindcss";
 import tailwindTypography from "@tailwindcss/typography";
 import tailwindAnimate from "tailwindcss-animate";
 
+const presetDir = dirname(fileURLToPath(import.meta.url));
+
 const preset = {
   darkMode: ["class"],
   content: [
-    join(__dirname, "./app/**/*.{ts,tsx,js,jsx,mdx}"),
-    join(__dirname, "./components/**/*.{ts,tsx,js,jsx,mdx}"),
-    join(__dirname, "./src/**/*.{ts,tsx,js,jsx,mdx}"),
-    join(__dirname, "../../packages/*/app/**/*.{ts,tsx,js,jsx,mdx}"),
-    join(__dirname, "../../packages/*/components/**/*.{ts,tsx,js,jsx,mdx}"),
-    join(__dirname, "../../packages/*/providers/**/*.{ts,tsx,js,jsx,mdx}"),
-    join(__dirname, "../../packages/*/src/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "./app/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "./components/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "./src/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "../../packages/*/app/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "../../packages/*/components/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "../../packages/*/providers/**/*.{ts,tsx,js,jsx,mdx}"),
+    join(presetDir, "../../packages/*/src/**/*.{ts,tsx,js,jsx,mdx}"),
   ],
   theme: {
     container: { center: true, padding: "2rem" },
@@ -61,6 +64,20 @@ const preset = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
         xl: "calc(var(--radius) + 4px)",
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        mono: [
+          "var(--font-mono)",
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Monaco",
+          "Consolas",
+          "Liberation Mono",
+          "Courier New",
+          "monospace",
+        ],
       },
       boxShadow: {
         card: "0 1px 2px rgba(0,0,0,.05)",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@airnub/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@supabase/ssr':
+        specifier: ^0.7.0
+        version: 0.7.0(@supabase/supabase-js@2.58.0)
       '@vercel/og':
         specifier: ^0.8.5
         version: 0.8.5
@@ -234,6 +237,9 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.4
         version: 1.2.15(@types/react-dom@19.1.9(@types/react@19.1.15))(@types/react@19.1.15)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@24.5.2)(typescript@5.9.2)))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1


### PR DESCRIPTION
## Summary
- fix Supabase admin utilities and lead queries so typechecking and builds succeed
- replace Google font dependencies with CSS variable fallbacks and share Tailwind content globs
- wrap locale switcher in suspense and remove conflicting trust redirect to restore static builds

## Testing
- pnpm brand:sync
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm --filter @airnub/airnub-app dev (terminated manually)
- pnpm --filter @airnub/speckit-app dev (terminated manually)


------
https://chatgpt.com/codex/tasks/task_e_68dab7b4b454832491991d9478ddb92f