### PR TITLE
Fix Airnub hero CTAs and nav link to new microsites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,10 @@ SUPABASE_DB_PASSWORD_PROD=
 # LINK_CHECK_IGNORE_HOSTS=
 # LINK_CHECK_TIMEOUT=10000
 # LINK_CHECK_CONCURRENCY=8
+
+# --- Microsite origin overrides (optional) -----------------------------------
+# Uncomment to route Airnub microsite links to local dev servers instead of the
+# production domains. Each override should point to the base URL hosting the
+# corresponding microsite when developing locally.
+# NEXT_PUBLIC_AIRNUB_ADF_ORIGIN=http://localhost:3001
+# NEXT_PUBLIC_AIRNUB_SPECKIT_ORIGIN=http://localhost:3002

--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -23,6 +23,7 @@ import { ActiveSiteShell } from "../../components/ActiveSiteShell";
 import {
   airnubNavigation,
   buildBrandMetadata,
+  resolveMicrositeHref,
   resolvedBrandConfig as airnubBrand,
   type BrandContacts,
 } from "@airnub/brand";
@@ -133,17 +134,20 @@ export default async function LocaleLayout({
     return undefined;
   };
 
-  const navItems = airnubNavigation.header.map((item) => ({
-    label: translateLabel(item.labelKey),
-    href: localizeHref(item.href, item.external),
-    external: item.external,
-  }));
+  const navItems = airnubNavigation.header.map((item) => {
+    const resolvedHref = resolveMicrositeHref(item.href);
+    return {
+      label: translateLabel(item.labelKey),
+      href: localizeHref(resolvedHref, item.external),
+      external: item.external,
+    };
+  });
 
   const footerColumns: FooterColumn[] = airnubNavigation.footer.groups.map((group) => ({
     heading: translateLabel(group.headingKey),
     links: group.links.map((link) => ({
       label: translateLabel(link.labelKey),
-      href: localizeHref(link.href, link.external),
+      href: localizeHref(resolveMicrositeHref(link.href), link.external),
       external: link.external,
     })),
   }));

--- a/apps/airnub/app/[locale]/page.tsx
+++ b/apps/airnub/app/[locale]/page.tsx
@@ -16,6 +16,7 @@ import {
   ForgeLabsLogo,
   NorthbeamLogo,
 } from "@airnub/ui";
+import { resolveMicrositeHref } from "@airnub/brand";
 import { serverFetch } from "@airnub/seo";
 import { getTranslations } from "next-intl/server";
 import { LocaleLink } from "../../components/LocaleLink";
@@ -100,19 +101,19 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
       {
         id: "primary",
         label: t("hero.primaryCta.label"),
-        href: t("hero.primaryCta.href"),
+        href: resolveMicrositeHref(t("hero.primaryCta.href")),
         variant: "primary" as const,
       },
       {
         id: "secondary",
         label: t("hero.secondaryCta.label"),
-        href: t("hero.secondaryCta.href"),
+        href: resolveMicrositeHref(t("hero.secondaryCta.href")),
         variant: "secondary" as const,
       },
       {
         id: "tertiary",
         label: t("hero.tertiaryCta.label"),
-        href: t("hero.tertiaryCta.href"),
+        href: resolveMicrositeHref(t("hero.tertiaryCta.href")),
         variant: "ghost" as const,
       },
     ],
@@ -148,8 +149,8 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
       id,
       title: t(`projects.items.${id}.title`),
       description: t(`projects.items.${id}.description`),
-      siteHref: t(`projects.items.${id}.siteHref`),
-      docsHref: t(`projects.items.${id}.docsHref`),
+      siteHref: resolveMicrositeHref(t(`projects.items.${id}.siteHref`)),
+      docsHref: resolveMicrositeHref(t(`projects.items.${id}.docsHref`)),
     })),
   } as const;
 
@@ -173,6 +174,15 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
     { backgroundColor: "var(--brand-accent)" },
     { backgroundColor: "color-mix(in srgb, var(--brand-foreground) 70%, transparent)" },
   ] as const;
