### PR TITLE
docs: add brand quickstart and ui validation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [Architecture & Rendering](https://airnub.github.io/airnub-site/docs/archite
 
 ## 🎨 Branding & Rebranding
 
-Both marketing apps share a single brand pack so forks only have to update one place.
+Both marketing apps share a single brand pack so forks only have to update one place. Need the condensed playbook? Jump to the [Brand Pack Quickstart](packages/brand/QUICKSTART.md).
 
 - **Source of truth (editable assets):** [`.brand/public/brand/`](.brand/public/brand/)
 - **Runtime package:** [`packages/brand/`](packages/brand/) (ships config, CSS tokens, TypeScript navigation, and the static OG image helper)
@@ -93,6 +93,7 @@ Forks that want to diverge from the default brand can commit their own `.brand/p
 
 - [Architecture & Rendering](https://airnub.github.io/airnub-site/docs/architecture) ([local](docs/docs/architecture.md))
 - [Branding & Rebranding](https://airnub.github.io/airnub-site/docs/branding) ([local](docs/docs/branding.md))
+- [Brand Pack Quickstart](packages/brand/QUICKSTART.md)
 - [Supabase Guide](https://airnub.github.io/airnub-site/docs/supabase) ([local](docs/docs/supabase.md))
 - [Local Development](https://airnub.github.io/airnub-site/docs/development) ([local](docs/docs/development.md))
 - [CI & Contribution Workflow](https://airnub.github.io/airnub-site/docs/ci) ([local](docs/docs/ci.md))
@@ -100,7 +101,7 @@ Forks that want to diverge from the default brand can commit their own `.brand/p
 
 ## Contributing
 
-Follow Conventional Commits (`feat:`, `fix:`, `docs:` …) and keep secrets out of the repository. See the [CI & Contribution Workflow](./docs/ci.md) for enforcement details.
+Follow Conventional Commits (`feat:`, `fix:`, `docs:` …) and keep secrets out of the repository. See the [CI & Contribution Workflow](docs/docs/ci.md) for enforcement details.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "docs:dev": "pnpm --filter docs start",
     "docs:build": "pnpm --filter docs build",
     "docs:deploy": "pnpm --filter docs deploy",
-    "lint:dark": "grep -R --line-number --color=always 'dark:' apps packages || true"
+    "lint:dark": "grep -R --line-number --color=always 'dark:' apps packages || true",
+    "validate:ui": "bash scripts/validate-ui.sh"
   },
   "devDependencies": {
     "@types/react": "^19.1.15",

--- a/packages/brand/QUICKSTART.md
+++ b/packages/brand/QUICKSTART.md
@@ -1,0 +1,80 @@
+# Brand Pack Quickstart
+
+This guide walks you through the minimal set of steps required to restyle the marketing sites with a new brand pack.
+
+## 1. Adjust the shared `theme.css`
+
+Both apps import the shared theme layer from `@airnub/ui/styles.css`. That file serves as our canonical `theme.css` and is responsible for exposing CSS custom properties (`--background`, `--primary`, and so on) that the component library consumes.
+
+1. Open [`packages/ui/styles.css`](../ui/styles.css).
+2. Update the CSS variables or Tailwind utility layers you need (for example, adjust `--radius` or override semantic colors).
+3. Keep the variables mapped to the brand token fallbacks (for example, `var(--brand-primary)`) so deployments that rely on environment overrides continue to work.
+4. Commit the changes so downstream forks pick up your new `theme.css` definition.
+
+If you need to tweak spacing or layout primitives, edit [`packages/brand/runtime/layout.css`](./runtime/layout.css); it is imported by `styles.css` alongside the tokens and behaves like an extended `theme.css` layer.
+
+## 2. Swap brand assets
+
+The editable source assets live in [`.brand/public/brand/`](../../.brand/public/brand/). Replace the contents of that folder with your logo set:
+
+- `logo.svg`
+- `logo-dark.svg`
+- `logo-mark.svg`
+- `favicon.svg`
+- `og.png`
+
+Keep filenames consistent—`pnpm brand:sync` expects those exact names.
+
+## 3. Edit navigation definitions
+
+Update [`packages/brand/src/navigation.ts`](./src/navigation.ts) if the information architecture changes. Both apps read the strongly typed navigation trees defined there, so adjusting a link in this file automatically updates the shared headers and footers.
+
+- Update the Airnub tree exported as `airnubNavigation`.
+- Update the Speckit tree exported as `speckitNavigation`.
+- Preserve the shape (`title`, `href`, `children`) so the apps stay type-safe.
+
+## 4. Apply environment overrides (optional)
+
+Set environment variables before running the sync if you need to override colors, metadata, or social links at build time:
+
+```bash
+export BRAND_NAME="YourCo"
+export BRAND_DOMAIN="yourco.example"
+export BRAND_DESCRIPTION="Your product tagline"
+export BRAND_COLOR_PRIMARY="#2563eb"
+export BRAND_COLOR_SECONDARY="#0f172a"
+export BRAND_COLOR_ACCENT="#1d4ed8"
+export BRAND_COLOR_BACKGROUND="#ffffff"
+export BRAND_COLOR_FOREGROUND="#111827"
+export BRAND_LOGO_LIGHT="/brand/logo.svg"
+export BRAND_LOGO_DARK="/brand/logo-dark.svg"
+export BRAND_LOGO_MARK="/brand/logo-mark.svg"
+export BRAND_FAVICON="/brand/favicon.svg"
+export BRAND_OG="/brand/og.png"
+export BRAND_SOCIAL_GITHUB="https://github.com/yourco"
+export BRAND_CONTACT_SUPPORT="support@yourco.example"
+```
+
+Any `BRAND_SOCIAL_*` or `BRAND_CONTACT_*` variable is camel-cased in the generated config (for example, `BRAND_SOCIAL_PRODUCT_HUNT` becomes `productHunt`).
+
+## 5. Run the sync
+
+Execute the sync script from the repository root:
+
+```bash
+pnpm brand:sync
+```
+
+The script copies `.brand/public/brand/` into `packages/brand/public/brand/` and each app’s `public/brand/` directory, then regenerates:
+
+- [`packages/brand/runtime/brand.config.json`](./runtime/brand.config.json)
+- [`packages/brand/runtime/tokens.css`](./runtime/tokens.css)
+- [`packages/brand/runtime/tokens-speckit.css`](./runtime/tokens-speckit.css)
+- [`packages/brand/runtime/navigation.json`](./runtime/navigation.json)
+
+## 6. Verify the updates
+
+1. Run `pnpm validate:ui` to ensure no inline colors or rogue `dark:` classes slipped into the UI components.
+2. Start the apps (`pnpm dev`) or build them (`pnpm -w build`) to confirm the new assets, metadata, and navigation render correctly.
+
+That’s it—your updated `theme.css`, assets, and navigation will now flow through both marketing sites.

--- a/scripts/validate-ui.sh
+++ b/scripts/validate-ui.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+TARGETS=(
+  "apps/airnub/app"
+  "apps/airnub/components"
+  "apps/speckit/app"
+  "apps/speckit/components"
+  "packages/ui/providers"
+  "packages/ui/src"
+)
+
+EXCLUDE_DIRS=(
+  --exclude-dir=node_modules
+  --exclude-dir=.next
+  --exclude-dir=dist
+  --exclude-dir=build
+  --exclude-dir=coverage
+)
+
+INLINE_COLOR_PATTERN='#[0-9a-fA-F]\{3,\}'
+
+print_matches() {
+  local header="$1"
+  local matches="$2"
+
+  printf '\n%s\n' "$header"
+  printf '%s\n' "$matches"
+}
+
+run_grep() {
+  local pattern="$1"
+  shift
+  grep -R --line-number --color=never \
+    "${EXCLUDE_DIRS[@]}" \
+    --include='*.tsx' \
+    --include='*.ts' \
+    --include='*.jsx' \
+    --include='*.js' \
+    --include='*.css' \
+    -E "$pattern" \
+    "$@" 2>/dev/null || true
+}
+
+inline_color_matches=$(run_grep "$INLINE_COLOR_PATTERN" "${TARGETS[@]}")
+if [[ -n "$inline_color_matches" ]]; then
+  print_matches "Inline color references detected:" "$inline_color_matches"
+  echo
+  echo "❌ Inline hex colors found. Use CSS variables from @airnub/brand instead."
+  exit 1
+else
+  echo "✅ No inline hex colors found."
+fi
+
+DARK_CLASS_PATTERN='class(Name)?=.*dark:'
+
+dark_class_matches=$(run_grep "$DARK_CLASS_PATTERN" "${TARGETS[@]}")
+if [[ -n "$dark_class_matches" ]]; then
+  print_matches "Tailwind dark: classes detected:" "$dark_class_matches"
+  echo
+  echo "❌ Remove Tailwind dark: variants and rely on the shared theme tokens."
+  exit 1
+else
+  echo "✅ No rogue dark: classes found."
+fi


### PR DESCRIPTION
## Summary
- add a brand pack quickstart guide that covers theme.css updates, asset swaps, navigation edits, and environment overrides
- link the main README to the new quickstart and fix the local CI workflow link
- provide a validate-ui bash script and pnpm task to flag inline colors or rogue dark classes

## Testing
- pnpm validate:ui

------
https://chatgpt.com/codex/tasks/task_e_68dc493cbdf88324a214dec4f8c3d5d6