### PR TITLE
feat: standardize section spacing across marketing pages

### DIFF
--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -140,7 +140,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
   ] as const;
 
   return (
-    <div className="space-y-24 pb-24">
+    <main className="flex flex-col">
       <Hero
         eyebrow={hero.eyebrow}
         title={hero.title}
@@ -234,6 +234,6 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           </div>
         }
       />
-    </div>
+    </main>
   );
 }

--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -33,7 +33,7 @@ export default async function SpeckitHome() {
   const home = messages.home;
 
   return (
-    <div className="space-y-24 pb-24">
+    <main className="flex flex-col">
       <Hero
         eyebrow={home.hero.eyebrow}
         title={home.hero.title}
@@ -161,6 +161,6 @@ export default async function SpeckitHome() {
           logo: <span className="text-sm font-semibold text-foreground">{logo}</span>,
         }))}
       />
-    </div>
+    </main>
   );
 }

--- a/packages/brand/package.json
+++ b/packages/brand/package.json
@@ -25,6 +25,9 @@
     },
     "./runtime/tokens.css": {
       "default": "./runtime/tokens.css"
+    },
+    "./runtime/layout.css": {
+      "default": "./runtime/layout.css"
     }
   }
 }

--- a/packages/brand/runtime/layout.css
+++ b/packages/brand/runtime/layout.css
@@ -1,0 +1,5 @@
+:root {
+  --section-gap-sm: 3rem;
+  --section-gap-md: 4.5rem;
+  --section-gap-lg: 6rem;
+}

