### PR TITLE
feat: tighten smoke checks and add privacy pages

### DIFF
--- a/LINK-REPORT.md
+++ b/LINK-REPORT.md
@@ -1,7 +1,7 @@
 # Link Check
 
 ## airnub
-- No broken internal links
+- http://localhost:3101/en-US/resources → 404
 
 ## speckit
 - No broken internal links

--- a/SMOKE-REPORT.json
+++ b/SMOKE-REPORT.json
@@ -8,36 +8,127 @@
       "boot": "pass",
       "routes": {
         "/": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3101/en-US",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3101/en-US"
+          ]
         },
         "/work": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3101/en-US/work",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3101/en-US/work"
+          ]
         },
         "/projects": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3101/en-US/projects",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3101/en-US/projects"
+          ]
         },
         "/about": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3101/en-US/about",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3101/en-US/about"
+          ]
         },
         "/contact": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3101/en-US/contact",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3101/en-US/contact"
+          ]
+        },
+        "/privacy": {
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3101/en-US/privacy",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3101/en-US/privacy"
+          ]
         },
         "/robots.txt": {
           "status": 200,
-          "ctype": "text/plain"
+          "ctype": "text/plain",
+          "finalUrl": "http://localhost:3101/robots.txt",
+          "redirected": false,
+          "redirects": [],
+          "robots": {
+            "hasSitemap": true
+          }
         },
         "/sitemap.xml": {
           "status": 200,
-          "ctype": "application/xml"
+          "ctype": "application/xml",
+          "finalUrl": "http://localhost:3101/sitemap.xml",
+          "redirected": false,
+          "redirects": [],
+          "sitemap": {
+            "missing": [],
+            "locs": [
+              "https://airnub.io/en-US",
+              "https://airnub.io/en-US/work",
+              "https://airnub.io/en-US/projects",
+              "https://airnub.io/en-US/about",
+              "https://airnub.io/en-US/contact",
+              "https://airnub.io/en-GB",
+              "https://airnub.io/en-GB/work",
+              "https://airnub.io/en-GB/projects",
+              "https://airnub.io/en-GB/about",
+              "https://airnub.io/en-GB/contact",
+              "https://airnub.io/ga",
+              "https://airnub.io/ga/work",
+              "https://airnub.io/ga/projects",
+              "https://airnub.io/ga/about",
+              "https://airnub.io/ga/contact",
+              "https://airnub.io/fr",
+              "https://airnub.io/fr/work",
+              "https://airnub.io/fr/projects",
+              "https://airnub.io/fr/about",
+              "https://airnub.io/fr/contact",
+              "https://airnub.io/es",
+              "https://airnub.io/es/work",
+              "https://airnub.io/es/projects",
+              "https://airnub.io/es/about",
+              "https://airnub.io/es/contact",
+              "https://airnub.io/de",
+              "https://airnub.io/de/work",
+              "https://airnub.io/de/projects",
+              "https://airnub.io/de/about",
+              "https://airnub.io/de/contact",
+              "https://airnub.io/pt",
+              "https://airnub.io/pt/work",
+              "https://airnub.io/pt/projects",
+              "https://airnub.io/pt/about",
+              "https://airnub.io/pt/contact",
+              "https://airnub.io/it",
+              "https://airnub.io/it/work",
+              "https://airnub.io/it/projects",
+              "https://airnub.io/it/about",
+              "https://airnub.io/it/contact"
+            ]
+          }
         },
         "/opengraph-image": {
           "status": 200,
-          "ctype": "image/png"
+          "ctype": "image/png",
+          "finalUrl": "http://localhost:3101/opengraph-image",
+          "redirected": false,
+          "redirects": []
         }
       }
     },
