### PR TITLE
docs: clarify branding workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,34 +35,62 @@ See [Architecture & Rendering](https://airnub.github.io/airnub-site/docs/archite
 
 `pnpm dev` launches both apps in parallel. Use `pnpm --filter ./apps/airnub dev` or `pnpm --filter ./apps/speckit dev` to run a single app.
 
-## Brand assets & overrides
+## 🎨 Branding & Rebranding
 
-Canonical brand assets live in [`.brand/public/brand/`](.brand/public/brand/), while the shared TypeScript config stays in [`packages/brand/src/brand.config.ts`](packages/brand/src/brand.config.ts). Running the sync script copies the assets into each app's `public/brand/` directory and regenerates runtime-friendly files in [`packages/brand/runtime/`](packages/brand/runtime/).
+Both marketing apps share a single brand pack so forks only have to update one place.
 
-After editing anything under `.brand/` (images or supporting files), run:
+- **Source of truth (editable assets):** [`.brand/public/brand/`](.brand/public/brand/)
+- **Runtime package:** [`packages/brand/`](packages/brand/) (ships config, CSS tokens, OG template, and navigation JSON)
+- **Shared UI chrome:** [`packages/ui/`](packages/ui/) (headers, footers, cards, etc.)
 
-```bash
-pnpm brand:sync
-```
+### Quick rebrand checklist
 
-This command will:
+1. Replace the assets in `.brand/public/brand/` with your own:
+   - `logo.svg` (light/primary lockup)
+   - `logo-dark.svg` (dark theme lockup)
+   - `logo-mark.svg` (square mark)
+   - `favicon.svg`
+   - `og.png` (Open Graph / social background)
+2. (Optional) Configure environment overrides for metadata and colors before building:
+   ```bash
+   export BRAND_NAME="YourCo"
+   export BRAND_DOMAIN="yourco.example"
+   export BRAND_DESCRIPTION="Your product tagline"
+   export BRAND_COLOR_PRIMARY="#2563eb"
+   export BRAND_COLOR_SECONDARY="#0f172a"
+   export BRAND_COLOR_ACCENT="#1d4ed8"
+   export BRAND_COLOR_BACKGROUND="#ffffff"
+   export BRAND_COLOR_FOREGROUND="#111827"
+   export BRAND_LOGO_LIGHT="/brand/logo.svg"
+   export BRAND_LOGO_DARK="/brand/logo-dark.svg"
+   export BRAND_LOGO_MARK="/brand/logo-mark.svg"
+   export BRAND_FAVICON="/brand/favicon.svg"
+   export BRAND_OG="/brand/og.png"
+   export BRAND_SOCIAL_GITHUB="https://github.com/yourco"
+   export BRAND_CONTACT_SUPPORT="support@yourco.example"
+   ```
+   Any `BRAND_SOCIAL_*` or `BRAND_CONTACT_*` variable is camel-cased into the runtime config (for example `BRAND_SOCIAL_PRODUCT_HUNT` → `productHunt`).
+3. Run the sync script so both apps pick up the new pack and regenerated runtime files:
+   ```bash
+   pnpm brand:sync
+   ```
+4. Build or start your apps as usual (`pnpm -w build` or `pnpm dev`). No per-app asset edits are required.
 
-- Copy `.brand/public/brand/` into `packages/brand/public/brand/` and both apps' `public/brand/` folders so `/brand/*` requests resolve everywhere.
-- Regenerate `packages/brand/runtime/brand.config.json` and `packages/brand/runtime/tokens.css` so runtime code and CSS can safely consume the shared brand tokens without bundling TypeScript.
+The sync script copies `.brand/public/brand/` into `packages/brand/public/brand/` and each app's `public/brand/` directory, then regenerates:
 
-If you need to tweak metadata (name, colors, social links, etc.), you can either edit [`packages/brand/src/brand.config.ts`](packages/brand/src/brand.config.ts) directly or provide environment overrides before running the sync script. Supported variables include:
+- [`packages/brand/runtime/brand.config.json`](packages/brand/runtime/brand.config.json)
+- [`packages/brand/runtime/tokens.css`](packages/brand/runtime/tokens.css)
+- [`packages/brand/runtime/tokens-speckit.css`](packages/brand/runtime/tokens-speckit.css)
+- [`packages/brand/runtime/navigation.json`](packages/brand/runtime/navigation.json)
 
-- `BRAND_NAME`, `BRAND_DOMAIN`, `BRAND_DESCRIPTION`
-- `BRAND_COLOR_PRIMARY`, `BRAND_COLOR_SECONDARY`, `BRAND_COLOR_ACCENT`, `BRAND_COLOR_BACKGROUND`, `BRAND_COLOR_FOREGROUND`
-- `BRAND_LOGO_LIGHT`, `BRAND_LOGO_DARK`, `BRAND_LOGO_MARK`
-- `BRAND_FAVICON`, `BRAND_OG`
-- `BRAND_SOCIAL_*` (e.g., `BRAND_SOCIAL_GITHUB`, `BRAND_SOCIAL_LINKEDIN`, `BRAND_SOCIAL_PRODUCT_HUNT`)
+Apps import the CSS tokens in `app/layout.tsx` and delegate their Open Graph image + favicons to `@airnub/brand`, so rebrands propagate automatically.
 
-After updating any of these values, re-run `pnpm brand:sync` so the runtime outputs stay fresh.
+Forks that want to diverge from the default brand can commit their own `.brand/public/brand/` assets, set the appropriate `BRAND_*` environment variables in CI/deploy, and run `pnpm brand:sync` during the build pipeline.
 
 ## Additional documentation
 
 - [Architecture & Rendering](https://airnub.github.io/airnub-site/docs/architecture) ([local](docs/docs/architecture.md))
+- [Branding & Rebranding](https://airnub.github.io/airnub-site/docs/branding) ([local](docs/docs/branding.md))
 - [Supabase Guide](https://airnub.github.io/airnub-site/docs/supabase) ([local](docs/docs/supabase.md))
 - [Local Development](https://airnub.github.io/airnub-site/docs/development) ([local](docs/docs/development.md))
 - [CI & Contribution Workflow](https://airnub.github.io/airnub-site/docs/ci) ([local](docs/docs/ci.md))

--- a/docs/docs/branding.md
+++ b/docs/docs/branding.md
@@ -1,0 +1,103 @@
+---
+id: branding
+title: Branding, Theming & Rebranding
+sidebar_position: 0
+---
+
+# Branding, Theming & Rebranding
+
+The Airnub monorepo uses a central brand pack so both marketing apps stay in sync and forks can apply a new identity without touching application code.
+
+## Goals
+
+- **Single source of truth** for logos, colors, navigation, and metadata
+- **Shared UI chrome** (headers, footers, cards) powered by `@airnub/ui`
+- **No per-app overrides**—every app imports the same runtime tokens
+- **Fork-friendly** so swapping assets + environment variables triggers a full rebrand
+
+## Overview
+
+| Piece | Location | Purpose |
+| --- | --- | --- |
+| Editable assets | `.brand/public/brand/` | Drop-in SVG/PNG source files committed by each fork |
+| Brand package | `packages/brand/` | Exposes config, CSS tokens, OG template, navigation |
+| Runtime tokens | `packages/brand/runtime/` | Generated CSS + JSON consumed at build/runtime |
+| Shared UI | `packages/ui/` | Header, footer, cards, and other brand-aware components |
+| Apps | `apps/airnub`, `apps/speckit` | Import tokens and shared chrome automatically |
+
+## Rebrand checklist
+
+1. Replace the assets inside `.brand/public/brand/`:
+   - `logo.svg`
+   - `logo-dark.svg`
+   - `logo-mark.svg`
+   - `favicon.svg`
+   - `og.png`
+2. (Optional) Export environment overrides so metadata and colors update along with the imagery:
+   ```bash
+   export BRAND_NAME="YourCo"
+   export BRAND_DOMAIN="yourco.example"
+   export BRAND_DESCRIPTION="Your product tagline"
+   export BRAND_COLOR_PRIMARY="#2563eb"
+   export BRAND_COLOR_SECONDARY="#0f172a"
+   export BRAND_COLOR_ACCENT="#1d4ed8"
+   export BRAND_COLOR_BACKGROUND="#ffffff"
+   export BRAND_COLOR_FOREGROUND="#111827"
+   export BRAND_LOGO_LIGHT="/brand/logo.svg"
+   export BRAND_LOGO_DARK="/brand/logo-dark.svg"
+   export BRAND_LOGO_MARK="/brand/logo-mark.svg"
+   export BRAND_FAVICON="/brand/favicon.svg"
+   export BRAND_OG="/brand/og.png"
+   export BRAND_SOCIAL_GITHUB="https://github.com/yourco"
+   export BRAND_CONTACT_SUPPORT="support@yourco.example"
+   ```
+   - Any `BRAND_SOCIAL_*` or `BRAND_CONTACT_*` variable is camel-cased into the runtime JSON (for example `BRAND_SOCIAL_PRODUCT_HUNT` → `productHunt`).
+   - Leave variables unset to fall back to the defaults defined in [`packages/brand/src/brand.config.ts`](../../packages/brand/src/brand.config.ts).
+3. Regenerate the runtime artifacts:
+   ```bash
+   pnpm brand:sync
+   ```
+4. Build or start your apps (`pnpm -w build`, `pnpm dev`). Both apps import the refreshed tokens and assets automatically.
+
+## How the sync script works
+
+```mermaid
+flowchart LR
+  A[.brand/public/brand/*] -- pnpm brand:sync --> B[packages/brand/public/brand/*]
+  A -- pnpm brand:sync --> C[apps/*/public/brand/*]
+  B -- tokens.json/css --> D[@airnub/brand runtime/*]
+  D --> E[apps import tokens.css + OG template]
+  D --> F[@airnub/ui consumes navigation]
+```
+
+- `packages/brand/runtime/brand.config.json` stores the resolved metadata (including env overrides).
+- `packages/brand/runtime/tokens.css` exposes CSS variables for both apps.
+- `packages/brand/runtime/tokens-speckit.css` contains Speckit-specific tweaks that components import as needed.
+- `packages/brand/runtime/navigation.json` keeps header/footer navigation consistent.
+
+## Where the apps hook in
+
+- `apps/*/app/layout.tsx` imports `@airnub/brand/runtime/tokens.css`.
+- `apps/*/app/opengraph-image.tsx` re-exports `@airnub/brand/og/template`.
+- `apps/*/app/icon.tsx` loads `/brand/favicon.svg`.
+- `@airnub/ui` components load navigation data from the runtime JSON.
+
+Because every app reads from the same runtime outputs, you should **not** keep brand assets or duplicated CSS in app directories (except the generated `public/brand/` copies that the sync script writes).
+
+## Forking guidelines
+
+- Commit your new assets under `.brand/public/brand/` so downstream forks inherit your defaults.
+- Run `pnpm brand:sync` during CI/CD before building apps to guarantee runtime files are fresh.
+- Avoid hard-coding colors or image paths in new components—prefer the CSS variables and public URLs produced by the brand package.
+- If one fork needs a different theme per app, export different `BRAND_*` env vars per deployment target.
+
+## Troubleshooting
+
+| Issue | Fix |
+| --- | --- |
+| Logos did not update | Confirm you replaced files in `.brand/public/brand/` **and** ran `pnpm brand:sync`. Check that your build pipeline runs the sync before Next.js compiles. |
+| Colors still default | Ensure the `BRAND_COLOR_*` env vars are available at build time (not just runtime). Remove stale caches in `.next/` if developing locally. |
+| OG image stale | Make sure `app/opengraph-image.tsx` re-exports the template from `@airnub/brand/og/template`. Delete `.next/cache` when testing locally. |
+| Unexpected navigation links | Update `airnubNavigation` / `speckitNavigation` in [`packages/brand/src/index.ts`](../../packages/brand/src/index.ts) and re-run the sync. |
+
+For more detail, refer back to the root [`README.md`](../../README.md#-branding--rebranding) or the package-level [`README`](../../packages/brand/README.md).

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -4,6 +4,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
   tutorialSidebar: [
+    'branding',
     'architecture',
     'development',
     'supabase',

--- a/packages/brand/README.md
+++ b/packages/brand/README.md
@@ -1,0 +1,80 @@
+# @airnub/brand — Central Brand Pack
+
+This package is the single source of truth for logos, colors, navigation, and metadata that the Airnub and Speckit apps share.
+
+- Assets originate from [`.brand/public/brand/`](../../.brand/public/brand/)
+- Runtime outputs live under [`packages/brand/runtime/`](./runtime/)
+- UI chrome consumes the tokens via [`packages/ui/`](../ui/)
+
+Running `pnpm brand:sync` copies the source assets into this package, pushes them into each app, and regenerates the runtime files described below.
+
+## How the sync pipeline works
+
+```
+.brand/public/brand/*      # editable assets committed by each fork
+          │
+          ├─ pnpm brand:sync → packages/brand/public/brand/*
+          │                     packages/brand/runtime/brand.config.json
+          │                     packages/brand/runtime/tokens.css
+          │                     packages/brand/runtime/tokens-speckit.css
+          │                     packages/brand/runtime/navigation.json
+          └─ pnpm brand:sync → apps/airnub/public/brand/*
+                                apps/speckit/public/brand/*
+```
+
+- `brand.config.json` — resolved metadata + colors (includes environment overrides)
+- `tokens.css` — CSS variables consumed by both apps
+- `tokens-speckit.css` — Speckit-specific overrides loaded where needed
+- `navigation.json` — shared navigation definitions for headers/footers
+
+## Rebranding in three steps
+
+1. Swap the assets inside `.brand/public/brand/`:
+   - `logo.svg`
+   - `logo-dark.svg`
+   - `logo-mark.svg`
+   - `favicon.svg`
+   - `og.png`
+2. (Optional) Set environment variables before running the sync so metadata and colors follow suit:
+   ```bash
+   export BRAND_NAME="YourCo"
+   export BRAND_DOMAIN="yourco.example"
+   export BRAND_DESCRIPTION="Your product tagline"
+   export BRAND_COLOR_PRIMARY="#2563eb"
+   export BRAND_COLOR_SECONDARY="#0f172a"
+   export BRAND_COLOR_ACCENT="#1d4ed8"
+   export BRAND_COLOR_BACKGROUND="#ffffff"
+   export BRAND_COLOR_FOREGROUND="#111827"
+   export BRAND_LOGO_LIGHT="/brand/logo.svg"
+   export BRAND_LOGO_DARK="/brand/logo-dark.svg"
+   export BRAND_LOGO_MARK="/brand/logo-mark.svg"
+   export BRAND_FAVICON="/brand/favicon.svg"
+   export BRAND_OG="/brand/og.png"
+   export BRAND_SOCIAL_GITHUB="https://github.com/yourco"
+   export BRAND_CONTACT_SUPPORT="support@yourco.example"
+   ```
+   Any `BRAND_SOCIAL_*` or `BRAND_CONTACT_*` variable is camel-cased into the final JSON (`BRAND_SOCIAL_PRODUCT_HUNT` → `productHunt`).
+3. Run the sync:
+   ```bash
+   pnpm brand:sync
+   ```
+
+Both apps will now pick up the new assets and tokens without touching their own `public/` folders. Build or start dev servers as normal (`pnpm -w build`, `pnpm dev`).
+
+## Consuming the brand package
+
+- Apps import CSS variables from `@airnub/brand/runtime/tokens.css`
+- Speckit can opt into `@airnub/brand/runtime/tokens-speckit.css` for its accent tweaks
+- OG images are defined in `og/template.tsx` and re-exported by `apps/*/app/opengraph-image.tsx`
+- `@airnub/ui` pulls navigation items from `runtime/navigation.json`
+
+If you need to override values programmatically, use `resolveBrandConfig` from [`src/brand.config.ts`](./src/brand.config.ts).
+
+## Guardrails for forks
+
+- Keep every brand asset in `.brand/public/brand/`
+- Avoid hard-coding hex colors; consume the CSS custom properties instead
+- Regenerate runtime files by running `pnpm brand:sync` in CI before building apps
+- Commit regenerated assets when they change so downstream forks have the latest baseline
+
+Need more context? The root [`README.md`](../../README.md#-branding--rebranding) and [`docs/docs/branding.md`](../../docs/docs/branding.md) walk through the full pipeline with diagrams and troubleshooting tips.


### PR DESCRIPTION
## Summary
- expand the root README with a detailed rebranding checklist and environment overrides
- document the brand package pipeline and fork workflow inside packages/brand and docs site
- add the new branding guide to the Docusaurus sidebar for quick discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68dc0f4f613c8324bae3942fc2fa3d36