--- a/packages/ui/src/Section.tsx
+++ b/packages/ui/src/Section.tsx
@@ -1,0 +1,52 @@
+import type { ComponentPropsWithoutRef, ElementType, PropsWithChildren } from "react";
+import { clsx } from "clsx";
+
+import { Container } from "./Container";
+
+type SectionOwnProps<T extends ElementType> = {
+  as?: T;
+  /**
+   * Whether to wrap children in the shared Container component.
+   * Defaults to true so sections stay aligned with the grid.
+   */
+  container?: boolean;
+  /**
+   * Applies the standard vertical stack spacing between direct children.
+   * Disable when a section manages internal layout manually.
+   */
+  stack?: boolean;
+  contentClassName?: string;
+};
+
+type SectionProps<T extends ElementType> = PropsWithChildren<
+  SectionOwnProps<T> &
+    Omit<ComponentPropsWithoutRef<T>, "as" | "children" | "className"> & {
+      className?: string;
+    }
+>;
+
+const sectionPaddingClass = "py-section-sm sm:py-section-md lg:py-section-lg";
+const sectionStackClass = "space-y-section-sm sm:space-y-section-md lg:space-y-section-lg";
+
+export function Section<T extends ElementType = "section">({
+  as,
+  container = true,
+  stack = true,
+  contentClassName,
+  className,
+  children,
+  ...rest
+}: SectionProps<T>) {
+  const Component = (as ?? "section") as ElementType;
+  const content = container ? (
+    <Container className={clsx(stack && sectionStackClass, contentClassName)}>{children}</Container>
+  ) : (
+    <div className={clsx(stack && sectionStackClass, contentClassName)}>{children}</div>
+  );
+
+  return (
+    <Component className={clsx(sectionPaddingClass, className)} {...(rest as ComponentPropsWithoutRef<T>)}>
+      {content}
+    </Component>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./components/client/Button";
 export * from "./Container";
+export * from "./Section";
 export * from "./components/client/Header";
 export * from "./components/client/FormMessage";
 export * from "./Footer";

--- a/packages/ui/src/sections/CTASection.tsx
+++ b/packages/ui/src/sections/CTASection.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Container } from "../Container";
+import { Section } from "../Section";
 import { Card, CardContent } from "../components/card";
 import { cn } from "../lib/cn";
 
@@ -41,67 +41,65 @@ export function CTASection({
   className,
 }: CTASectionProps) {
   return (
-    <section className={className}>
-      <Container>
-        <Card
-          className={cn(
-            "overflow-hidden border border-border",
-            tone === "subtle" ? "bg-[var(--brand-surface-subtle)] text-foreground" : undefined
-          )}
-        >
-          <CardContent className="grid gap-12 pt-6 lg:grid-cols-[2fr,3fr] lg:items-start">
-            <div className="space-y-6">
-              <div
-                className={cn(
-                  "space-y-4",
-                  align === "center" ? "text-center" : "text-left"
-                )}
-              >
-                {eyebrow ? (
-                  <p className="text-xs font-semibold uppercase tracking-wide text-primary/80">
-                    {eyebrow}
+    <Section className={className} stack={false}>
+      <Card
+        className={cn(
+          "overflow-hidden border border-border",
+          tone === "subtle" ? "bg-[var(--brand-surface-subtle)] text-foreground" : undefined
+        )}
+      >
+        <CardContent className="grid gap-12 pt-6 lg:grid-cols-[2fr,3fr] lg:items-start">
+          <div className="space-y-6">
+            <div
+              className={cn(
+                "space-y-4",
+                align === "center" ? "text-center" : "text-left"
+              )}
+            >
+              {eyebrow ? (
+                <p className="text-xs font-semibold uppercase tracking-wide text-primary/80">
+                  {eyebrow}
+                </p>
+              ) : null}
+              <div className="space-y-4">
+                <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">{title}</h2>
+                {description ? (
+                  <p
+                    className={cn(
+                      "text-base text-muted-foreground",
+                      align === "center" ? "mx-auto max-w-3xl" : undefined
+                    )}
+                  >
+                    {description}
                   </p>
                 ) : null}
-                <div className="space-y-4">
-                  <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">{title}</h2>
-                  {description ? (
-                    <p
-                      className={cn(
-                        "text-base text-muted-foreground",
-                        align === "center" ? "mx-auto max-w-3xl" : undefined
-                      )}
-                    >
-                      {description}
-                    </p>
-                  ) : null}
-                </div>
               </div>
-              {children}
-              {items && items.length > 0 ? (
-                <ul className="space-y-3 text-sm text-muted-foreground">
-                  {items.map((item, index) => (
-                    <li key={item.id} className="flex gap-3">
-                      <span
-                        className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full"
-                        style={bulletStyles[index % bulletStyles.length]}
-                        aria-hidden="true"
-                      />
-                      <div className="space-y-1">
-                        <p className="font-semibold text-foreground">{item.title}</p>
-                        {item.description ? (
-                          <p className="text-sm text-muted-foreground">{item.description}</p>
-                        ) : null}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
-              {actions ? <div className="flex flex-wrap gap-4">{actions}</div> : null}
             </div>
-            {aside}
-          </CardContent>
-        </Card>
-      </Container>
-    </section>
+            {children}
+            {items && items.length > 0 ? (
+              <ul className="space-y-3 text-sm text-muted-foreground">
+                {items.map((item, index) => (
+                  <li key={item.id} className="flex gap-3">
+                    <span
+                      className="mt-1 inline-flex h-2.5 w-2.5 flex-none rounded-full"
+                      style={bulletStyles[index % bulletStyles.length]}
+                      aria-hidden="true"
+                    />
+                    <div className="space-y-1">
+                      <p className="font-semibold text-foreground">{item.title}</p>
+                      {item.description ? (
+                        <p className="text-sm text-muted-foreground">{item.description}</p>
+                      ) : null}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {actions ? <div className="flex flex-wrap gap-4">{actions}</div> : null}
+          </div>
+          {aside}
+        </CardContent>
+      </Card>
+    </Section>
   );
 }

--- a/packages/ui/src/sections/FeatureGrid.tsx
+++ b/packages/ui/src/sections/FeatureGrid.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Container } from "../Container";
+import { Section } from "../Section";
 import { Card, CardDescription, CardHeader, CardTitle } from "../components/card";
 import { cn } from "../lib/cn";
 
@@ -30,53 +30,49 @@ export function FeatureGrid({
   className,
 }: FeatureGridProps) {
   return (
-    <section className={className}>
-      <Container className="space-y-12">
-        {(eyebrow || title || description) && (
-          <div
-            className={cn(
-              "space-y-4",
-              align === "center" ? "text-center" : "text-left"
-            )}
-          >
-            {eyebrow ? (
-              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
-                {eyebrow}
-              </p>
-            ) : null}
-            {title ? (
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-                {title}
-              </h2>
-            ) : null}
-            {description ? (
-              <p
-                className={cn(
-                  "text-base text-muted-foreground",
-                  align === "center" ? "mx-auto max-w-3xl" : undefined
-                )}
-              >
-                {description}
-              </p>
-            ) : null}
-          </div>
-        )}
-        <div className={cn("grid gap-6", columnsClassName)}>
-          {items.map((item) => (
-            <Card key={item.id} className="h-full">
-              <CardHeader className="h-full gap-3">
-                {item.icon ? (
-                  <div className="text-primary" aria-hidden="true">
-                    {item.icon}
-                  </div>
-                ) : null}
-                <CardTitle className="text-xl">{item.title}</CardTitle>
-                <CardDescription>{item.description}</CardDescription>
-              </CardHeader>
-            </Card>
-          ))}
+    <Section
+      className={className}
+      contentClassName={cn(align === "center" ? "text-center" : "text-left")}
+    >
+      {(eyebrow || title || description) && (
+        <div className="space-y-4">
+          {eyebrow ? (
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+              {eyebrow}
+            </p>
+          ) : null}
+          {title ? (
+            <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+              {title}
+            </h2>
+          ) : null}
+          {description ? (
+            <p
+              className={cn(
+                "text-base text-muted-foreground",
+                align === "center" ? "mx-auto max-w-3xl" : undefined
+              )}
+            >
+              {description}
+            </p>
+          ) : null}
         </div>
-      </Container>
-    </section>
+      )}
+      <div className={cn("grid gap-6", columnsClassName)}>
+        {items.map((item) => (
+          <Card key={item.id} className="h-full">
+            <CardHeader className="h-full gap-3">
+              {item.icon ? (
+                <div className="text-primary" aria-hidden="true">
+                  {item.icon}
+                </div>
+              ) : null}
+              <CardTitle className="text-xl">{item.title}</CardTitle>
+              <CardDescription>{item.description}</CardDescription>
+            </CardHeader>
+          </Card>
+        ))}
+      </div>
+    </Section>
   );
 }

--- a/packages/ui/src/sections/Hero.tsx
+++ b/packages/ui/src/sections/Hero.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Container } from "../Container";
+import { Section } from "../Section";
 import { cn } from "../lib/cn";
 
 export type HeroProps = {
@@ -29,37 +29,42 @@ export function Hero({
   className,
 }: HeroProps) {
   return (
-    <section className={cn(variantClassNames[variant], className)}>
-      <Container
-        className={cn(
-          "max-w-4xl py-16",
-          align === "center" ? "text-center" : "text-left"
-        )}
-      >
+    <Section
+      className={cn(variantClassNames[variant], className)}
+      contentClassName={cn("max-w-4xl", align === "center" ? "text-center" : "text-left")}
+    >
+      <div className="space-y-6">
         {eyebrow ? (
           <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
             {eyebrow}
           </p>
         ) : null}
-        <h1
-          className={cn(
-            "mt-4 text-4xl font-semibold tracking-tight sm:text-5xl",
-            align === "center" ? "mx-auto" : undefined
-          )}
-        >
-          {title}
-        </h1>
-        {description ? (
-          <p className={cn("mt-6 text-lg text-muted-foreground", align === "center" ? "mx-auto max-w-3xl" : undefined)}>
-            {description}
-          </p>
-        ) : null}
-        {actions ? (
-          <div className={cn("mt-8 flex flex-wrap gap-4", align === "center" ? "justify-center" : "justify-start")}>
-            {actions}
-          </div>
-        ) : null}
-      </Container>
-    </section>
+        <div className="space-y-6">
+          <h1
+            className={cn(
+              "text-4xl font-semibold tracking-tight sm:text-5xl",
+              align === "center" ? "mx-auto" : undefined
+            )}
+          >
+            {title}
+          </h1>
+          {description ? (
+            <p
+              className={cn(
+                "text-lg text-muted-foreground",
+                align === "center" ? "mx-auto max-w-3xl" : undefined
+              )}
+            >
+              {description}
+            </p>
+          ) : null}
+        </div>
+      </div>
+      {actions ? (
+        <div className={cn("flex flex-wrap gap-4", align === "center" ? "justify-center" : "justify-start")}>
+          {actions}
+        </div>
+      ) : null}
+    </Section>
   );
 }

--- a/packages/ui/src/sections/LogoCloud.tsx
+++ b/packages/ui/src/sections/LogoCloud.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Container } from "../Container";
+import { Section } from "../Section";
 import { Card, CardContent } from "../components/card";
 import { cn } from "../lib/cn";
 
@@ -27,50 +27,46 @@ export function LogoCloud({
   className,
 }: LogoCloudProps) {
   return (
-    <section className={className}>
-      <Container
-        className={cn(
-          "space-y-8",
-          align === "center" ? "text-center" : "text-left"
-        )}
-      >
-        {(eyebrow || title || description) && (
-          <div className="space-y-4">
-            {eyebrow ? (
-              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
-                {eyebrow}
-              </p>
-            ) : null}
-            {title ? (
-              <h2 className="text-3xl font-semibold text-foreground">
-                {title}
-              </h2>
-            ) : null}
-            {description ? (
-              <p
-                className={cn(
-                  "text-base text-muted-foreground",
-                  align === "center" ? "mx-auto max-w-3xl" : undefined
-                )}
-              >
-                {description}
-              </p>
-            ) : null}
-          </div>
-        )}
-        <div className="flex flex-wrap items-center justify-center gap-6">
-          {items.map((item) => (
-            <Card key={item.id} className="h-16 w-40 border-dashed bg-background shadow-none">
-              <CardContent className="flex h-full items-center justify-center p-4 text-muted-foreground">
-                <span className="sr-only">{item.name}</span>
-                <div aria-hidden="true" className="flex items-center justify-center text-foreground/90">
-                  {item.logo}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+    <Section
+      className={className}
+      contentClassName={cn(align === "center" ? "text-center" : "text-left")}
+    >
+      {(eyebrow || title || description) && (
+        <div className="space-y-4">
+          {eyebrow ? (
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+              {eyebrow}
+            </p>
+          ) : null}
+          {title ? (
+            <h2 className="text-3xl font-semibold text-foreground">
+              {title}
+            </h2>
+          ) : null}
+          {description ? (
+            <p
+              className={cn(
+                "text-base text-muted-foreground",
+                align === "center" ? "mx-auto max-w-3xl" : undefined
+              )}
+            >
+              {description}
+            </p>
+          ) : null}
         </div>
-      </Container>
-    </section>
+      )}
+      <div className="flex flex-wrap items-center justify-center gap-6">
+        {items.map((item) => (
+          <Card key={item.id} className="h-16 w-40 border-dashed bg-background shadow-none">
+            <CardContent className="flex h-full items-center justify-center p-4 text-muted-foreground">
+              <span className="sr-only">{item.name}</span>
+              <div aria-hidden="true" className="flex items-center justify-center text-foreground/90">
+                {item.logo}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </Section>
   );
 }

--- a/packages/ui/src/sections/TestimonialWall.tsx
+++ b/packages/ui/src/sections/TestimonialWall.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Container } from "../Container";
+import { Section } from "../Section";
 import { Card, CardContent } from "../components/card";
 import { cn } from "../lib/cn";
 
@@ -65,39 +65,35 @@ export function TestimonialWall({
   }
 
   return (
-    <section className={className}>
-      <Container className="space-y-12">
-        {(eyebrow || title || description) && (
-          <div
-            className={cn(
-              "space-y-4",
-              align === "center" ? "text-center" : "text-left"
-            )}
-          >
-            {eyebrow ? (
-              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
-                {eyebrow}
-              </p>
-            ) : null}
-            {title ? (
-              <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
-                {title}
-              </h2>
-            ) : null}
-            {description ? (
-              <p
-                className={cn(
-                  "text-base text-muted-foreground",
-                  align === "center" ? "mx-auto max-w-3xl" : undefined
-                )}
-              >
-                {description}
-              </p>
-            ) : null}
-          </div>
-        )}
-        {grid}
-      </Container>
-    </section>
+    <Section
+      className={className}
+      contentClassName={cn(align === "center" ? "text-center" : "text-left")}
+    >
+      {(eyebrow || title || description) && (
+        <div className="space-y-4">
+          {eyebrow ? (
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+              {eyebrow}
+            </p>
+          ) : null}
+          {title ? (
+            <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+              {title}
+            </h2>
+          ) : null}
+          {description ? (
+            <p
+              className={cn(
+                "text-base text-muted-foreground",
+                align === "center" ? "mx-auto max-w-3xl" : undefined
+              )}
+            >
+              {description}
+            </p>
+          ) : null}
+        </div>
+      )}
+      {grid}
+    </Section>
   );
 }

--- a/packages/ui/styles/tokens.css
+++ b/packages/ui/styles/tokens.css
@@ -1,4 +1,5 @@
 @import "@airnub/brand/runtime/tokens.css";
+@import "@airnub/brand/runtime/layout.css";
 
 :root {
   --brand-background: var(--brand-color-background, #ffffff);

--- a/packages/ui/tailwind-preset.ts
+++ b/packages/ui/tailwind-preset.ts
@@ -87,6 +87,11 @@ const preset = {
           "monospace",
         ],
       },
+      spacing: {
+        "section-sm": "var(--section-gap-sm)",
+        "section-md": "var(--section-gap-md)",
+        "section-lg": "var(--section-gap-lg)",
+      },
       boxShadow: {
         card: "0 1px 2px rgba(0,0,0,.05)",
       },


### PR DESCRIPTION
## Summary
- add responsive section spacing tokens and export them through the Tailwind preset
- introduce a reusable <Section> wrapper and migrate shared sections to use it
- rely on the new layout utilities across both home pages for consistent vertical rhythm

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68db116eca4083249d28b2d7fbd8310e