@@ -49,23 +140,64 @@
       "routes": {
         "/": {
           "status": 200,
-          "ctype": "text/html; charset=utf-8"
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3102/",
+          "redirected": false,
+          "redirects": []
         },
         "/quickstart": {
           "status": 200,
-          "ctype": "text/html; charset=utf-8"
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3102/quickstart",
+          "redirected": false,
+          "redirects": []
+        },
+        "/privacy": {
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3102/privacy",
+          "redirected": false,
+          "redirects": []
         },
         "/robots.txt": {
           "status": 200,
-          "ctype": "text/plain"
+          "ctype": "text/plain",
+          "finalUrl": "http://localhost:3102/robots.txt",
+          "redirected": false,
+          "redirects": [],
+          "robots": {
+            "hasSitemap": true
+          }
         },
         "/sitemap.xml": {
           "status": 200,
-          "ctype": "application/xml"
+          "ctype": "application/xml",
+          "finalUrl": "http://localhost:3102/sitemap.xml",
+          "redirected": false,
+          "redirects": [],
+          "sitemap": {
+            "missing": [],
+            "locs": [
+              "https://speckit.airnub.io",
+              "https://speckit.airnub.io/product",
+              "https://speckit.airnub.io/quickstart",
+              "https://speckit.airnub.io/how-it-works",
+              "https://speckit.airnub.io/solutions",
+              "https://speckit.airnub.io/solutions/ciso",
+              "https://speckit.airnub.io/solutions/devsecops",
+              "https://speckit.airnub.io/template",
+              "https://speckit.airnub.io/pricing",
+              "https://speckit.airnub.io/contact",
+              "https://speckit.airnub.io/trust"
+            ]
+          }
         },
         "/opengraph-image": {
           "status": 200,
-          "ctype": "image/png"
+          "ctype": "image/png",
+          "finalUrl": "http://localhost:3102/opengraph-image",
+          "redirected": false,
+          "redirects": []
         }
       }
     },
@@ -76,24 +208,76 @@
       "boot": "pass",
       "routes": {
         "/": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3103/en-US",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3103/en-US"
+          ]
         },
         "/quickstart": {
-          "status": 307,
-          "ctype": ""
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3103/en-US/quickstart",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3103/en-US/quickstart"
+          ]
+        },
+        "/privacy": {
+          "status": 200,
+          "ctype": "text/html; charset=utf-8",
+          "finalUrl": "http://localhost:3103/en-US/privacy",
+          "redirected": true,
+          "redirects": [
+            "http://localhost:3103/en-US/privacy"
+          ]
         },
         "/robots.txt": {
           "status": 200,
-          "ctype": "text/plain"
+          "ctype": "text/plain",
+          "finalUrl": "http://localhost:3103/robots.txt",
+          "redirected": false,
+          "redirects": [],
+          "robots": {
+            "hasSitemap": true
+          }
         },
         "/sitemap.xml": {
           "status": 200,
-          "ctype": "application/xml"
+          "ctype": "application/xml",
+          "finalUrl": "http://localhost:3103/sitemap.xml",
+          "redirected": false,
+          "redirects": [],
+          "sitemap": {
+            "missing": [],
+            "locs": [
+              "https://adf.airnub.io/en-US",
+              "https://adf.airnub.io/en-US/quickstart",
+              "https://adf.airnub.io/en-GB",
+              "https://adf.airnub.io/en-GB/quickstart",
+              "https://adf.airnub.io/ga",
+              "https://adf.airnub.io/ga/quickstart",
+              "https://adf.airnub.io/fr",
+              "https://adf.airnub.io/fr/quickstart",
+              "https://adf.airnub.io/es",
+              "https://adf.airnub.io/es/quickstart",
+              "https://adf.airnub.io/de",
+              "https://adf.airnub.io/de/quickstart",
+              "https://adf.airnub.io/pt",
+              "https://adf.airnub.io/pt/quickstart",
+              "https://adf.airnub.io/it",
+              "https://adf.airnub.io/it/quickstart"
+            ]
+          }
         },
         "/opengraph-image": {
           "status": 200,
-          "ctype": "image/png"
+          "ctype": "image/png",
+          "finalUrl": "http://localhost:3103/opengraph-image",
+          "redirected": false,
+          "redirects": []
         }
       }
     }

--- a/SMOKE-REPORT.md
+++ b/SMOKE-REPORT.md
@@ -7,11 +7,12 @@
 - Mode: start
 - Boot: ✅
 - Routes:
-  - /: 307
-  - /work: 307
-  - /projects: 307
-  - /about: 307
-  - /contact: 307
+  - / → http://localhost:3101/en-US: 200 text/html; charset=utf-8
+  - /work → http://localhost:3101/en-US/work: 200 text/html; charset=utf-8
+  - /projects → http://localhost:3101/en-US/projects: 200 text/html; charset=utf-8
+  - /about → http://localhost:3101/en-US/about: 200 text/html; charset=utf-8
+  - /contact → http://localhost:3101/en-US/contact: 200 text/html; charset=utf-8
+  - /privacy → http://localhost:3101/en-US/privacy: 200 text/html; charset=utf-8
   - /robots.txt: 200 text/plain
   - /sitemap.xml: 200 application/xml
   - /opengraph-image: 200 image/png
@@ -23,6 +24,7 @@
 - Routes:
   - /: 200 text/html; charset=utf-8
   - /quickstart: 200 text/html; charset=utf-8
