### PR TITLE
Update site smoke workflow and navigation content

### DIFF
--- a/.github/workflows/site-smoke.yml
+++ b/.github/workflows/site-smoke.yml
@@ -2,25 +2,33 @@ name: Site smoke
 on:
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
+  workflow_dispatch: {}
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    env:
+      DISABLE_PWA: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - run: corepack enable pnpm && pnpm install --frozen-lockfile
-      - name: Generate reports (build→start→probe)
-        env:
-          DISABLE_PWA: "1"
-        run: pnpm reports
-      - name: Upload artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v4
         with:
-          name: site-reports
+          version: 9
+          run_install: true
+
+      - run: pnpm -w build
+      - run: pnpm --filter ./apps/airnub exec next start -p 3101 & pnpm --filter ./apps/speckit exec next start -p 3102 & pnpm --filter ./apps/adf exec next start -p 3103 & sleep 5
+      - run: pnpm reports
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: site-smoke-artifacts
+          retention-days: 7
           path: |
             SMOKE-REPORT.md
             SMOKE-REPORT.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Airnub-Site Monorepo
 
+## Status
+
+[![Site smoke](https://github.com/airnub/airnub-site/actions/workflows/site-smoke.yml/badge.svg)](../../actions/workflows/site-smoke.yml)
+[![Links](https://github.com/airnub/airnub-site/actions/workflows/links.yml/badge.svg)](../../actions/workflows/links.yml)
+[![Accessibility](https://github.com/airnub/airnub-site/actions/workflows/a11y.yml/badge.svg)](../../actions/workflows/a11y.yml)
+[![Docs deploy](https://github.com/airnub/airnub-site/actions/workflows/deploy-docs.yml/badge.svg)](../../actions/workflows/deploy-docs.yml)
+
 Marketing sites for Airnub and Speckit that share a Supabase backend, a component library, and Turborepo-powered tooling. Both apps run on the Next.js App Router with incremental static regeneration by default.
 
 ## What's inside

--- a/packages/brand/runtime/navigation.json
+++ b/packages/brand/runtime/navigation.json
@@ -22,6 +22,11 @@
         "href": "/about"
       },
       {
+        "id": "hire",
+        "labelKey": "nav.hire",
+        "href": "/hire"
+      },
+      {
         "id": "contact",
         "labelKey": "nav.contact",
         "href": "/contact"
@@ -133,6 +138,11 @@
             "id": "company.about",
             "labelKey": "footer.columns.company.links.about",
             "href": "/about"
+          },
+          {
+            "id": "company.hire",
+            "labelKey": "footer.columns.company.links.hire",
+            "href": "/hire"
           },
           {
             "id": "company.careers",

--- a/packages/brand/src/navigation.ts
+++ b/packages/brand/src/navigation.ts
@@ -72,6 +72,7 @@ export const airnubNavigation: SiteNavigationDefinition = {
     { id: "work", labelKey: "nav.work", href: "/work" },
     { id: "projects", labelKey: "nav.projects", href: "/projects" },
     { id: "about", labelKey: "nav.about", href: "/about" },
+    { id: "hire", labelKey: "nav.hire", href: "/hire" },
     { id: "contact", labelKey: "nav.contact", href: "/contact" },
   ],
   footer: {
@@ -180,6 +181,11 @@ export const airnubNavigation: SiteNavigationDefinition = {
             id: "company.about",
             labelKey: "footer.columns.company.links.about",
             href: "/about",
+          },
+          {
+            id: "company.hire",
+            labelKey: "footer.columns.company.links.hire",
+            href: "/hire",
           },
           {
             id: "company.careers",

--- a/packages/i18n/shared/de.json
+++ b/packages/i18n/shared/de.json
@@ -30,6 +30,7 @@
       "work": "Leistungen",
       "projects": "Projekte",
       "about": "Über uns",
+      "hire": "For Recruiters & Clients",
       "contact": "Kontakt"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Unternehmen",
           "links": {
             "about": "Über uns",
+            "hire": "For Recruiters & Clients",
             "careers": "Karriere",
             "press": "Presse",
             "legal": "Rechtliches"

--- a/packages/i18n/shared/en-GB.json
+++ b/packages/i18n/shared/en-GB.json
@@ -30,6 +30,7 @@
       "work": "Work",
       "projects": "Projects",
       "about": "About",
+      "hire": "For Recruiters & Clients",
       "contact": "Contact"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Company",
           "links": {
             "about": "About",
+            "hire": "For Recruiters & Clients",
             "careers": "Careers",
             "press": "Press",
             "legal": "Legal"

--- a/packages/i18n/shared/en-US.json
+++ b/packages/i18n/shared/en-US.json
@@ -30,6 +30,7 @@
       "work": "Work",
       "projects": "Projects",
       "about": "About",
+      "hire": "For Recruiters & Clients",
       "contact": "Contact"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Company",
           "links": {
             "about": "About",
+            "hire": "For Recruiters & Clients",
             "careers": "Careers",
             "press": "Press",
             "legal": "Legal"

--- a/packages/i18n/shared/es.json
+++ b/packages/i18n/shared/es.json
@@ -30,6 +30,7 @@
       "work": "Servicios",
       "projects": "Proyectos",
       "about": "Empresa",
+      "hire": "Para reclutadores y clientes",
       "contact": "Contacto"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Empresa",
           "links": {
             "about": "Acerca de",
+            "hire": "Para reclutadores y clientes",
             "careers": "Carreras",
             "press": "Prensa",
             "legal": "Legal"

--- a/packages/i18n/shared/fr.json
+++ b/packages/i18n/shared/fr.json
@@ -30,6 +30,7 @@
       "work": "Services",
       "projects": "Projets",
       "about": "Entreprise",
+      "hire": "Pour les recruteurs et clients",
       "contact": "Contact"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Entreprise",
           "links": {
             "about": "À propos",
+            "hire": "Pour les recruteurs et clients",
             "careers": "Carrières",
             "press": "Presse",
             "legal": "Juridique"

--- a/packages/i18n/shared/ga.json
+++ b/packages/i18n/shared/ga.json
@@ -30,6 +30,7 @@
       "work": "Seirbhísí",
       "projects": "Tionscadail",
       "about": "Fúinn",
+      "hire": "Do earcaitheoirí agus cliaint",
       "contact": "Teagmháil"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Cuideachta",
           "links": {
             "about": "Fúinn",
+            "hire": "Do earcaitheoirí agus cliaint",
             "careers": "Gairmeacha",
             "press": "Preas",
             "legal": "Dlí"

--- a/packages/i18n/shared/it.json
+++ b/packages/i18n/shared/it.json
@@ -30,6 +30,7 @@
       "work": "Servizi",
       "projects": "Progetti",
       "about": "Azienda",
+      "hire": "Per recruiter e clienti",
       "contact": "Contatti"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Azienda",
           "links": {
             "about": "Chi siamo",
+            "hire": "Per recruiter e clienti",
             "careers": "Carriere",
             "press": "Stampa",
             "legal": "Legale"

--- a/packages/i18n/shared/pt.json
+++ b/packages/i18n/shared/pt.json
@@ -30,6 +30,7 @@
       "work": "Serviços",
       "projects": "Projetos",
       "about": "Empresa",
+      "hire": "Para recrutadores e clientes",
       "contact": "Contacto"
     },
     "footer": {
@@ -71,6 +72,7 @@
           "heading": "Empresa",
           "links": {
             "about": "Sobre",
+            "hire": "Para recrutadores e clientes",
             "careers": "Carreiras",
             "press": "Imprensa",
             "legal": "Jurídico"


### PR DESCRIPTION
## Summary
- align the site-smoke workflow with the shared Node.js/pnpm setup, add a manual trigger, and retain uploaded artifacts for a week
- surface CI health badges at the top of the README for quick status visibility
- expose the For Recruiters & Clients hire link across header and footer navigation with localized copy updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e58b9c9cb88324bcfde152f79b2b25