### PR TITLE
feat(speckit): add contact form feedback loop

### DIFF
--- a/apps/speckit/app/contact/ContactForm.tsx
+++ b/apps/speckit/app/contact/ContactForm.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useActionState, useEffect, useMemo, useRef } from "react";
+import { useFormStatus } from "react-dom";
+import { Button, FormMessage, useToast } from "@airnub/ui";
+import type { LeadFormState } from "./actions";
+
+export type ContactFormLabels = {
+  name: string;
+  email: string;
+  company: string;
+  focus: string;
+  emailRequiredSuffix: string;
+  required: string;
+  submit: string;
+  success: {
+    title: string;
+    description: string;
+  };
+  error: {
+    title: string;
+    description: string;
+  };
+  validation: {
+    email: string;
+  };
+};
+
+type ContactFormProps = {
+  action: (state: LeadFormState, formData: FormData) => Promise<LeadFormState>;
+  initialState: LeadFormState;
+  labels: ContactFormLabels;
+  toastDismissLabel: string;
+};
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} aria-disabled={pending} className="min-w-[10rem] justify-center">
+      {pending ? `${label}…` : label}
+    </Button>
+  );
+}
+
+export function ContactForm({ action, initialState, labels, toastDismissLabel }: ContactFormProps) {
+  const formRef = useRef<HTMLFormElement>(null);
+  const { notify } = useToast();
+  const [state, formAction] = useActionState(action, initialState);
+  const previousStatus = useRef<LeadFormState["status"]>(initialState.status);
+
+  const successTitle = labels.success.title;
+  const successDescription = labels.success.description;
+  const errorTitle = labels.error.title;
+  const errorDescription = labels.error.description;
+  const emailValidationMessage = labels.validation.email;
+
+  useEffect(() => {
+    if (previousStatus.current === state.status) {
+      return;
+    }
+
+    previousStatus.current = state.status;
+
+    if (state.status === "success") {
+      notify({
+        title: successTitle,
+        description: successDescription,
+        variant: "success",
+        closeLabel: toastDismissLabel,
+      });
+      formRef.current?.reset();
+    } else if (state.status === "error") {
+      const description = state.errors?.email ? emailValidationMessage : state.message ?? errorDescription;
+      notify({
+        title: errorTitle,
+        description,
+        variant: "error",
+        closeLabel: toastDismissLabel,
+      });
+    }
+  }, [state, successTitle, successDescription, errorTitle, errorDescription, emailValidationMessage, notify, toastDismissLabel]);
+
+  const emailErrorId = state.errors?.email ? "contact-email-error" : undefined;
+  const emailErrorMessage = useMemo(() => {
+    if (!state.errors?.email) {
+      return undefined;
+    }
+    if (state.errors.email === "validation.email") {
+      return emailValidationMessage;
+    }
+    return errorDescription;
+  }, [state.errors, emailValidationMessage, errorDescription]);
+
+  return (
+    <form ref={formRef} action={formAction} className="space-y-6" noValidate>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div>
+          <label htmlFor="full_name" className="block text-sm font-semibold text-foreground">
+            {labels.name}
+          </label>
+          <input
+            id="full_name"
+            name="full_name"
+            type="text"
+            autoComplete="name"
+            className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block text-sm font-semibold text-foreground">
+            {labels.email}{" "}
+            <span className="text-rose-400" aria-hidden="true">
+              {labels.emailRequiredSuffix}
+            </span>
+            <span className="sr-only">({labels.required})</span>
+          </label>
+          <input
+            id="email"
+            name="email"
+            type="email"
+            required
+            autoComplete="email"
+            aria-describedby={emailErrorId}
+            className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          {emailErrorMessage ? (
+            <FormMessage id={emailErrorId} variant="error" className="mt-3 text-sm font-medium">
+              {emailErrorMessage}
+            </FormMessage>
+          ) : null}
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div>
+          <label htmlFor="company" className="block text-sm font-semibold text-foreground">
+            {labels.company}
+          </label>
+          <input
+            id="company"
+            name="company"
+            type="text"
+            autoComplete="organization"
+            className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+        <div>
+          <label htmlFor="message" className="block text-sm font-semibold text-foreground">
+            {labels.focus}
+          </label>
+          <textarea
+            id="message"
+            name="message"
+            rows={4}
+            className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+      </div>
+      {state.status === "success" ? (
+        <FormMessage variant="success" className="mt-4 text-sm font-medium">
+          {successDescription}
+        </FormMessage>
+      ) : null}
+      {state.status === "error" && !state.errors?.email ? (
+        <FormMessage variant="error" className="mt-4 text-sm font-medium">
+          {state.message ?? errorDescription}
+        </FormMessage>
+      ) : null}
+      <div className="pt-2">
+        <SubmitButton label={labels.submit} />
+      </div>
+    </form>
+  );
+}