+  - /privacy: 200 text/html; charset=utf-8
   - /robots.txt: 200 text/plain
   - /sitemap.xml: 200 application/xml
   - /opengraph-image: 200 image/png
@@ -32,8 +34,9 @@
 - Mode: start
 - Boot: ✅
 - Routes:
-  - /: 307
-  - /quickstart: 307
+  - / → http://localhost:3103/en-US: 200 text/html; charset=utf-8
+  - /quickstart → http://localhost:3103/en-US/quickstart: 200 text/html; charset=utf-8
+  - /privacy → http://localhost:3103/en-US/privacy: 200 text/html; charset=utf-8
   - /robots.txt: 200 text/plain
   - /sitemap.xml: 200 application/xml
   - /opengraph-image: 200 image/png

--- a/apps/adf/app/[locale]/layout.tsx
+++ b/apps/adf/app/[locale]/layout.tsx
@@ -171,6 +171,11 @@ export default async function LocaleLayout({
 
   const year = new Date().getFullYear();
   const githubUrl = adfBrand.social.github;
+  const analyticsProvider = process.env.NEXT_PUBLIC_ANALYTICS ?? null;
+  const analyticsProviderLower = analyticsProvider?.toLowerCase();
+  const analyticsDomain =
+    analyticsProviderLower === "plausible" ? process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN : undefined;
+  const analyticsGaId = analyticsProviderLower === "ga4" ? process.env.NEXT_PUBLIC_GA4_ID : undefined;
 
   return (
     <html
@@ -183,11 +188,7 @@ export default async function LocaleLayout({
         <JsonLd data={jsonLd} />
       </head>
       <body className="flex min-h-screen flex-col">
-        <Analytics
-          provider={process.env.NEXT_PUBLIC_ANALYTICS as any}
-          domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
-          gaId={process.env.NEXT_PUBLIC_GA4_ID}
-        />
+        <Analytics provider={analyticsProvider} domain={analyticsDomain} gaId={analyticsGaId} />
         <NextIntlClientProvider
           locale={locale}
           messages={messages as unknown as AbstractIntlMessages}

--- a/apps/adf/app/[locale]/privacy/page.tsx
+++ b/apps/adf/app/[locale]/privacy/page.tsx
@@ -1,0 +1,25 @@
+import { assertLocale } from "../../i18n/routing";
+import adfBrand from "../../../brand.config";
+
+export const metadata = { title: "Privacy" };
+
+export default async function PrivacyPage({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale: localeParam } = await params;
+  const locale = assertLocale(localeParam);
+  const contactEmail =
+    adfBrand.contact.security ?? adfBrand.contact.support ?? adfBrand.contact.general ?? "hello@airnub.io";
+
+  return (
+    <main className="prose mx-auto p-8" lang={locale}>
+      <h1>Privacy</h1>
+      <p>
+        We only collect the information required to publish ADF documentation and community resources. Analytics are disabled
+        unless explicitly configured via environment variables. We never sell or share personal data.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Questions? Email <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+      </p>
+    </main>
+  );
+}

--- a/apps/adf/app/privacy/page.tsx
+++ b/apps/adf/app/privacy/page.tsx
@@ -1,0 +1,23 @@
+import adfBrand from "../../brand.config";
+
+export const metadata = { title: "Privacy" };
+
+export default function PrivacyPage() {
+  const contactEmail =
+    adfBrand.contact.security ?? adfBrand.contact.support ?? adfBrand.contact.general ?? "hello@airnub.io";
+
+  return (
+    <main className="prose mx-auto p-8">
+      <h1>Privacy</h1>
+      <p>
+        The Agentic Delivery Framework site only stores information needed to provide documentation and community
+        resources. Analytics tooling is disabled unless explicitly configured at deploy time. We never sell or share
+        personal data.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Questions? Email <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+      </p>
+    </main>
+  );
+}

--- a/apps/airnub/app/[locale]/layout.tsx
+++ b/apps/airnub/app/[locale]/layout.tsx
@@ -202,6 +202,11 @@ export default async function LocaleLayout({
   };
 
   const year = new Date().getFullYear();
+  const analyticsProvider = process.env.NEXT_PUBLIC_ANALYTICS ?? null;
+  const analyticsProviderLower = analyticsProvider?.toLowerCase();
+  const analyticsDomain =
+    analyticsProviderLower === "plausible" ? process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN : undefined;
+  const analyticsGaId = analyticsProviderLower === "ga4" ? process.env.NEXT_PUBLIC_GA4_ID : undefined;
 
   return (
     <html
@@ -217,11 +222,7 @@ export default async function LocaleLayout({
         />
       </head>
       <body className="flex min-h-screen flex-col">
-        <Analytics
-          provider={process.env.NEXT_PUBLIC_ANALYTICS as any}
-          domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
-          gaId={process.env.NEXT_PUBLIC_GA4_ID}
-        />
+        <Analytics provider={analyticsProvider} domain={analyticsDomain} gaId={analyticsGaId} />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <BrandProvider value={airnubBrand}>
             <ThemeProvider>

--- a/apps/speckit/app/layout.tsx
+++ b/apps/speckit/app/layout.tsx
@@ -169,6 +169,11 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
 
   const year = new Date().getFullYear();
   const githubUrl = speckitBrand.social.github ?? "https://github.com";
+  const analyticsProvider = process.env.NEXT_PUBLIC_ANALYTICS ?? null;
+  const analyticsProviderLower = analyticsProvider?.toLowerCase();
+  const analyticsDomain =
+    analyticsProviderLower === "plausible" ? process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN : undefined;
+  const analyticsGaId = analyticsProviderLower === "ga4" ? process.env.NEXT_PUBLIC_GA4_ID : undefined;
 
   return (
     <html
@@ -181,11 +186,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
         <JsonLd data={jsonLd} />
       </head>
       <body className="flex min-h-screen flex-col">
-        <Analytics
-          provider={process.env.NEXT_PUBLIC_ANALYTICS as any}
-          domain={process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN}
-          gaId={process.env.NEXT_PUBLIC_GA4_ID}
-        />
+        <Analytics provider={analyticsProvider} domain={analyticsDomain} gaId={analyticsGaId} />
         <BrandProvider value={speckitBrand}>
           <ThemeProvider>
             <ToastProvider>

--- a/apps/speckit/app/privacy/page.tsx
+++ b/apps/speckit/app/privacy/page.tsx
@@ -1,0 +1,26 @@
+import speckitBrand from "../../brand.config";
+
+export const metadata = { title: "Privacy" };
+
+export default function PrivacyPage() {
+  const contactEmail =
+    speckitBrand.contact.security ??
+    speckitBrand.contact.support ??
+    speckitBrand.contact.general ??
+    "hello@airnub.io";
+
+  return (
+    <main className="prose mx-auto p-8">
+      <h1>Privacy</h1>
+      <p>
+        We collect only the data required to operate Speckit. Analytics are disabled by default and are
+        only enabled when explicitly configured in the deployment environment. We never sell or share
+        personal data.
+      </p>
+      <h2>Contact</h2>
+      <p>
+        Questions? Email <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+      </p>
+    </main>
+  );
+}

--- a/packages/ui/src/Analytics.tsx
+++ b/packages/ui/src/Analytics.tsx
@@ -1,12 +1,43 @@
 'use client';
 import Script from 'next/script';
 
-export default function Analytics({ provider, domain, gaId }:{provider?:'plausible'|'ga4'|'off',domain?:string,gaId?:string}) {
-  if (provider === 'plausible' && domain) {
+type AnalyticsProvider = 'plausible' | 'ga4';
+
+function normalizeProvider(provider?: string | null): AnalyticsProvider | null {
+  if (!provider) {
+    return null;
+  }
+  const normalized = provider.toLowerCase();
+  if (normalized === 'plausible' || normalized === 'ga4') {
+    return normalized;
+  }
+  return null;
+}
+
+export default function Analytics({
+  provider,
+  domain,
+  gaId,
+}: {
+  provider?: string | null;
+  domain?: string;
+  gaId?: string;
+}) {
+  const normalized = normalizeProvider(provider);
+
+  if (normalized === 'plausible') {
+    if (!domain) {
+      return null;
+    }
     return <Script defer data-domain={domain} src="https://plausible.io/js/script.js" />;
   }
-  if (provider === 'ga4' && gaId) {
-    return <Script async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} />
+
+  if (normalized === 'ga4') {
+    if (!gaId) {
+      return null;
+    }
+    return <Script async src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`} />;
   }
+
   return null;
 }


### PR DESCRIPTION
## Summary
- teach the smoke runner to follow redirects, validate sitemap contents, and verify robots.txt sitemap hints
- surface final destinations in the Markdown report and capture link-check output after running the reports script
- add simple privacy routes for the Speckit and ADF apps while hardening analytics opt-in handling

## Testing
- DISABLE_PWA=1 pnpm reports

------
https://chatgpt.com/codex/tasks/task_e_68e47ff9fab883248896f5f130ff2866