### PR TITLE
feat: refresh Speckit hero CTAs

### DIFF
--- a/apps/speckit/app/page.tsx
+++ b/apps/speckit/app/page.tsx
@@ -31,6 +31,37 @@ export default async function SpeckitHome() {
   const language = await getCurrentLanguage();
   const messages = getSpeckitMessages(language);
   const home = messages.home;
+  const heroActions = home.hero.actions;
+
+  const isExternalLink = (href: string) => /^https?:\/\//.test(href);
+
+  const heroActionItems = [
+    heroActions.primaryLabel
+      ? {
+          label: heroActions.primaryLabel,
+          href: heroActions.primaryHref ?? "https://airnub.github.io/speckit",
+          variant: "primary" as const,
+        }
+      : null,
+    heroActions.secondaryLabel
+      ? {
+          label: heroActions.secondaryLabel,
+          href: heroActions.secondaryHref ?? "/quickstart",
+          variant: "secondary" as const,
+        }
+      : null,
+    heroActions.tertiaryLabel
+      ? {
+          label: heroActions.tertiaryLabel,
+          href: heroActions.tertiaryHref ?? "https://github.com/airnub/speckit",
+          variant: "ghost" as const,
+        }
+      : null,
+  ].filter(Boolean) as {
+    label: string;
+    href: string;
+    variant: "primary" | "secondary" | "ghost";
+  }[];
 
   return (
     <main className="flex flex-col">
@@ -40,24 +71,22 @@ export default async function SpeckitHome() {
         description={home.hero.description}
         variant="gradient"
         actions={
-          <>
-            {home.hero.actions.primaryLabel ? (
-              <Button asChild>
-                <Link href={home.hero.actions.primaryHref ?? "/contact"}>{home.hero.actions.primaryLabel}</Link>
-              </Button>
-            ) : null}
-            {home.hero.actions.secondaryLabel ? (
-              <Button variant="ghost" asChild>
-                <Link
-                  href={home.hero.actions.secondaryHref ?? "https://docs.speckit.dev"}
-                  target={home.hero.actions.secondaryHref?.startsWith("http") ? "_blank" : undefined}
-                  rel={home.hero.actions.secondaryHref?.startsWith("http") ? "noreferrer" : undefined}
-                >
-                  {home.hero.actions.secondaryLabel}
-                </Link>
-              </Button>
-            ) : null}
-          </>
+          heroActionItems.length
+            ? heroActionItems.map((action) => {
+                const external = isExternalLink(action.href);
+                return (
+                  <Button key={action.label} variant={action.variant} asChild>
+                    <Link
+                      href={action.href}
+                      target={external ? "_blank" : undefined}
+                      rel={external ? "noopener" : undefined}
+                    >
+                      {action.label}
+                    </Link>
+                  </Button>
+                );
+              })
+            : undefined
         }
       />
 

--- a/apps/speckit/i18n/messages.ts
+++ b/apps/speckit/i18n/messages.ts
@@ -20,6 +20,8 @@ type DualActionHeroMessages = HeroMessages & {
     primaryHref?: string;
     secondaryLabel?: string;
     secondaryHref?: string;
+    tertiaryLabel?: string;
+    tertiaryHref?: string;
   };
 };
 

--- a/apps/speckit/messages/de.json
+++ b/apps/speckit/messages/de.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speckit",
-      "title": "End-Vibe-Codierung. ",
-      "description": "Speckkit verwandelt die Einhaltung eines Scrambles in eine kontinuierliche Entwicklernative. ",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Fordern Sie eine Demo an",
-        "primaryHref": "/Kontakt",
-        "secondaryLabel": "Erforschen von Dokumenten",
-        "secondaryHref": "https://docs.speckit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/en-GB.json
+++ b/apps/speckit/messages/en-GB.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speckit",
-      "title": "End vibe-coding. Ship secure, auditable releases.",
-      "description": "Speckit turns compliance from a scramble into a continuous, developer-native loop. Govern specs, orchestrate policy gates, and ship evidence on demand.",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Request a demo",
-        "primaryHref": "/contact",
-        "secondaryLabel": "Explore docs",
-        "secondaryHref": "https://docs.speckit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/en-US.json
+++ b/apps/speckit/messages/en-US.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speckit",
-      "title": "End vibe-coding. Ship secure, auditable releases.",
-      "description": "Speckit turns compliance from a scramble into a continuous, developer-native loop. Govern specs, orchestrate policy gates, and ship evidence on demand.",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Request a demo",
-        "primaryHref": "/contact",
-        "secondaryLabel": "Explore docs",
-        "secondaryHref": "https://docs.speckit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/es.json
+++ b/apps/speckit/messages/es.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Mota",
-      "title": "Endvibe codificación. ",
-      "description": "Speckit convierte el cumplimiento de una lucha en un bucle continuo y nativo del desarrollador. ",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Solicitar una demostración",
-        "primaryHref": "/contacto",
-        "secondaryLabel": "Explorar documentos",
-        "secondaryHref": "https://docs.speckit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/fr.json
+++ b/apps/speckit/messages/fr.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speckit",
-      "title": "Fin codant d'ambiance. ",
-      "description": "Speckit transforme la conformité d'une brouillage en une boucle continue et native du développeur. ",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Demander une démo",
-        "primaryHref": "/contact",
-        "secondaryLabel": "Explorer les documents",
-        "secondaryHref": "https://docs.speckit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/ga.json
+++ b/apps/speckit/messages/ga.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speiceas",
-      "title": "Deireadh a chur le códú vibe. ",
-      "description": "Casann Speckit comhlíonadh ó scramble go lúb leanúnach, dúchais forbróra. ",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Taispeántas a iarraidh",
-        "primaryHref": "/teagmháil",
-        "secondaryLabel": "Docs a iniúchadh",
-        "secondaryHref": "https://docs.speckit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/it.json
+++ b/apps/speckit/messages/it.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speckit",
-      "title": "End Codifica per l'atmosfera. ",
-      "description": "Speckit trasforma la conformità da uno scramble in un ciclo continuo e nativo degli sviluppatori. ",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Richiedere una demo",
-        "primaryHref": "/contatto",
-        "secondaryLabel": "Esplora i documenti",
-        "secondaryHref": "https://docs.spect.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [

--- a/apps/speckit/messages/pt.json
+++ b/apps/speckit/messages/pt.json
@@ -72,14 +72,16 @@
   },
   "home": {
     "hero": {
-      "eyebrow": "Speckit",
-      "title": "End Coding Vibe. ",
-      "description": "Speckit transforma a conformidade de uma disputa em um loop contínuo e nativo do desenvolvedor. ",
+      "eyebrow": "Open source",
+      "title": "Automate platform governance from spec to ship.",
+      "description": "Speckit is the open-source workflow engine for policy gates and evidence. Sync specs to code, run gated releases, and publish audit-ready trails automatically.",
       "actions": {
-        "primaryLabel": "Solicite uma demonstração",
-        "primaryHref": "/contato",
-        "secondaryLabel": "Explore os documentos",
-        "secondaryHref": "https://docs.spececkit.dev"
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://airnub.github.io/speckit",
+        "secondaryLabel": "Run the quickstart",
+        "secondaryHref": "/quickstart",
+        "tertiaryLabel": "View on GitHub",
+        "tertiaryHref": "https://github.com/airnub/speckit"
       }
     },
     "features": [


### PR DESCRIPTION
## Summary
- update the Speckit home hero copy and CTA URLs across all locales to point at docs, quickstart, and GitHub
- render a third CTA in the hero with fallback URLs and noopener handling for external links
- extend the hero action message type so translations can surface the new CTA

## Testing
- pnpm --filter @airnub/speckit-app lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e84132c08324ac13fbc51a0876e3