--- a/apps/speckit/app/contact/page.tsx
+++ b/apps/speckit/app/contact/page.tsx
@@ -3,8 +3,9 @@ import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Cont
 import { PageHero } from "../../components/PageHero";
 import { getCurrentLanguage } from "../../lib/language";
 import { getSpeckitMessages, type SpeckitMessages } from "../../i18n/messages";
-import { submitLead } from "./actions";
+import { submitLead, type LeadFormState } from "./actions";
 import speckitBrand from "../../brand.config";
+import { ContactForm } from "./ContactForm";
 
 export const dynamic = "force-dynamic";
 
@@ -88,6 +89,30 @@ export default async function ContactPage() {
     speckitBrand.contact.general ??
     speckitBrand.contact.support;
   const securityEmail = speckitBrand.contact.security ?? speckitBrand.contact.general;
+  const initialLeadFormState: LeadFormState = { status: "idle" };
+
+  const errorEmail = productEmail ?? securityEmail ?? undefined;
+  const formattedErrorDescription = errorEmail
+    ? formatTemplate(contact.form.error.description, { email: errorEmail })
+    : contact.form.error.description;
+
+  const formLabels = {
+    name: contact.form.fields.nameLabel,
+    email: contact.form.fields.emailLabel,
+    company: contact.form.fields.companyLabel,
+    focus: contact.form.fields.focusLabel,
+    emailRequiredSuffix: contact.form.fields.emailRequiredSuffix,
+    required: contact.form.requiredLabel,
+    submit: contact.form.submitLabel,
+    success: contact.form.success,
+    error: {
+      title: contact.form.error.title,
+      description: formattedErrorDescription,
+    },
+    validation: contact.form.validation,
+  };
+
+  const toastDismissLabel = contact.form.toastDismissLabel;
 
   return (
     <div className="space-y-16 pb-20">
@@ -105,62 +130,12 @@ export default async function ContactPage() {
               <CardDescription className="text-sm text-muted-foreground">{contact.form.description}</CardDescription>
             </CardHeader>
             <CardContent>
-              <form action={submitLead} className="space-y-6">
-                <div className="grid gap-6 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="full_name" className="block text-sm font-semibold text-foreground">
-                      {contact.form.fields.nameLabel}
-                    </label>
-                    <input
-                      id="full_name"
-                      name="full_name"
-                      type="text"
-                      autoComplete="name"
-                      className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="email" className="block text-sm font-semibold text-foreground">
-                      {contact.form.fields.emailLabel}{" "}
-                      <span className="text-rose-400">{contact.form.fields.emailRequiredSuffix}</span>
-                    </label>
-                    <input
-                      id="email"
-                      name="email"
-                      type="email"
-                      required
-                      autoComplete="email"
-                      className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                  </div>
-                </div>
-                <div className="grid gap-6 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="company" className="block text-sm font-semibold text-foreground">
-                      {contact.form.fields.companyLabel}
-                    </label>
-                    <input
-                      id="company"
-                      name="company"
-                      type="text"
-                      autoComplete="organization"
-                      className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="message" className="block text-sm font-semibold text-foreground">
-                      {contact.form.fields.focusLabel}
-                    </label>
-                    <textarea
-                      id="message"
-                      name="message"
-                      rows={4}
-                      className="mt-2 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm text-foreground shadow-sm placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring"
-                    />
-                  </div>
-                </div>
-                <Button type="submit">{contact.form.submitLabel}</Button>
-              </form>
+              <ContactForm
+                action={submitLead}
+                initialState={initialLeadFormState}
+                labels={formLabels}
+                toastDismissLabel={toastDismissLabel}
+              />
             </CardContent>
           </Card>
           <ContactShortcuts

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -7,6 +7,7 @@ import {
   BrandProvider,
   ThemeProvider,
   ThemeToggle,
+  ToastProvider,
   type FooterColumn,
   type NavItem,
   GithubIcon,
@@ -181,7 +182,8 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       <body className="flex min-h-screen flex-col">
         <BrandProvider value={speckitBrand}>
           <ThemeProvider>
-            <ActiveSiteShell
+            <ToastProvider>
+              <ActiveSiteShell
               skipToContentLabel={layoutMessages.skipToContent}
               navItems={navItems}
               homeHref="/"
@@ -213,7 +215,8 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
               footerCopyright={`© ${year} ${speckitBrand.name}. All rights reserved.`}
             >
               {children}
-            </ActiveSiteShell>
+              </ActiveSiteShell>
+            </ToastProvider>
           </ThemeProvider>
         </BrandProvider>
       </body>

--- a/apps/speckit/i18n/messages.ts
+++ b/apps/speckit/i18n/messages.ts
@@ -133,6 +133,19 @@ type ContactMessages = {
     title: string;
     description: string;
     submitLabel: string;
+    requiredLabel: string;
+    success: {
+      title: string;
+      description: string;
+    };
+    error: {
+      title: string;
+      description: string;
+    };
+    validation: {
+      email: string;
+    };
+    toastDismissLabel: string;
     fields: {
       nameLabel: string;
       emailLabel: string;

--- a/apps/speckit/messages/de.json
+++ b/apps/speckit/messages/de.json
@@ -380,7 +380,20 @@
         "emailRequiredSuffix": "*",
         "companyLabel": "Unternehmen",
         "focusLabel": "Worauf sollten wir uns konzentrieren?"
-      }
+      },
+      "requiredLabel": "Erforderlich",
+      "success": {
+        "title": "Anfrage erhalten",
+        "description": "Danke für Ihre Nachricht. Wir melden uns innerhalb eines Werktags."
+      },
+      "error": {
+        "title": "Ihre Anfrage konnte nicht gesendet werden",
+        "description": "Bitte versuchen Sie es erneut oder schreiben Sie uns an {email}."
+      },
+      "validation": {
+        "email": "Bitte geben Sie eine gültige geschäftliche E-Mail-Adresse ein."
+      },
+      "toastDismissLabel": "Schließen"
     },
     "shortcuts": {
       "emailHeading": "E-Mail",

--- a/apps/speckit/messages/en-GB.json
+++ b/apps/speckit/messages/en-GB.json
@@ -374,6 +374,19 @@
       "title": "Request a demo",
       "description": "Tell us about your environment and target launch timeline.",
       "submitLabel": "Request demo",
+      "requiredLabel": "required",
+      "success": {
+        "title": "Request received",
+        "description": "Thanks for reaching out. We'll respond within one business day."
+      },
+      "error": {
+        "title": "We couldn't send your request",
+        "description": "Please try again or email us at {email}."
+      },
+      "validation": {
+        "email": "Enter a valid work email to continue."
+      },
+      "toastDismissLabel": "Dismiss",
       "fields": {
         "nameLabel": "Full name",
         "emailLabel": "Work email",

--- a/apps/speckit/messages/en-US.json
+++ b/apps/speckit/messages/en-US.json
@@ -374,6 +374,19 @@
       "title": "Request a demo",
       "description": "Tell us about your environment and target launch timeline.",
       "submitLabel": "Request demo",
+      "requiredLabel": "required",
+      "success": {
+        "title": "Request received",
+        "description": "Thanks for reaching out. We'll respond within one business day."
+      },
+      "error": {
+        "title": "We couldn't send your request",
+        "description": "Please try again or email us at {email}."
+      },
+      "validation": {
+        "email": "Enter a valid work email to continue."
+      },
+      "toastDismissLabel": "Dismiss",
       "fields": {
         "nameLabel": "Full name",
         "emailLabel": "Work email",

--- a/apps/speckit/messages/es.json
+++ b/apps/speckit/messages/es.json
@@ -380,7 +380,20 @@
         "emailRequiredSuffix": "*",
         "companyLabel": "Compañía",
         "focusLabel": "¿En qué debemos centrarnos?"
-      }
+      },
+      "requiredLabel": "Obligatorio",
+      "success": {
+        "title": "Solicitud recibida",
+        "description": "Gracias por contactarnos. Te responderemos en un día hábil."
+      },
+      "error": {
+        "title": "No pudimos enviar tu solicitud",
+        "description": "Intenta nuevamente o escríbenos a {email}."
+      },
+      "validation": {
+        "email": "Ingresa un correo de trabajo válido para continuar."
+      },
+      "toastDismissLabel": "Cerrar"
     },
     "shortcuts": {
       "emailHeading": "Correo electrónico",

--- a/apps/speckit/messages/fr.json
+++ b/apps/speckit/messages/fr.json
@@ -380,7 +380,20 @@
         "emailRequiredSuffix": "*",
         "companyLabel": "Entreprise",
         "focusLabel": "Sur quoi devrions-nous nous concentrer?"
-      }
+      },
+      "requiredLabel": "Obligatoire",
+      "success": {
+        "title": "Demande reçue",
+        "description": "Merci de nous avoir contactés. Nous vous répondrons sous un jour ouvrable."
+      },
+      "error": {
+        "title": "Nous n'avons pas pu envoyer votre demande",
+        "description": "Veuillez réessayer ou écrivez-nous à {email}."
+      },
+      "validation": {
+        "email": "Saisissez une adresse e-mail professionnelle valide pour continuer."
+      },
+      "toastDismissLabel": "Fermer"
     },
     "shortcuts": {
       "emailHeading": "E-mail",

--- a/apps/speckit/messages/ga.json
+++ b/apps/speckit/messages/ga.json
@@ -380,7 +380,20 @@
         "emailRequiredSuffix": "-",
         "companyLabel": "Cuideachta",
         "focusLabel": "Cad ba cheart dúinn díriú air?"
-      }
+      },
+      "requiredLabel": "Riachtanach",
+      "success": {
+        "title": "Iarratas faighte",
+        "description": "Go raibh maith agat as teagmháil a dhéanamh linn. Freagróimid laistigh de lá oibre."
+      },
+      "error": {
+        "title": "Níor éirigh linn d'iarratas a sheoladh",
+        "description": "Bain triail eile as nó seol ríomhphost chugainn ag {email}."
+      },
+      "validation": {
+        "email": "Iontráil ríomhphost oibre bailí chun leanúint ar aghaidh."
+      },
+      "toastDismissLabel": "Dún"
     },
     "shortcuts": {
       "emailHeading": "Ríomhphost a chur chuig",

--- a/apps/speckit/messages/it.json
+++ b/apps/speckit/messages/it.json
@@ -380,7 +380,20 @@
         "emailRequiredSuffix": "*",
         "companyLabel": "Azienda",
         "focusLabel": "Su cosa dovremmo concentrarci?"
-      }
+      },
+      "requiredLabel": "Obbligatorio",
+      "success": {
+        "title": "Richiesta ricevuta",
+        "description": "Grazie per averci contattato. Ti risponderemo entro un giorno lavorativo."
+      },
+      "error": {
+        "title": "Non siamo riusciti a inviare la tua richiesta",
+        "description": "Riprova oppure scrivici a {email}."
+      },
+      "validation": {
+        "email": "Inserisci un'e-mail di lavoro valida per continuare."
+      },
+      "toastDismissLabel": "Chiudi"
     },
     "shortcuts": {
       "emailHeading": "E-mail",

--- a/apps/speckit/messages/pt.json
+++ b/apps/speckit/messages/pt.json
@@ -380,7 +380,20 @@
         "emailRequiredSuffix": "*",
         "companyLabel": "Empresa",
         "focusLabel": "Em que devemos nos concentrar?"
-      }
+      },
+      "requiredLabel": "Obrigatório",
+      "success": {
+        "title": "Solicitação recebida",
+        "description": "Obrigado pelo contato. Responderemos em até um dia útil."
+      },
+      "error": {
+        "title": "Não foi possível enviar sua solicitação",
+        "description": "Tente novamente ou envie um e-mail para {email}."
+      },
+      "validation": {
+        "email": "Insira um e-mail de trabalho válido para continuar."
+      },
+      "toastDismissLabel": "Dispensar"
     },
     "shortcuts": {
       "emailHeading": "E-mail",


### PR DESCRIPTION
## Summary
- add a structured lead form state and friendly Supabase error handling for the Speckit contact action
- introduce a client-side contact form that uses useActionState for inline validation, toast feedback, and success resets
- extend Speckit contact translations with localized success, error, and validation copy to surface messaging in the UI

## Testing
- pnpm lint --filter @airnub/speckit-app

------
https://chatgpt.com/codex/tasks/task_e_68dc48971dfc8324b80853d453d41cc2