+
+  const speckitSiteHref = resolveMicrositeHref("https://speckit.airnub.io");
+  const speckitPrimaryLink = speckitSiteHref.startsWith("/") ? (
+    <LocaleLink href={speckitSiteHref}>{speckit.primaryCta}</LocaleLink>
+  ) : (
+    <Link href={speckitSiteHref} target="_blank" rel="noreferrer">
+      {speckit.primaryCta}
+    </Link>
+  );
 
   return (
     <main className="flex flex-col">
@@ -276,11 +286,7 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
         description={speckit.description}
         actions={
           <>
-            <Button asChild>
-              <Link href="https://speckit.airnub.io" target="_blank" rel="noreferrer">
-                {speckit.primaryCta}
-              </Link>
-            </Button>
+            <Button asChild>{speckitPrimaryLink}</Button>
             <Button variant="ghost" asChild>
               <LocaleLink href="/products">{speckit.secondaryCta}</LocaleLink>
             </Button>

--- a/apps/airnub/messages/de.json
+++ b/apps/airnub/messages/de.json
@@ -108,11 +108,11 @@
       "description": "Airnub kombiniert das Agentic Delivery Framework, Speckit und Compliance Engineers, damit Plattformteams gouvernierte KI-Services vom ersten Tag an mit Nachweisen starten können.",
       "primaryCta": {
         "label": "ADF entdecken",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Speckit kennenlernen",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Mit unserem Team sprechen",

--- a/apps/airnub/messages/en-GB.json
+++ b/apps/airnub/messages/en-GB.json
@@ -108,11 +108,11 @@
       "description": "Airnub combines the Agentic Delivery Framework, Speckit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
       "primaryCta": {
         "label": "Explore ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Meet Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Talk to our team",

--- a/apps/airnub/messages/en-US.json
+++ b/apps/airnub/messages/en-US.json
@@ -108,11 +108,11 @@
       "description": "Airnub combines the Agentic Delivery Framework, Speckit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
       "primaryCta": {
         "label": "Explore ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Meet Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Talk to our team",

--- a/apps/airnub/messages/es.json
+++ b/apps/airnub/messages/es.json
@@ -108,11 +108,11 @@
       "description": "Airnub combina el Agentic Delivery Framework, Speckit y ingenieros de cumplimiento para que los equipos de plataforma lancen servicios de IA gobernados con evidencia desde el día cero.",
       "primaryCta": {
         "label": "Explorar ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Conocer Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Habla con nuestro equipo",

--- a/apps/airnub/messages/fr.json
+++ b/apps/airnub/messages/fr.json
@@ -108,11 +108,11 @@
       "description": "Airnub associe l’Agentic Delivery Framework, Speckit et des ingénieurs conformité pour aider les équipes plateforme à lancer des services d’IA gouvernés avec des preuves dès le premier jour.",
       "primaryCta": {
         "label": "Découvrir ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Rencontrer Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Parler à notre équipe",

--- a/apps/airnub/messages/ga.json
+++ b/apps/airnub/messages/ga.json
@@ -108,11 +108,11 @@
       "description": "Comhcheanglaíonn Airnub an Agentic Delivery Framework, Speckit, agus innealtóirí comhlíonta chun go bhféadfaidh foirne ardáin seirbhísí AI rialaithe a sheoladh le fianaise ón gcéad lá.",
       "primaryCta": {
         "label": "Déan iniúchadh ar ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Buail le Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Labhair lenár bhfoireann",

--- a/apps/airnub/messages/it.json
+++ b/apps/airnub/messages/it.json
@@ -108,11 +108,11 @@
       "description": "Airnub unisce l’Agentic Delivery Framework, Speckit e ingegneri di compliance per permettere ai team piattaforma di lanciare servizi di IA governati con evidenze fin dal primo giorno.",
       "primaryCta": {
         "label": "Esplora ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Conosci Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Parla con il nostro team",

--- a/apps/airnub/messages/pt.json
+++ b/apps/airnub/messages/pt.json
@@ -108,11 +108,11 @@
       "description": "A Airnub combina o Agentic Delivery Framework, o Speckit e engenheiros de compliance para que as equipas de plataforma lancem serviços de IA governados com evidências desde o primeiro dia.",
       "primaryCta": {
         "label": "Explorar a ADF",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
         "label": "Conhecer o Speckit",
-        "href": "/speckit"
+        "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
         "label": "Fale com a nossa equipa",

--- a/packages/brand/runtime/navigation.json
+++ b/packages/brand/runtime/navigation.json
@@ -9,7 +9,7 @@
       {
         "id": "adf",
         "labelKey": "nav.adf",
-        "href": "/adf"
+        "href": "https://adf.airnub.io"
       },
       {
         "id": "solutions",

--- a/packages/brand/src/index.ts
+++ b/packages/brand/src/index.ts
@@ -3,3 +3,4 @@ export * from "./SpeckitWordmark";
 export * from "./brand.config";
 export * from "./metadata";
 export * from "./navigation";
+export * from "./microsites";

--- a/packages/brand/src/microsites.ts
+++ b/packages/brand/src/microsites.ts
@@ -1,0 +1,66 @@
+const PRODUCTION_MICROSITE_ORIGINS = {
+  adf: "https://adf.airnub.io",
+  speckit: "https://speckit.airnub.io",
+} as const;
+
+type MicrositeId = keyof typeof PRODUCTION_MICROSITE_ORIGINS;
+
+const ENVIRONMENT_OVERRIDES: Record<MicrositeId, string | undefined> = {
+  adf:
+    process.env.NEXT_PUBLIC_AIRNUB_ADF_ORIGIN ??
+    process.env.AIRNUB_ADF_ORIGIN ??
+    undefined,
+  speckit:
+    process.env.NEXT_PUBLIC_AIRNUB_SPECKIT_ORIGIN ??
+    process.env.AIRNUB_SPECKIT_ORIGIN ??
+    undefined,
+};
+
+const RESOLVED_MICROSITE_ORIGINS: Record<MicrositeId, string> = {
+  adf: normalizeOrigin(
+    ENVIRONMENT_OVERRIDES.adf ?? PRODUCTION_MICROSITE_ORIGINS.adf,
+  ),
+  speckit: normalizeOrigin(
+    ENVIRONMENT_OVERRIDES.speckit ?? PRODUCTION_MICROSITE_ORIGINS.speckit,
+  ),
+};
+
+const PRODUCTION_TO_RESOLVED = new Map<string, string>(
+  (Object.keys(PRODUCTION_MICROSITE_ORIGINS) as MicrositeId[]).map((id) => [
+    PRODUCTION_MICROSITE_ORIGINS[id],
+    RESOLVED_MICROSITE_ORIGINS[id],
+  ]),
+);
+
+function normalizeOrigin(origin: string) {
+  const trimmed = origin.trim();
+  if (trimmed === "") {
+    return trimmed;
+  }
+
+  return trimmed.replace(/\/+$/, "");
+}
+
+export function getMicrositeOrigin(id: MicrositeId) {
+  return RESOLVED_MICROSITE_ORIGINS[id];
+}
+
+export function resolveMicrositeHref(href: string) {
+  if (typeof href !== "string" || href.length === 0) {
+    return href;
+  }
+
+  for (const [productionOrigin, resolvedOrigin] of PRODUCTION_TO_RESOLVED) {
+    if (href === productionOrigin) {
+      return resolvedOrigin;
+    }
+
+    if (href.startsWith(`${productionOrigin}/`)) {
+      const suffix = href.slice(productionOrigin.length);
+      return `${resolvedOrigin}${suffix}`;
+    }
+  }
+
+  return href;
+}
+

--- a/packages/brand/src/navigation.ts
+++ b/packages/brand/src/navigation.ts
@@ -1,4 +1,5 @@
 import type { BrandContacts } from "./brand.config";
+import { getMicrositeOrigin } from "./microsites";
 
 export type NavigationLinkDefinition = {
   /**
@@ -69,7 +70,7 @@ export type SiteNavigationDefinition = {
 export const airnubNavigation: SiteNavigationDefinition = {
   header: [
     { id: "products", labelKey: "nav.products", href: "/products" },
-    { id: "adf", labelKey: "nav.adf", href: "https://adf.airnub.io" },
+    { id: "adf", labelKey: "nav.adf", href: getMicrositeOrigin("adf") },
     { id: "solutions", labelKey: "nav.solutions", href: "/solutions" },
     { id: "services", labelKey: "nav.services", href: "/services" },
     { id: "resources", labelKey: "nav.resources", href: "/resources" },

--- a/packages/brand/src/navigation.ts
+++ b/packages/brand/src/navigation.ts
@@ -69,7 +69,7 @@ export type SiteNavigationDefinition = {
 export const airnubNavigation: SiteNavigationDefinition = {
   header: [
     { id: "products", labelKey: "nav.products", href: "/products" },
-    { id: "adf", labelKey: "nav.adf", href: "/adf" },
+    { id: "adf", labelKey: "nav.adf", href: "https://adf.airnub.io" },
     { id: "solutions", labelKey: "nav.solutions", href: "/solutions" },
     { id: "services", labelKey: "nav.services", href: "/services" },
     { id: "resources", labelKey: "nav.resources", href: "/resources" },


### PR DESCRIPTION
## Summary
- update the Airnub hero primary and secondary CTAs across all locales to use the hosted ADF and Speckit microsite URLs
- point the shared brand navigation entry for the ADF header item at https://adf.airnub.io and regenerate the runtime navigation bundle

## Testing
- pnpm brand:sync

## Deployment
- Unable to deploy or run a live smoke test in this environment; please trigger the deployment pipeline and validate the hero CTAs and header link in the deployed build.

------
https://chatgpt.com/codex/tasks/task_e_68e40b5477308324bd6d24f9353142c2