### PR TITLE
chore: remove unused tailwind config workspace

### DIFF
--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,1 +1,0 @@
-{ "name": "@airnub/tailwind-config", "version": "0.0.0", "main": "tailwind.config.ts", "type": "module" }

--- a/packages/tailwind-config/tailwind.config.ts
+++ b/packages/tailwind-config/tailwind.config.ts
@@ -1,3 +1,0 @@
-import preset from "@airnub/ui/tailwind-preset";
-
-export default preset;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,8 +224,6 @@ importers:
 
   packages/seo: {}
 
-  packages/tailwind-config: {}
-
   packages/ui:
     dependencies:
       '@airnub/brand':


### PR DESCRIPTION
## Summary
- remove the unused `@airnub/tailwind-config` workspace
- clean up the pnpm lockfile to drop the unused importer entry

## Testing
- pnpm install

------
https://chatgpt.com/codex/tasks/task_e_68db0a471cd083249b46adecddc2ec25