### PR TITLE
feat: share marketing sections across home pages

### DIFF
--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -7,14 +7,16 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-  Container,
+  CTASection,
+  FeatureGrid,
+  Hero,
+  LogoCloud,
   CloudyardLogo,
   ForgeLabsLogo,
   NorthbeamLogo,
 } from "@airnub/ui";
 import { serverFetch } from "@airnub/seo";
 import { getTranslations } from "next-intl/server";
-import { PageHero } from "../../components/PageHero";
 import { LocaleLink } from "../../components/LocaleLink";
 import { assertLocale } from "../../i18n/routing";
 
@@ -131,11 +133,15 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
     })),
   } as const;
 
-  const outcomeAccentClasses = ["bg-brand-subtle", "bg-brand-accent", "bg-brand-bold"] as const;
+  const outcomeAccentStyles = [
+    { backgroundColor: "var(--brand-primary)" },
+    { backgroundColor: "var(--brand-accent)" },
+    { backgroundColor: "color-mix(in srgb, var(--brand-foreground) 70%, transparent)" },
+  ] as const;
 
   return (
     <div className="space-y-24 pb-24">
-      <PageHero
+      <Hero
         eyebrow={hero.eyebrow}
         title={hero.title}
         description={hero.description}
@@ -151,105 +157,71 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
         }
       />
 
-      <section>
-        <Container className="grid gap-10 lg:grid-cols-3">
-          {highlightItems.map((item) => (
-            <Card key={item.id}>
-              <CardHeader>
-                <CardTitle className="text-xl">{item.title}</CardTitle>
-                <CardDescription>{item.description}</CardDescription>
-              </CardHeader>
-            </Card>
-          ))}
-        </Container>
-      </section>
+      <FeatureGrid
+        items={highlightItems.map((item) => ({
+          id: item.id,
+          title: item.title,
+          description: item.description,
+        }))}
+      />
 
