### PR TITLE
Update Airnub hero messaging for AI copy

### DIFF
--- a/apps/airnub/messages/en-GB.json
+++ b/apps/airnub/messages/en-GB.json
@@ -104,18 +104,18 @@
     },
     "hero": {
       "eyebrow": "Launch: ADF + Speckit",
-      "title": "Govern supervised AI delivery with confidence",
-      "description": "Airnub combines the Agentic Delivery Framework, Speckit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
+      "title": "Build safely with AI from day zero",
+      "description": "Airnub combines the Agentic Delivery Framework, SpecKit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
       "primaryCta": {
         "label": "Explore ADF",
         "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
-        "label": "Meet Speckit",
+        "label": "Explore SpecKit",
         "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
-        "label": "Talk to our team",
+        "label": "Contact",
         "href": "/contact"
       }
     },

--- a/apps/airnub/messages/en-US.json
+++ b/apps/airnub/messages/en-US.json
@@ -104,18 +104,18 @@
     },
     "hero": {
       "eyebrow": "Launch: ADF + Speckit",
-      "title": "Govern supervised AI delivery with confidence",
-      "description": "Airnub combines the Agentic Delivery Framework, Speckit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
+      "title": "Build safely with AI from day zero",
+      "description": "Airnub combines the Agentic Delivery Framework, SpecKit, and compliance engineers so platform teams can launch governed AI services with evidence from day zero.",
       "primaryCta": {
         "label": "Explore ADF",
         "href": "https://adf.airnub.io"
       },
       "secondaryCta": {
-        "label": "Meet Speckit",
+        "label": "Explore SpecKit",
         "href": "https://speckit.airnub.io"
       },
       "tertiaryCta": {
-        "label": "Talk to our team",
+        "label": "Contact",
         "href": "/contact"
       }
     },


### PR DESCRIPTION
## Summary
- update the Airnub homepage hero copy in the en-US locale to use the approved AI messaging and CTA labels
- mirror the updated hero strings in the en-GB locale so both English variants show the same copy

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e414bb98d483248d00f1b8835698d1