### PR TITLE
feat: refresh Airnub home hero for launch

### DIFF
--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -93,8 +93,26 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
     eyebrow: t("hero.eyebrow"),
     title: t("hero.title"),
     description: t("hero.description"),
-    primaryCta: t("hero.primaryCta"),
-    secondaryCta: t("hero.secondaryCta"),
+    ctas: [
+      {
+        id: "primary",
+        label: t("hero.primaryCta.label"),
+        href: t("hero.primaryCta.href"),
+        variant: "primary" as const,
+      },
+      {
+        id: "secondary",
+        label: t("hero.secondaryCta.label"),
+        href: t("hero.secondaryCta.href"),
+        variant: "secondary" as const,
+      },
+      {
+        id: "tertiary",
+        label: t("hero.tertiaryCta.label"),
+        href: t("hero.tertiaryCta.href"),
+        variant: "ghost" as const,
+      },
+    ],
   } as const;
 
   const highlightItems = highlightKeys.map((key) => ({
@@ -147,12 +165,22 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
         description={hero.description}
         actions={
           <>
-            <Button asChild>
-              <LocaleLink href="/contact">{hero.primaryCta}</LocaleLink>
-            </Button>
-            <Button variant="ghost" asChild>
-              <LocaleLink href="/products">{hero.secondaryCta}</LocaleLink>
-            </Button>
+            {hero.ctas.map(({ id, href, label, variant }) => {
+              const isInternal = href.startsWith("/");
+              const link = isInternal ? (
+                <LocaleLink href={href}>{label}</LocaleLink>
+              ) : (
+                <Link href={href} target="_blank" rel="noreferrer">
+                  {label}
+                </Link>
+              );
+
+              return (
+                <Button key={id} variant={variant} asChild>
+                  {link}
+                </Button>
+              );
+            })}
           </>
         }
       />

--- a/apps/airnub/messages/de.json
+++ b/apps/airnub/messages/de.json
@@ -100,11 +100,21 @@
       "description": "Operationalisieren Sie Vertrauen in jeder Pipeline mit der Plattform-, Compliance- und Automatisierungs-Expertise von Airnub."
     },
     "hero": {
-      "eyebrow": "Airnub entwickelt gesteuerte, unternehmensreife Entwicklerplattformen.",
-      "title": "Operationalisieren Sie Vertrauen in jeder Release-Pipeline",
-      "description": "Wir helfen Plattform- und Sicherheitsteams, Tabellen durch codifizierte Leitplanken, Evidence-Automatisierung und entwicklernahe Workflows zu ersetzen.",
-      "primaryCta": "Mit unserem Team sprechen",
-      "secondaryCta": "Produkte entdecken"
+      "eyebrow": "Launch: ADF + Speckit",
+      "title": "Steuern Sie überwachte KI-Auslieferungen mit Vertrauen",
+      "description": "Airnub kombiniert das Agentic Delivery Framework, Speckit und Compliance Engineers, damit Plattformteams gouvernierte KI-Services vom ersten Tag an mit Nachweisen starten können.",
+      "primaryCta": {
+        "label": "ADF entdecken",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Speckit kennenlernen",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Mit unserem Team sprechen",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/en-GB.json
+++ b/apps/airnub/messages/en-GB.json
@@ -100,11 +100,21 @@
       "description": "Operationalise trust across every release pipeline with Airnub's platform engineering, compliance, and automation expertise."
     },
     "hero": {
-      "eyebrow": "Airnub builds governed, enterprise-ready developer platforms.",
-      "title": "Operationalise trust across every release pipeline",
-      "description": "We help platform and security teams replace spreadsheets with codified guardrails, evidence automation, and developer-native workflows.",
-      "primaryCta": "Talk to our team",
-      "secondaryCta": "Explore products"
+      "eyebrow": "Launch: ADF + Speckit",
+      "title": "Govern supervised AI delivery with confidence",
+      "description": "Airnub combines the Agentic Delivery Framework, Speckit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
+      "primaryCta": {
+        "label": "Explore ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Meet Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Talk to our team",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/en-US.json
+++ b/apps/airnub/messages/en-US.json
@@ -100,11 +100,21 @@
       "description": "Operationalize trust across every release pipeline with Airnub's platform engineering, compliance, and automation expertise."
     },
     "hero": {
-      "eyebrow": "Airnub builds governed, enterprise-ready developer platforms.",
-      "title": "Operationalize trust across every release pipeline",
-      "description": "We help platform and security teams replace spreadsheets with codified guardrails, evidence automation, and developer-native workflows.",
-      "primaryCta": "Talk to our team",
-      "secondaryCta": "Explore products"
+      "eyebrow": "Launch: ADF + Speckit",
+      "title": "Govern supervised AI delivery with confidence",
+      "description": "Airnub combines the Agentic Delivery Framework, Speckit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
+      "primaryCta": {
+        "label": "Explore ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Meet Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Talk to our team",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/es.json
+++ b/apps/airnub/messages/es.json
@@ -100,11 +100,21 @@
       "description": "Operativiza la confianza en cada canal de entrega gracias a la experiencia de Airnub en plataformas, cumplimiento y automatización."
     },
     "hero": {
-      "eyebrow": "Airnub crea plataformas de desarrolladores gobernadas y listas para la empresa.",
-      "title": "Operativiza la confianza en cada canal de lanzamiento",
-      "description": "Ayudamos a los equipos de plataforma y seguridad a reemplazar hojas de cálculo por barandillas codificadas, automatización de evidencias y flujos de trabajo nativos para desarrolladores.",
-      "primaryCta": "Habla con nuestro equipo",
-      "secondaryCta": "Explorar productos"
+      "eyebrow": "Lanzamiento: ADF + Speckit",
+      "title": "Gobierna el delivery de IA supervisada con confianza",
+      "description": "Airnub combina el Agentic Delivery Framework, Speckit y ingenieros de cumplimiento para que los equipos de plataforma lancen servicios de IA gobernados con evidencia desde el día cero.",
+      "primaryCta": {
+        "label": "Explorar ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Conocer Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Habla con nuestro equipo",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/fr.json
+++ b/apps/airnub/messages/fr.json
@@ -100,11 +100,21 @@
       "description": "Opérationnalisez la confiance sur chaque pipeline de livraison grâce à l'expertise d'Airnub en ingénierie plateforme, conformité et automatisation."
     },
     "hero": {
-      "eyebrow": "Airnub conçoit des plateformes développeurs gouvernées et prêtes pour l'entreprise.",
-      "title": "Opérationnalisez la confiance sur chaque pipeline de livraison",
-      "description": "Nous aidons les équipes plateforme et sécurité à remplacer les tableurs par des garde-fous codifiés, une automatisation des preuves et des workflows natifs pour les développeurs.",
-      "primaryCta": "Parler avec notre équipe",
-      "secondaryCta": "Explorer les produits"
+      "eyebrow": "Lancement : ADF + Speckit",
+      "title": "Gouvernez la livraison d’IA supervisée en toute confiance",
+      "description": "Airnub associe l’Agentic Delivery Framework, Speckit et des ingénieurs conformité pour aider les équipes plateforme à lancer des services d’IA gouvernés avec des preuves dès le premier jour.",
+      "primaryCta": {
+        "label": "Découvrir ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Rencontrer Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Parler à notre équipe",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/ga.json
+++ b/apps/airnub/messages/ga.json
@@ -100,11 +100,21 @@
       "description": "Cuir muinín i bhfeidhm i ngach píblíne seolta le saineolas Airnub ar ardáin, comhlíonadh agus uathoibriú."
     },
     "hero": {
-      "eyebrow": "Tógann Airnub ardáin forbróirí rialaithe atá réidh don fhiontar.",
-      "title": "Cuir muinín i bhfeidhm ar gach píblíne eisiúna",
-      "description": "Cuidímid le foirne ardáin agus slándála bileoga oibre a athrú go cosaintí códaithe, uathoibriú fianaise agus sreafaí oibre dúchasacha d'fhorbróirí.",
-      "primaryCta": "Labhair lenár bhfoireann",
-      "secondaryCta": "Fiosraigh na táirgí"
+      "eyebrow": "Seoladh: ADF + Speckit",
+      "title": "Bain rialú as seachadadh AI mhaoirsithe le muinín",
+      "description": "Comhcheanglaíonn Airnub an Agentic Delivery Framework, Speckit, agus innealtóirí comhlíonta chun go bhféadfaidh foirne ardáin seirbhísí AI rialaithe a sheoladh le fianaise ón gcéad lá.",
+      "primaryCta": {
+        "label": "Déan iniúchadh ar ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Buail le Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Labhair lenár bhfoireann",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/it.json
+++ b/apps/airnub/messages/it.json
@@ -100,11 +100,21 @@
       "description": "Operazionalizza la fiducia in ogni pipeline di rilascio grazie all'esperienza di Airnub in piattaforme, conformità e automazione."
     },
     "hero": {
-      "eyebrow": "Airnub crea piattaforme per sviluppatori governate e pronte per l'azienda.",
-      "title": "Operationalizza la fiducia in ogni pipeline di rilascio",
-      "description": "Aiutiamo i team di piattaforma e sicurezza a sostituire i fogli di calcolo con guardrail codificati, automazione delle evidenze e workflow nativi per gli sviluppatori.",
-      "primaryCta": "Parla con il nostro team",
-      "secondaryCta": "Esplora i prodotti"
+      "eyebrow": "Lancio: ADF + Speckit",
+      "title": "Governa la delivery di IA supervisionata con sicurezza",
+      "description": "Airnub unisce l’Agentic Delivery Framework, Speckit e ingegneri di compliance per permettere ai team piattaforma di lanciare servizi di IA governati con evidenze fin dal primo giorno.",
+      "primaryCta": {
+        "label": "Esplora ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Conosci Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Parla con il nostro team",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {

--- a/apps/airnub/messages/pt.json
+++ b/apps/airnub/messages/pt.json
@@ -100,11 +100,21 @@
       "description": "Operacionalize a confiança em cada pipeline de entrega com a experiência da Airnub em plataforma, conformidade e automação."
     },
     "hero": {
-      "eyebrow": "A Airnub cria plataformas governadas e prontas para empresas.",
-      "title": "Operacionalize a confiança em cada pipeline de lançamento",
-      "description": "Ajudamos as equipas de plataforma e segurança a substituir folhas de cálculo por guardrails codificados, automação de evidências e fluxos de trabalho nativos para developers.",
-      "primaryCta": "Fale com a nossa equipa",
-      "secondaryCta": "Explorar produtos"
+      "eyebrow": "Lançamento: ADF + Speckit",
+      "title": "Governe a entrega de IA supervisionada com confiança",
+      "description": "A Airnub combina o Agentic Delivery Framework, o Speckit e engenheiros de compliance para que as equipas de plataforma lancem serviços de IA governados com evidências desde o primeiro dia.",
+      "primaryCta": {
+        "label": "Explorar a ADF",
+        "href": "/adf"
+      },
+      "secondaryCta": {
+        "label": "Conhecer o Speckit",
+        "href": "/speckit"
+      },
+      "tertiaryCta": {
+        "label": "Fale com a nossa equipa",
+        "href": "/contact"
+      }
     },
     "highlights": {
       "unifiedGovernance": {


### PR DESCRIPTION
## Summary
- replace the Airnub home hero copy across all locales with the launch messaging and CTA targets for ADF, Speckit, and contact
- update the homepage hero rendering to read the new translation shape and render three locale-aware CTAs

## Testing
- pnpm --filter ./apps/airnub lint

------
https://chatgpt.com/codex/tasks/task_e_68e3dbfe96448324aab2330f7d3778ea