-      <section>
-        <Container className="text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-            {t("customers.eyebrow")}
-          </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-8">
-            {customerItems.map(({ id, name, Logo }) => (
-              <Card key={id} aria-label={name} className="group h-16 w-40 transition-colors">
-                <CardContent className="flex h-full items-center justify-center p-4 text-muted-foreground transition-colors group-hover:text-foreground">
-                  <Logo className="h-6 w-auto" aria-hidden="true" focusable="false" />
-                  <span className="sr-only">{name}</span>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </Container>
-      </section>
+      <LogoCloud
+        eyebrow={t("customers.eyebrow")}
+        items={customerItems.map(({ id, name, Logo }) => ({
+          id,
+          name,
+          logo: <Logo className="h-6 w-auto" aria-hidden="true" focusable="false" />,
+        }))}
+      />
 
-      <section>
-        <Container>
+      <CTASection
+        title={speckit.title}
+        description={speckit.description}
+        actions={
+          <>
+            <Button asChild>
+              <Link href="https://speckit.airnub.io" target="_blank" rel="noreferrer">
+                {speckit.primaryCta}
+              </Link>
+            </Button>
+            <Button variant="ghost" asChild>
+              <LocaleLink href="/products">{speckit.secondaryCta}</LocaleLink>
+            </Button>
+          </>
+        }
+        aside={
           <Card>
-            <CardContent className="grid gap-12 pt-5 lg:grid-cols-2 lg:items-start">
-              <div className="space-y-6">
-                <CardHeader className="gap-4 p-0">
-                  <CardTitle className="text-3xl tracking-tight text-card-foreground sm:text-4xl">
-                    {speckit.title}
-                  </CardTitle>
-                  <CardDescription className="text-base text-muted-foreground">
-                    {speckit.description}
-                  </CardDescription>
-                </CardHeader>
-                <div className="flex flex-wrap gap-4">
-                  <Button asChild>
-                    <Link href="https://speckit.airnub.io" target="_blank" rel="noreferrer">
-                      {speckit.primaryCta}
-                    </Link>
-                  </Button>
-                  <Button variant="ghost" asChild>
-                    <LocaleLink href="/products">{speckit.secondaryCta}</LocaleLink>
-                  </Button>
-                </div>
-              </div>
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-lg">{speckit.outcomesTitle}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <ul className="space-y-3 text-sm text-muted-foreground">
-                    {speckit.outcomes.map((outcome, index) => {
-                      const accentClass = outcomeAccentClasses[
-                        Math.min(index, outcomeAccentClasses.length - 1)
-                      ];
-                      return (
-                        <li key={outcome.id} className="flex gap-3">
-                          <span
-                            className={`mt-1 inline-flex h-2.5 w-2.5 rounded-full ${accentClass}`}
-                            aria-hidden="true"
-                          />
-                          {outcome.copy}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </CardContent>
-              </Card>
+            <CardHeader>
+              <CardTitle className="text-lg">{speckit.outcomesTitle}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {speckit.outcomes.map((outcome, index) => (
+                  <li key={outcome.id} className="flex gap-3">
+                    <span
+                      className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full"
+                      style={outcomeAccentStyles[index % outcomeAccentStyles.length]}
+                      aria-hidden="true"
+                    />
+                    <span>{outcome.copy}</span>
+                  </li>
+                ))}
+              </ul>
             </CardContent>
           </Card>
-        </Container>
-      </section>
+        }
+      />
 
-      <section>
-        <Container className="grid gap-12 lg:grid-cols-[2fr,3fr] lg:items-center">
-          <div className="space-y-6">
-            <div>
-              <h2 className="text-3xl font-semibold text-foreground">{services.title}</h2>
-              <p className="mt-4 text-base text-muted-foreground">{services.description}</p>
-            </div>
-            <ul className="space-y-3 text-sm text-muted-foreground">
-              {services.steps.map((step) => (
-                <li key={step.id}>
-                  <strong className="font-semibold text-foreground">{step.label}</strong>{" "}
-                  {step.description}
-                </li>
-              ))}
-            </ul>
-          </div>
+      <CTASection
+        title={services.title}
+        description={services.description}
+        items={services.steps.map((step) => ({
+          id: step.id,
+          title: step.label,
+          description: step.description,
+        }))}
+        tone="subtle"
+        aside={
           <div className="grid gap-6 md:grid-cols-2">
             {services.cards.map((card) => (
               <Card key={card.id}>
@@ -260,8 +232,8 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
               </Card>
             ))}
           </div>
-        </Container>
-      </section>
+        }
+      />
     </div>
   );
 }

--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -7,9 +7,12 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-  Container,
+  CTASection,
+  FeatureGrid,
+  Hero,
+  LogoCloud,
+  TestimonialWall,
 } from "@airnub/ui";
-import { PageHero } from "../components/PageHero";
 import { getCurrentLanguage } from "../lib/language";
 import { getSpeckitMessages } from "../i18n/messages";
 
@@ -31,10 +34,11 @@ export default async function SpeckitHome() {
 
   return (
     <div className="space-y-24 pb-24">
-      <PageHero
+      <Hero
         eyebrow={home.hero.eyebrow}
         title={home.hero.title}
         description={home.hero.description}
+        variant="gradient"
         actions={
           <>
             {home.hero.actions.primaryLabel ? (
@@ -57,35 +61,18 @@ export default async function SpeckitHome() {
         }
       />
 
-      <section>
-        <Container className="grid gap-8 lg:grid-cols-3">
-          {home.features.map((feature) => (
-            <Card key={feature.title} className="h-full">
-              <CardHeader className="h-full">
-                <CardTitle className="text-xl">{feature.title}</CardTitle>
-                <CardDescription>{feature.description}</CardDescription>
-              </CardHeader>
-            </Card>
-          ))}
-        </Container>
-      </section>
+      <FeatureGrid
+        items={home.features.map((feature) => ({
+          id: feature.title,
+          title: feature.title,
+          description: feature.description,
+        }))}
+      />
 
-      <section>
-        <Container className="grid gap-12 lg:grid-cols-[3fr,2fr] lg:items-center">
-          <div>
-            <h2 className="text-3xl font-semibold text-foreground">{home.workflows.title}</h2>
-            <p className="mt-4 text-base text-muted-foreground">{home.workflows.description}</p>
-            <div className="mt-6 grid gap-4">
-              {home.workflows.items.map((workflow) => (
-                <Card key={workflow.name} className="h-full">
-                  <CardHeader className="h-full">
-                    <CardTitle className="text-lg">{workflow.name}</CardTitle>
-                    <CardDescription>{workflow.description}</CardDescription>
-                  </CardHeader>
-                </Card>
-              ))}
-            </div>
-          </div>
+      <CTASection
+        title={home.workflows.title}
+        description={home.workflows.description}
+        aside={
           <Card className="relative overflow-hidden">
             <div
               className="absolute inset-0 bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--brand-primary)_15%,transparent),_transparent_55%)]"
@@ -126,60 +113,54 @@ export default async function SpeckitHome() {
               </div>
             </CardContent>
           </Card>
-        </Container>
-      </section>
+        }
+      >
+        <div className="grid gap-4">
+          {home.workflows.items.map((workflow) => (
+            <Card key={workflow.name} className="h-full">
+              <CardHeader className="h-full">
+                <CardTitle className="text-lg">{workflow.name}</CardTitle>
+                <CardDescription>{workflow.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </CTASection>
 
-      <section>
-        <Container>
-          <Card>
-            <CardContent className="grid gap-10 pt-5 lg:grid-cols-[2fr,3fr] lg:items-center">
-              <div className="space-y-6">
-                <CardHeader className="p-0">
-                  <CardTitle className="text-3xl text-foreground">{home.alignment.title}</CardTitle>
-                  <CardDescription className="text-base text-muted-foreground">
-                    {home.alignment.description}
-                  </CardDescription>
-                </CardHeader>
-                <div className="flex flex-wrap gap-4">
-                  <Button variant="ghost" asChild>
-                    <Link href={home.alignment.actions.primaryHref}>{home.alignment.actions.primaryLabel}</Link>
-                  </Button>
-                  <Button asChild>
-                    <Link href={home.alignment.actions.secondaryHref}>{home.alignment.actions.secondaryLabel}</Link>
-                  </Button>
-                </div>
-              </div>
-              <div className="grid gap-4 md:grid-cols-2">
-                {home.alignment.cards.map((card) => (
-                  <Card key={card.title} className="bg-muted shadow-none">
-                    <CardHeader>
-                      <CardTitle className="text-lg">{card.title}</CardTitle>
-                      <CardDescription>{card.description}</CardDescription>
-                    </CardHeader>
-                  </Card>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
-        </Container>
-      </section>
+      <CTASection
+        title={home.alignment.title}
+        description={home.alignment.description}
+        actions={
+          <>
+            <Button variant="ghost" asChild>
+              <Link href={home.alignment.actions.primaryHref}>{home.alignment.actions.primaryLabel}</Link>
+            </Button>
+            <Button asChild>
+              <Link href={home.alignment.actions.secondaryHref}>{home.alignment.actions.secondaryLabel}</Link>
+            </Button>
+          </>
+        }
+        aside={
+          <TestimonialWall
+            items={home.alignment.cards.map((card) => ({
+              id: card.title,
+              author: card.title,
+              quote: card.description,
+            }))}
+            columnsClassName="md:grid-cols-2"
+            inline
+          />
+        }
+      />
 
-      <section>
-        <Container className="text-center">
-          <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
-            {home.integrations.eyebrow}
-          </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-6 text-muted-foreground">
-            {home.integrations.items.map((logo) => (
-              <Card key={logo} className="h-16 w-36 shadow-none">
-                <CardContent className="flex h-full items-center justify-center pt-5 text-sm font-semibold text-foreground">
-                  {logo}
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </Container>
-      </section>
+      <LogoCloud
+        eyebrow={home.integrations.eyebrow}
+        items={home.integrations.items.map((logo) => ({
+          id: logo,
+          name: logo,
+          logo: <span className="text-sm font-semibold text-foreground">{logo}</span>,
+        }))}
+      />
     </div>
   );
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,3 +14,4 @@ export * from "./logos";
 export * from "./fonts";
 export * from "./brand";
 export * from "./layouts/SiteShell";
+export * from "./sections";

--- a/packages/ui/src/sections/CTASection.tsx
+++ b/packages/ui/src/sections/CTASection.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode } from "react";
+import { Container } from "../Container";
+import { Card, CardContent } from "../components/card";
+import { cn } from "../lib/cn";
+
+export type CTASectionItem = {
+  id: string;
+  title: string;
+  description?: string;
+};
+
+export type CTASectionProps = {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  items?: CTASectionItem[];
+  actions?: ReactNode;
+  aside?: ReactNode;
+  children?: ReactNode;
+  tone?: "surface" | "subtle";
+  align?: "start" | "center";
+  className?: string;
+};
+
+const bulletStyles = [
+  { backgroundColor: "var(--brand-primary)" },
+  { backgroundColor: "var(--brand-accent)" },
+  { backgroundColor: "color-mix(in srgb, var(--brand-foreground) 70%, transparent)" },
+];
+
+export function CTASection({
+  eyebrow,
+  title,
+  description,
+  items,
+  actions,
+  aside,
+  children,
+  tone = "surface",
+  align = "start",
+  className,
+}: CTASectionProps) {
+  return (
+    <section className={className}>
+      <Container>
+        <Card
+          className={cn(
+            "overflow-hidden border border-border",
+            tone === "subtle" ? "bg-[var(--brand-surface-subtle)] text-foreground" : undefined
+          )}
+        >
+          <CardContent className="grid gap-12 pt-6 lg:grid-cols-[2fr,3fr] lg:items-start">
+            <div className="space-y-6">
+              <div
+                className={cn(
+                  "space-y-4",
+                  align === "center" ? "text-center" : "text-left"
+                )}
+              >
+                {eyebrow ? (
+                  <p className="text-xs font-semibold uppercase tracking-wide text-primary/80">
+                    {eyebrow}
+                  </p>
+                ) : null}
+                <div className="space-y-4">
+                  <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">{title}</h2>
+                  {description ? (
+                    <p
+                      className={cn(
+                        "text-base text-muted-foreground",
+                        align === "center" ? "mx-auto max-w-3xl" : undefined
+                      )}
+                    >
+                      {description}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+              {children}
+              {items && items.length > 0 ? (
+                <ul className="space-y-3 text-sm text-muted-foreground">
+                  {items.map((item, index) => (
+                    <li key={item.id} className="flex gap-3">
+                      <span
+                        className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full"
+                        style={bulletStyles[index % bulletStyles.length]}
+                        aria-hidden="true"
+                      />
+                      <div className="space-y-1">
+                        <p className="font-semibold text-foreground">{item.title}</p>
+                        {item.description ? (
+                          <p className="text-sm text-muted-foreground">{item.description}</p>
+                        ) : null}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {actions ? <div className="flex flex-wrap gap-4">{actions}</div> : null}
+            </div>
+            {aside}
+          </CardContent>
+        </Card>
+      </Container>
+    </section>
+  );
+}

--- a/packages/ui/src/sections/FeatureGrid.tsx
+++ b/packages/ui/src/sections/FeatureGrid.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+import { Container } from "../Container";
+import { Card, CardDescription, CardHeader, CardTitle } from "../components/card";
+import { cn } from "../lib/cn";
+
+export type FeatureGridItem = {
+  id: string;
+  title: string;
+  description: string;
+  icon?: ReactNode;
+};
+
+export type FeatureGridProps = {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  items: FeatureGridItem[];
+  columnsClassName?: string;
+  align?: "start" | "center";
+  className?: string;
+};
+
+export function FeatureGrid({
+  eyebrow,
+  title,
+  description,
+  items,
+  columnsClassName = "md:grid-cols-2 lg:grid-cols-3",
+  align = "start",
+  className,
+}: FeatureGridProps) {
+  return (
+    <section className={className}>
+      <Container className="space-y-12">
+        {(eyebrow || title || description) && (
+          <div
+            className={cn(
+              "space-y-4",
+              align === "center" ? "text-center" : "text-left"
+            )}
+          >
+            {eyebrow ? (
+              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+                {eyebrow}
+              </p>
+            ) : null}
+            {title ? (
+              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+                {title}
+              </h2>
+            ) : null}
+            {description ? (
+              <p
+                className={cn(
+                  "text-base text-muted-foreground",
+                  align === "center" ? "mx-auto max-w-3xl" : undefined
+                )}
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+        )}
+        <div className={cn("grid gap-6", columnsClassName)}>
+          {items.map((item) => (
+            <Card key={item.id} className="h-full">
+              <CardHeader className="h-full gap-3">
+                {item.icon ? (
+                  <div className="text-primary" aria-hidden="true">
+                    {item.icon}
+                  </div>
+                ) : null}
+                <CardTitle className="text-xl">{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/packages/ui/src/sections/Hero.tsx
+++ b/packages/ui/src/sections/Hero.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from "react";
+import { Container } from "../Container";
+import { cn } from "../lib/cn";
+
+export type HeroProps = {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+  align?: "start" | "center";
+  variant?: "subtle" | "gradient" | "plain";
+  className?: string;
+};
+
+const variantClassNames: Record<NonNullable<HeroProps["variant"]>, string> = {
+  subtle: "relative overflow-hidden border-b border-border bg-[var(--brand-surface-subtle)] text-foreground",
+  gradient:
+    "relative overflow-hidden border-b border-border bg-[radial-gradient(circle_at_top,_color-mix(in_srgb,var(--brand-primary)_14%,transparent)_0,_transparent_55%)] text-foreground",
+  plain: "relative overflow-hidden border-b border-border bg-background text-foreground",
+};
+
+export function Hero({
+  eyebrow,
+  title,
+  description,
+  actions,
+  align = "start",
+  variant = "subtle",
+  className,
+}: HeroProps) {
+  return (
+    <section className={cn(variantClassNames[variant], className)}>
+      <Container
+        className={cn(
+          "max-w-4xl py-16",
+          align === "center" ? "text-center" : "text-left"
+        )}
+      >
+        {eyebrow ? (
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+            {eyebrow}
+          </p>
+        ) : null}
+        <h1
+          className={cn(
+            "mt-4 text-4xl font-semibold tracking-tight sm:text-5xl",
+            align === "center" ? "mx-auto" : undefined
+          )}
+        >
+          {title}
+        </h1>
+        {description ? (
+          <p className={cn("mt-6 text-lg text-muted-foreground", align === "center" ? "mx-auto max-w-3xl" : undefined)}>
+            {description}
+          </p>
+        ) : null}
+        {actions ? (
+          <div className={cn("mt-8 flex flex-wrap gap-4", align === "center" ? "justify-center" : "justify-start")}>
+            {actions}
+          </div>
+        ) : null}
+      </Container>
+    </section>
+  );
+}

--- a/packages/ui/src/sections/LogoCloud.tsx
+++ b/packages/ui/src/sections/LogoCloud.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import { Container } from "../Container";
+import { Card, CardContent } from "../components/card";
+import { cn } from "../lib/cn";
+
+export type LogoCloudItem = {
+  id: string;
+  name: string;
+  logo: ReactNode;
+};
+
+export type LogoCloudProps = {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  items: LogoCloudItem[];
+  align?: "start" | "center";
+  className?: string;
+};
+
+export function LogoCloud({
+  eyebrow,
+  title,
+  description,
+  items,
+  align = "center",
+  className,
+}: LogoCloudProps) {
+  return (
+    <section className={className}>
+      <Container
+        className={cn(
+          "space-y-8",
+          align === "center" ? "text-center" : "text-left"
+        )}
+      >
+        {(eyebrow || title || description) && (
+          <div className="space-y-4">
+            {eyebrow ? (
+              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+                {eyebrow}
+              </p>
+            ) : null}
+            {title ? (
+              <h2 className="text-3xl font-semibold text-foreground">
+                {title}
+              </h2>
+            ) : null}
+            {description ? (
+              <p
+                className={cn(
+                  "text-base text-muted-foreground",
+                  align === "center" ? "mx-auto max-w-3xl" : undefined
+                )}
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+        )}
+        <div className="flex flex-wrap items-center justify-center gap-6">
+          {items.map((item) => (
+            <Card key={item.id} className="h-16 w-40 border-dashed bg-background shadow-none">
+              <CardContent className="flex h-full items-center justify-center p-4 text-muted-foreground">
+                <span className="sr-only">{item.name}</span>
+                <div aria-hidden="true" className="flex items-center justify-center text-foreground/90">
+                  {item.logo}
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/packages/ui/src/sections/TestimonialWall.tsx
+++ b/packages/ui/src/sections/TestimonialWall.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+import { Container } from "../Container";
+import { Card, CardContent } from "../components/card";
+import { cn } from "../lib/cn";
+
+export type TestimonialWallItem = {
+  id: string;
+  quote: string;
+  author: string;
+  role?: string;
+  avatar?: ReactNode;
+};
+
+export type TestimonialWallProps = {
+  eyebrow?: string;
+  title?: string;
+  description?: string;
+  items: TestimonialWallItem[];
+  columnsClassName?: string;
+  align?: "start" | "center";
+  className?: string;
+  inline?: boolean;
+};
+
+export function TestimonialWall({
+  eyebrow,
+  title,
+  description,
+  items,
+  columnsClassName = "md:grid-cols-2",
+  align = "start",
+  className,
+  inline = false,
+}: TestimonialWallProps) {
+  const grid = (
+    <div className={cn("grid gap-6", columnsClassName, inline ? className : undefined)}>
+      {items.map((item) => (
+        <Card
+          key={item.id}
+          className="h-full border-none bg-[var(--brand-surface-subtle)] text-foreground shadow-none"
+        >
+          <CardContent className="flex h-full flex-col gap-6 pt-5">
+            <div className="space-y-3">
+              <p className="text-base text-muted-foreground">{item.quote}</p>
+            </div>
+            <div className="flex items-center gap-3">
+              {item.avatar ? (
+                <div className="h-10 w-10 overflow-hidden rounded-full bg-[var(--brand-surface-accent)] text-sm font-semibold text-foreground">
+                  {item.avatar}
+                </div>
+              ) : null}
+              <div className="space-y-1 text-sm">
+                <p className="font-semibold text-foreground">{item.author}</p>
+                {item.role ? <p className="text-muted-foreground">{item.role}</p> : null}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+
+  if (inline) {
+    return grid;
+  }
+
+  return (
+    <section className={className}>
+      <Container className="space-y-12">
+        {(eyebrow || title || description) && (
+          <div
+            className={cn(
+              "space-y-4",
+              align === "center" ? "text-center" : "text-left"
+            )}
+          >
+            {eyebrow ? (
+              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+                {eyebrow}
+              </p>
+            ) : null}
+            {title ? (
+              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+                {title}
+              </h2>
+            ) : null}
+            {description ? (
+              <p
+                className={cn(
+                  "text-base text-muted-foreground",
+                  align === "center" ? "mx-auto max-w-3xl" : undefined
+                )}
+              >
+                {description}
+              </p>
+            ) : null}
+          </div>
+        )}
+        {grid}
+      </Container>
+    </section>
+  );
+}

--- a/packages/ui/src/sections/index.ts
+++ b/packages/ui/src/sections/index.ts
@@ -1,0 +1,5 @@
+export * from "./Hero";
+export * from "./FeatureGrid";
+export * from "./LogoCloud";
+export * from "./CTASection";
+export * from "./TestimonialWall";


### PR DESCRIPTION
## Summary
- add reusable Hero, FeatureGrid, LogoCloud, CTASection, and TestimonialWall components to `@airnub/ui`
- expose the new sections from the UI package entrypoint
- refactor the Airnub and Speckit home pages to consume the shared sections

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68db0e39566883248748ef1507dce8b1