### PR TITLE
Add Speckit quickstart marketing page

### DIFF
--- a/apps/speckit/app/(marketing)/quickstart/page.tsx
+++ b/apps/speckit/app/(marketing)/quickstart/page.tsx
@@ -1,0 +1,174 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Container,
+} from "@airnub/ui";
+import { PageHero } from "../../../components/PageHero";
+import { getCurrentLanguage } from "../../../lib/language";
+import { getSpeckitMessages } from "../../../i18n/messages";
+
+export const dynamic = "force-dynamic";
+
+function isExternalLink(href: string | undefined): boolean {
+  if (!href) {
+    return false;
+  }
+  return href.startsWith("http");
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const language = await getCurrentLanguage();
+  const quickstart = getSpeckitMessages(language).quickstart;
+  return {
+    title: quickstart.hero.title,
+    description: quickstart.hero.description,
+  };
+}
+
+export default async function QuickstartPage() {
+  const language = await getCurrentLanguage();
+  const quickstart = getSpeckitMessages(language).quickstart;
+
+  return (
+    <div className="space-y-16 pb-20">
+      <PageHero
+        eyebrow={quickstart.hero.eyebrow}
+        title={quickstart.hero.title}
+        description={quickstart.hero.description}
+        actions={
+          <>
+            {quickstart.hero.actions.primaryLabel ? (
+              <Button asChild>
+                <Link
+                  href={quickstart.hero.actions.primaryHref ?? "https://docs.speckit.dev"}
+                  target={isExternalLink(quickstart.hero.actions.primaryHref) ? "_blank" : undefined}
+                  rel={isExternalLink(quickstart.hero.actions.primaryHref) ? "noreferrer" : undefined}
+                >
+                  {quickstart.hero.actions.primaryLabel}
+                </Link>
+              </Button>
+            ) : null}
+            {quickstart.hero.actions.secondaryLabel ? (
+              <Button asChild variant="secondary">
+                <Link
+                  href={quickstart.hero.actions.secondaryHref ?? "/template"}
+                  target={isExternalLink(quickstart.hero.actions.secondaryHref) ? "_blank" : undefined}
+                  rel={isExternalLink(quickstart.hero.actions.secondaryHref) ? "noreferrer" : undefined}
+                >
+                  {quickstart.hero.actions.secondaryLabel}
+                </Link>
+              </Button>
+            ) : null}
+            {quickstart.hero.actions.tertiaryLabel ? (
+              <Button asChild variant="ghost">
+                <Link
+                  href={quickstart.hero.actions.tertiaryHref ?? "https://github.com/airnub/speckit"}
+                  target={isExternalLink(quickstart.hero.actions.tertiaryHref) ? "_blank" : undefined}
+                  rel={isExternalLink(quickstart.hero.actions.tertiaryHref) ? "noreferrer" : undefined}
+                >
+                  {quickstart.hero.actions.tertiaryLabel}
+                </Link>
+              </Button>
+            ) : null}
+          </>
+        }
+      />
+
+      <section>
+        <Container className="space-y-10">
+          <div className="space-y-3">
+            {quickstart.intro.eyebrow ? (
+              <p className="text-sm font-semibold uppercase tracking-wide text-primary/80">
+                {quickstart.intro.eyebrow}
+              </p>
+            ) : null}
+            <h2 className="text-3xl font-semibold tracking-tight sm:text-4xl">{quickstart.intro.title}</h2>
+            <p className="text-lg text-muted-foreground">{quickstart.intro.description}</p>
+          </div>
+
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <h3 className="text-2xl font-semibold text-foreground">{quickstart.steps.heading}</h3>
+              <p className="text-muted-foreground">{quickstart.steps.description}</p>
+            </div>
+            <ol className="grid gap-6 lg:grid-cols-2">
+              {quickstart.steps.items.map((step, index) => (
+                <li key={step.title} className="list-none">
+                  <Card className="h-full">
+                    <CardHeader className="space-y-4">
+                      <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-wide text-primary/80">
+                        <span className="inline-flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-base text-primary">
+                          {index + 1}
+                        </span>
+                        <span>{quickstart.steps.label.replace("{count}", String(index + 1))}</span>
+                      </div>
+                      <CardTitle className="text-2xl">{step.title}</CardTitle>
+                      <CardDescription>{step.description}</CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-4 text-sm text-muted-foreground">
+                      {step.command ? (
+                        <div>
+                          {step.commandLabel ? (
+                            <p className="text-xs font-semibold uppercase tracking-wide text-foreground">
+                              {step.commandLabel}
+                            </p>
+                          ) : null}
+                          <pre className="mt-2 overflow-x-auto rounded-lg bg-muted px-3 py-2 font-mono text-xs text-foreground">
+                            <code>{step.command}</code>
+                          </pre>
+                        </div>
+                      ) : null}
+                      {step.links && step.links.length > 0 ? (
+                        <div className="flex flex-wrap gap-3">
+                          {step.links.map((link) => {
+                            const external = isExternalLink(link.href);
+                            return (
+                              <Button key={link.label} asChild variant="ghost" className="px-4 py-2 text-sm font-semibold">
+                                <Link href={link.href} target={external ? "_blank" : undefined} rel={external ? "noreferrer" : undefined}>
+                                  {link.label}
+                                </Link>
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      ) : null}
+                    </CardContent>
+                  </Card>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </Container>
+      </section>
+
+      <section>
+        <Container>
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-2xl">{quickstart.resources.title}</CardTitle>
+              <CardDescription>{quickstart.resources.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-3">
+              {quickstart.resources.items.map((item) => {
+                const external = isExternalLink(item.href);
+                return (
+                  <Button key={item.label} asChild variant="secondary" className="px-5 py-2 text-sm font-semibold">
+                    <Link href={item.href} target={external ? "_blank" : undefined} rel={external ? "noreferrer" : undefined}>
+                      {item.label}
+                    </Link>
+                  </Button>
+                );
+              })}
+            </CardContent>
+          </Card>
+        </Container>
+      </section>
+    </div>
+  );
+}

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -161,7 +161,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
       return {
         label,
         href,
-        external: cta.external,
+        ...(typeof cta.external === "boolean" ? { external: cta.external } : {}),
       };
     })
     .filter((link): link is { label: string; href: string; external?: boolean } => Boolean(link));

--- a/apps/speckit/i18n/messages.ts
+++ b/apps/speckit/i18n/messages.ts
@@ -129,6 +129,38 @@ type TemplateMessages = {
   steps: FeatureMessages[];
 };
 
+type QuickstartMessages = {
+  hero: DualActionHeroMessages;
+  intro: {
+    eyebrow?: string;
+    title: string;
+    description: string;
+  };
+  steps: {
+    heading: string;
+    description: string;
+    label: string;
+    items: {
+      title: string;
+      description: string;
+      commandLabel?: string;
+      command?: string;
+      links?: {
+        label: string;
+        href: string;
+      }[];
+    }[];
+  };
+  resources: {
+    title: string;
+    description: string;
+    items: {
+      label: string;
+      href: string;
+    }[];
+  };
+};
+
 type ContactMessages = {
   hero: HeroMessages;
   form: {
@@ -216,6 +248,7 @@ type LayoutMessages = {
   };
   nav: {
     product: string;
+    quickstart: string;
     howItWorks: string;
     solutions: string;
     docs: string;
@@ -237,6 +270,7 @@ type LayoutMessages = {
         docs: string;
         apiReference: string;
         community: string;
+        quickstart: string;
       };
       openSource: {
         heading: string;
@@ -265,6 +299,7 @@ export type SpeckitMessages = {
   pricing: PricingMessages;
   product: ProductMessages;
   howItWorks: HowItWorksMessages;
+  quickstart: QuickstartMessages;
   template: TemplateMessages;
   contact: ContactMessages;
   solutions: SolutionsOverviewMessages;

--- a/apps/speckit/lib/routes.ts
+++ b/apps/speckit/lib/routes.ts
@@ -3,6 +3,7 @@ export const SPECKIT_BASE_URL = "https://speckit.airnub.io" as const;
 export const speckitRoutes = [
   "",
   "/product",
+  "/quickstart",
   "/how-it-works",
   "/solutions",
   "/solutions/ciso",

--- a/apps/speckit/messages/de.json
+++ b/apps/speckit/messages/de.json
@@ -33,7 +33,8 @@
       "docs": "Dokumente",
       "pricing": "Preisgestaltung",
       "trust": "Vertrauen",
-      "contact": "Kontakt"
+      "contact": "Kontakt",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orchestriert die Strecke von Spezifikation bis Release mit programmierbaren Richtlinien-Gates und kontinuierlichen Nachweisen.",
@@ -48,7 +49,8 @@
           "heading": "Ressourcen",
           "docs": "Dokumente",
           "apiReference": "API -Referenz",
-          "community": "Gemeinschaft"
+          "community": "Gemeinschaft",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Open Source",
@@ -475,6 +477,101 @@
         {
           "title": "Beobachtbarkeitshaken",
           "description": "Senden Sie Steuerergebnisse an Datadog, Grafana oder Lack mit tiefen Links in Beweise."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/en-GB.json
+++ b/apps/speckit/messages/en-GB.json
@@ -33,7 +33,8 @@
       "docs": "Docs",
       "pricing": "Pricing",
       "trust": "Trust",
-      "contact": "Contact"
+      "contact": "Contact",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orchestrates the spec-to-release loop with programmable policy gates and continuous evidence.",
@@ -48,7 +49,8 @@
           "heading": "Resources",
           "docs": "Docs",
           "apiReference": "API reference",
-          "community": "Community"
+          "community": "Community",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Open Source",
@@ -475,6 +477,101 @@
         {
           "title": "Observability hooks",
           "description": "Send control results to Datadog, Grafana, or Slack with deep links into evidence."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/en-US.json
+++ b/apps/speckit/messages/en-US.json
@@ -33,7 +33,8 @@
       "docs": "Docs",
       "pricing": "Pricing",
       "trust": "Trust",
-      "contact": "Contact"
+      "contact": "Contact",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orchestrates the spec-to-release loop with programmable policy gates and continuous evidence.",
@@ -48,7 +49,8 @@
           "heading": "Resources",
           "docs": "Docs",
           "apiReference": "API reference",
-          "community": "Community"
+          "community": "Community",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Open Source",
@@ -475,6 +477,101 @@
         {
           "title": "Observability hooks",
           "description": "Send control results to Datadog, Grafana, or Slack with deep links into evidence."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/es.json
+++ b/apps/speckit/messages/es.json
@@ -33,7 +33,8 @@
       "docs": "Documento",
       "pricing": "Fijación de precios",
       "trust": "Confianza",
-      "contact": "Contacto"
+      "contact": "Contacto",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orquesta el ciclo de especificación a lanzamiento con compuertas programables y evidencia continua.",
@@ -48,7 +49,8 @@
           "heading": "Recursos",
           "docs": "Documento",
           "apiReference": "Referencia de API",
-          "community": "Comunidad"
+          "community": "Comunidad",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Código abierto",
@@ -475,6 +477,101 @@
         {
           "title": "Ganchos de observabilidad",
           "description": "Envíe los resultados de control a Datadog, Grafana o Slack con enlaces profundos como evidencia."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/fr.json
+++ b/apps/speckit/messages/fr.json
@@ -33,7 +33,8 @@
       "docs": "Docs",
       "pricing": "Prix",
       "trust": "Confiance",
-      "contact": "Contact"
+      "contact": "Contact",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orchestre la boucle spécification-vers-release avec des garde-fous programmables et des preuves continues.",
@@ -48,7 +49,8 @@
           "heading": "Ressources",
           "docs": "Docs",
           "apiReference": "Référence de l'API",
-          "community": "Communauté"
+          "community": "Communauté",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Open source",
@@ -475,6 +477,101 @@
         {
           "title": "Crochets d'observabilité",
           "description": "Envoyez des résultats de contrôle à Datadog, Grafana ou Slack avec des liens profonds en preuves."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/ga.json
+++ b/apps/speckit/messages/ga.json
@@ -33,7 +33,8 @@
       "docs": "Docs",
       "pricing": "Praghsáil",
       "trust": "Iontaobhas",
-      "contact": "Lionsa tadhaill"
+      "contact": "Lionsa tadhaill",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Orchstraíonn Speckit an lúb ó shonraíocht go seoladh le geataí beartais inscálaithe agus fianaise leanúnach.",
@@ -48,7 +49,8 @@
           "heading": "Caisiún",
           "docs": "Docs",
           "apiReference": "Tagairt API",
-          "community": "Pobal"
+          "community": "Pobal",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Foinse Oscailte",
@@ -475,6 +477,101 @@
         {
           "title": "Crúcaí inbhraiteachta",
           "description": "Seol na torthaí rialaithe chuig DataDog, Grafana, nó slack le naisc dhomhain i bhfianaise."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/it.json
+++ b/apps/speckit/messages/it.json
@@ -33,7 +33,8 @@
       "docs": "Documenti",
       "pricing": "Prezzi",
       "trust": "Fiducia",
-      "contact": "Contatto"
+      "contact": "Contatto",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orchestra il ciclo dalla specifica al rilascio con gate programmabili e prove continue.",
@@ -48,7 +49,8 @@
           "heading": "Risorse",
           "docs": "Documenti",
           "apiReference": "Riferimento API",
-          "community": "Comunità"
+          "community": "Comunità",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Open source",
@@ -475,6 +477,101 @@
         {
           "title": "Ganci di osservabilità",
           "description": "Invia i risultati del controllo a Datadog, Grafana o Slack con profondi collegamenti in evidenza."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/apps/speckit/messages/pt.json
+++ b/apps/speckit/messages/pt.json
@@ -33,7 +33,8 @@
       "docs": "Documentos",
       "pricing": "Preço",
       "trust": "Confiar",
-      "contact": "Contato"
+      "contact": "Contato",
+      "quickstart": "Quickstart"
     },
     "footer": {
       "description": "Speckit orquestra o ciclo da especificação ao lançamento com portões programáveis e evidências contínuas.",
@@ -48,7 +49,8 @@
           "heading": "Recursos",
           "docs": "Documentos",
           "apiReference": "Referência da API",
-          "community": "Comunidade"
+          "community": "Comunidade",
+          "quickstart": "Quickstart guide"
         },
         "openSource": {
           "heading": "Código aberto",
@@ -475,6 +477,101 @@
         {
           "title": "Ganchos de observabilidade",
           "description": "Envie os resultados do controle para Datadog, Grafana ou Slack com links profundos em evidências."
+        }
+      ]
+    }
+  },
+  "quickstart": {
+    "hero": {
+      "eyebrow": "Quickstart",
+      "title": "Launch Speckit in four guided commands.",
+      "description": "Use the afternoon-friendly quickstart to sync the template, generate governance scaffolding, verify policies, and launch the TUI coach.",
+      "actions": {
+        "primaryLabel": "Read the docs",
+        "primaryHref": "https://docs.speckit.dev",
+        "secondaryLabel": "Browse templates",
+        "secondaryHref": "https://github.com/airnub/speckit-templates"
+      }
+    },
+    "intro": {
+      "eyebrow": "Get hands-on",
+      "title": "Ship a governed release with the starter workspace",
+      "description": "You only need Node.js 20+, pnpm, and a GitHub repository. Follow the steps below to model your first spec, wire automation, and capture evidence."
+    },
+    "steps": {
+      "heading": "Run the quickstart commands",
+      "description": "Each command runs from your terminal inside the project directory. Replace placeholder names with your own service or repository.",
+      "label": "Step {count}",
+      "items": [
+        {
+          "title": "Initialize the template workspace",
+          "description": "Clone the opinionated Speckit starter so you begin with prewired policies, CI, and documentation structure.",
+          "commandLabel": "Scaffold the repo",
+          "command": "pnpm dlx degit airnub/speckit-templates/quickstart speckit-quickstart",
+          "links": [
+            {
+              "label": "Template overview",
+              "href": "/template"
+            },
+            {
+              "label": "Template repository",
+              "href": "https://github.com/airnub/speckit-templates"
+            }
+          ]
+        },
+        {
+          "title": "Generate specs and automation",
+          "description": "Run the generator to sync your spec definitions into pipelines, policy gates, and evidence collectors.",
+          "commandLabel": "Generate artifacts",
+          "command": "pnpm speckit gen --write",
+          "links": [
+            {
+              "label": "Generator docs",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Verify policies and tests",
+          "description": "Execute the built-in checks to confirm guardrails pass before you open a pull request.",
+          "commandLabel": "Run verification",
+          "command": "pnpm speckit verify",
+          "links": [
+            {
+              "label": "Verification guide",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        },
+        {
+          "title": "Coach the rollout with the TUI",
+          "description": "Open the interactive coach to walk policy owners through approvals, evidence, and rollout tasks.",
+          "commandLabel": "Launch the TUI",
+          "command": "pnpm speckit coach",
+          "links": [
+            {
+              "label": "Coach reference",
+              "href": "https://docs.speckit.dev/cli"
+            }
+          ]
+        }
+      ]
+    },
+    "resources": {
+      "title": "Keep exploring",
+      "description": "Expand beyond the quickstart with deeper documentation, rollout templates, and the open-source repo.",
+      "items": [
+        {
+          "label": "Full documentation",
+          "href": "https://docs.speckit.dev"
+        },
+        {
+          "label": "Rollout template",
+          "href": "/template"
+        },
+        {
+          "label": "Speckit on GitHub",
+          "href": "https://github.com/airnub/speckit"
         }
       ]
     }

--- a/packages/brand/runtime/navigation.json
+++ b/packages/brand/runtime/navigation.json
@@ -185,6 +185,11 @@
         "href": "/product"
       },
       {
+        "id": "quickstart",
+        "labelKey": "layout.nav.quickstart",
+        "href": "/quickstart"
+      },
+      {
         "id": "howItWorks",
         "labelKey": "layout.nav.howItWorks",
         "href": "/how-it-works"
@@ -244,6 +249,11 @@
           "id": "resources",
           "headingKey": "layout.footer.columns.resources.heading",
           "links": [
+            {
+              "id": "resources.quickstart",
+              "labelKey": "layout.footer.columns.resources.quickstart",
+              "href": "/quickstart"
+            },
             {
               "id": "resources.docs",
               "labelKey": "layout.footer.columns.resources.docs",

--- a/packages/brand/src/navigation.ts
+++ b/packages/brand/src/navigation.ts
@@ -214,6 +214,7 @@ export const airnubNavigation: SiteNavigationDefinition = {
 export const speckitNavigation: SiteNavigationDefinition = {
   header: [
     { id: "product", labelKey: "layout.nav.product", href: "/product" },
+    { id: "quickstart", labelKey: "layout.nav.quickstart", href: "/quickstart" },
     { id: "howItWorks", labelKey: "layout.nav.howItWorks", href: "/how-it-works" },
     { id: "solutions", labelKey: "layout.nav.solutions", href: "/solutions" },
     {
@@ -258,6 +259,11 @@ export const speckitNavigation: SiteNavigationDefinition = {
         id: "resources",
         headingKey: "layout.footer.columns.resources.heading",
         links: [
+          {
+            id: "resources.quickstart",
+            labelKey: "layout.footer.columns.resources.quickstart",
+            href: "/quickstart",
+          },
           {
             id: "resources.docs",
             labelKey: "layout.footer.columns.resources.docs",


### PR DESCRIPTION
## Summary
- add a localized quickstart marketing route that walks through the template, generator, verification, and coach workflow
- extend Speckit messages, routes, and brand navigation so the quickstart is linked from the header/footer and sitemap
- adjust the layout CTA mapping to keep the external flag optional and regenerate brand runtime assets

## Testing
- pnpm --filter @airnub/speckit-app lint
- pnpm --filter @airnub/speckit-app typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3f697c050832493937011243dd7ed