### PR TITLE
feat: add microsite cards to home page

### DIFF
--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -11,6 +11,7 @@ import {
   FeatureGrid,
   Hero,
   LogoCloud,
+  Section,
   CloudyardLogo,
   ForgeLabsLogo,
   NorthbeamLogo,
@@ -67,6 +68,8 @@ const serviceCardIds = [
   "innerSource",
   "trustReadiness",
 ] as const;
+
+const projectIds = ["adf", "speckit"] as const;
 
 const airnubHomeContent = {
   highlights: highlightIds,
@@ -136,6 +139,20 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
     outcomes: speckitOutcomeIds.map((id) => ({ id, copy: t(`speckit.outcomes.items.${id}`) })),
   } as const;
 
+  const projects = {
+    title: t("projects.title"),
+    description: t("projects.description"),
+    visitCta: t("projects.visitCta"),
+    docsCta: t("projects.docsCta"),
+    items: projectIds.map((id) => ({
+      id,
+      title: t(`projects.items.${id}.title`),
+      description: t(`projects.items.${id}.description`),
+      siteHref: t(`projects.items.${id}.siteHref`),
+      docsHref: t(`projects.items.${id}.docsHref`),
+    })),
+  } as const;
+
   const services = {
     title: t("services.title"),
     description: t("services.description"),
@@ -184,6 +201,58 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
           </>
         }
       />
+
+      <Section>
+        <div className="space-y-12">
+          <div className="space-y-4 text-center">
+            <h2 className="text-3xl font-semibold text-foreground sm:text-4xl">
+              {projects.title}
+            </h2>
+            <p className="mx-auto max-w-2xl text-base text-muted-foreground">
+              {projects.description}
+            </p>
+          </div>
+          <div className="grid gap-6 md:grid-cols-2">
+            {projects.items.map((project) => {
+              const siteIsInternal = project.siteHref.startsWith("/");
+              const docsIsInternal = project.docsHref.startsWith("/");
+
+              const siteLink = siteIsInternal ? (
+                <LocaleLink href={project.siteHref}>{projects.visitCta}</LocaleLink>
+              ) : (
+                <Link href={project.siteHref} target="_blank" rel="noopener">
+                  {projects.visitCta}
+                </Link>
+              );
+
+              const docsLink = docsIsInternal ? (
+                <LocaleLink href={project.docsHref}>{projects.docsCta}</LocaleLink>
+              ) : (
+                <Link href={project.docsHref} target="_blank" rel="noopener">
+                  {projects.docsCta}
+                </Link>
+              );
+
+              return (
+                <Card key={project.id} className="flex h-full flex-col">
+                  <CardHeader className="flex-1 space-y-3">
+                    <CardTitle className="text-xl">{project.title}</CardTitle>
+                    <CardDescription>{project.description}</CardDescription>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <div className="flex flex-wrap gap-3">
+                      <Button asChild>{siteLink}</Button>
+                      <Button variant="outline" asChild>
+                        {docsLink}
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </div>
+      </Section>
 
       <FeatureGrid
         items={highlightItems.map((item) => ({

--- a/apps/airnub/messages/de.json
+++ b/apps/airnub/messages/de.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Entdecken Sie unsere Plattform-Beschleuniger",
+      "description": "Dedizierte Microsites zeigen, wie das Agentic Delivery Framework und Speckit vertrauensbasierte Automatisierung in Plattformteams bringen.",
+      "visitCta": "Website besuchen",
+      "docsCta": "Dokumentation ansehen",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Erkunden Sie Muster, Playbooks und Kontrollautomatisierung für das Agentic Delivery Framework.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "Erfahren Sie, wie Speckit Spezifikationen, Kontrollen und Nachweise mit programmierbaren Workflows steuert.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Vereinheitlichte Governance",

--- a/apps/airnub/messages/en-GB.json
+++ b/apps/airnub/messages/en-GB.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Explore our platform accelerators",
+      "description": "Dedicated microsites show how the Agentic Delivery Framework and Speckit bring trust-first automation to platform teams.",
+      "visitCta": "Visit site",
+      "docsCta": "View docs",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Blueprint the Agentic Delivery Framework with patterns, playbooks, and control automation.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "See how Speckit governs specs, controls, and evidence with programmable workflows.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Unified governance",

--- a/apps/airnub/messages/en-US.json
+++ b/apps/airnub/messages/en-US.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Explore our platform accelerators",
+      "description": "Dedicated microsites show how the Agentic Delivery Framework and Speckit bring trust-first automation to platform teams.",
+      "visitCta": "Visit site",
+      "docsCta": "View docs",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Blueprint the Agentic Delivery Framework with patterns, playbooks, and control automation.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "See how Speckit governs specs, controls, and evidence with programmable workflows.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Unified governance",

--- a/apps/airnub/messages/es.json
+++ b/apps/airnub/messages/es.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Explora nuestros aceleradores de plataforma",
+      "description": "Micrositios dedicados muestran cómo el Agentic Delivery Framework y Speckit aportan automatización centrada en la confianza a los equipos de plataforma.",
+      "visitCta": "Visitar sitio",
+      "docsCta": "Ver documentación",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Descubre patrones, playbooks y automatización de controles para el Agentic Delivery Framework.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "Conoce cómo Speckit gobierna especificaciones, controles y evidencia con flujos de trabajo programables.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Gobernanza unificada",

--- a/apps/airnub/messages/fr.json
+++ b/apps/airnub/messages/fr.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Découvrez nos accélérateurs de plateforme",
+      "description": "Des microsites dédiés montrent comment l’Agentic Delivery Framework et Speckit apportent une automatisation axée sur la confiance aux équipes plateforme.",
+      "visitCta": "Visiter le site",
+      "docsCta": "Voir la documentation",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Explorez modèles, playbooks et automatisation des contrôles pour l’Agentic Delivery Framework.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "Découvrez comment Speckit gouverne spécifications, contrôles et preuves grâce à des workflows programmables.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Gouvernance unifiée",

--- a/apps/airnub/messages/ga.json
+++ b/apps/airnub/messages/ga.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Fiosraigh ár luasairí ardáin",
+      "description": "Taispeánann micrea-shuímh thiomnaithe conas a thugann Agentic Delivery Framework agus Speckit uathoibriú atá bunaithe ar mhuinín do fhoirne ardáin.",
+      "visitCta": "Tabhair cuairt ar an suíomh",
+      "docsCta": "Amharc ar na doiciméid",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Féach patrúin, lámhleabhair agus uathoibriú rialuithe don Agentic Delivery Framework.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "Feic conas a rialaíonn Speckit sonraíochtaí, rialuithe agus fianaise le sreafaí oibre cláirnithe.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Rialachas aontaithe",

--- a/apps/airnub/messages/it.json
+++ b/apps/airnub/messages/it.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Esplora i nostri acceleratori di piattaforma",
+      "description": "Micrositi dedicati mostrano come Agentic Delivery Framework e Speckit portino automazione basata sulla fiducia ai team piattaforma.",
+      "visitCta": "Visita il sito",
+      "docsCta": "Vedi la documentazione",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Approfondisci pattern, playbook e automazione dei controlli per l’Agentic Delivery Framework.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "Scopri come Speckit governa specifiche, controlli ed evidenze con workflow programmabili.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Governance unificata",

--- a/apps/airnub/messages/pt.json
+++ b/apps/airnub/messages/pt.json
@@ -116,6 +116,26 @@
         "href": "/contact"
       }
     },
+    "projects": {
+      "title": "Explore nossos aceleradores de plataforma",
+      "description": "Microsites dedicados mostram como o Agentic Delivery Framework e o Speckit levam automação baseada em confiança às equipas de plataforma.",
+      "visitCta": "Visitar site",
+      "docsCta": "Ver documentação",
+      "items": {
+        "adf": {
+          "title": "Agentic Delivery Framework",
+          "description": "Conheça padrões, playbooks e automação de controlos do Agentic Delivery Framework.",
+          "siteHref": "https://adf.airnub.io",
+          "docsHref": "https://docs.speckit.dev/adf"
+        },
+        "speckit": {
+          "title": "Speckit",
+          "description": "Veja como o Speckit governa especificações, controlos e evidências com fluxos de trabalho programáveis.",
+          "siteHref": "https://speckit.airnub.io",
+          "docsHref": "https://docs.speckit.dev"
+        }
+      }
+    },
     "highlights": {
       "unifiedGovernance": {
         "title": "Governança unificada",


### PR DESCRIPTION
## Summary
- add localized `home.projects` translations for the ADF and Speckit microsites and their documentation URLs
- render a translated projects section on the Airnub home page with cards that link to each microsite and its docs

## Testing
- pnpm --filter @airnub/airnub-app lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e5ab63d0832492b2707f2dedcc3d